### PR TITLE
ContractID => ContractId and make internals public

### DIFF
--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -11,7 +11,7 @@ use crate::storage::{Key, Storage};
 use crate::weak_host::WeakHost;
 
 use crate::xdr::{ScMap, ScMapEntry, ScObject, ScStatic, ScStatus, ScStatusType, ScVal, ScVec};
-use crate::{xdr, ContractID};
+use crate::{xdr, ContractId};
 use std::rc::Rc;
 
 use crate::host_object::{HostMap, HostObj, HostObject, HostObjectType, HostVal, HostVec};
@@ -63,7 +63,7 @@ impl From<BitSetError> for HostError {
 /// with [`Host::push_frame`].
 #[derive(Clone)]
 pub(crate) struct Frame {
-    pub(crate) contract_id: ContractID,
+    pub(crate) contract_id: ContractId,
     // Other activation-frame / execution-context values here.
 }
 
@@ -135,7 +135,7 @@ impl Host {
 
     /// Returns [`ContractID`] from top of context stack, panicking if the stack
     /// is empty.
-    fn get_current_contract_id(&self) -> ContractID {
+    fn get_current_contract_id(&self) -> ContractId {
         self.with_current_frame(|frame| frame.contract_id.clone())
     }
 
@@ -406,7 +406,7 @@ impl Host {
                 .as_slice()
                 .try_into()
                 .map_err(|_| HostError::General("invalid contract hash"))?;
-            Ok(ContractID(xdr::Hash(arr)))
+            Ok(ContractId(xdr::Hash(arr)))
         })?;
         let key = ScVal::Static(ScStatic::Void); // TODO: replace with "SCS_LEDGER_KEY_CONTRACT_CODE_WASM"
         let storage_key = Key {

--- a/stellar-contract-env-host/src/lib.rs
+++ b/stellar-contract-env-host/src/lib.rs
@@ -13,6 +13,6 @@ mod test;
 pub use host::{Host, HostError};
 pub use stellar_contract_env_common::*;
 
-// TODO: this should become xdr::ContractID when that type arrives.
+// TODO: this should become xdr::ContractId when that type arrives.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
-pub struct ContractID(xdr::Hash);
+pub struct ContractId(pub xdr::Hash);

--- a/stellar-contract-env-host/src/storage.rs
+++ b/stellar-contract-env-host/src/storage.rs
@@ -1,12 +1,12 @@
 use std::rc::Rc;
 
 use crate::xdr::ScVal;
-use crate::{ContractID, HostError};
+use crate::{ContractId, HostError};
 use im_rc::OrdMap;
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Key {
-    pub contract_id: ContractID,
+    pub contract_id: ContractId,
     pub key: ScVal,
 }
 
@@ -172,7 +172,7 @@ mod test_footprint {
     fn footprint_record_access() {
         let mut fp = Footprint::default();
         // record when key not exist
-        let contract_id = ContractID([0; 32].into());
+        let contract_id = ContractId([0; 32].into());
         let key = ScVal::I32(0);
         let key = Key { contract_id, key };
         fp.record_access(&key, AccessType::ReadOnly);
@@ -187,7 +187,7 @@ mod test_footprint {
 
     #[test]
     fn footprint_enforce_access() {
-        let contract_id = ContractID([0; 32].into());
+        let contract_id = ContractId([0; 32].into());
         let key = ScVal::I32(0);
         let key = Key { contract_id, key };
         let om = OrdMap::unit(key.clone(), AccessType::ReadOnly);
@@ -202,7 +202,7 @@ mod test_footprint {
     #[should_panic(expected = "access to unknown footprint entry")]
     fn footprint_enforce_access_not_exist() {
         let mut fp = Footprint::default();
-        let contract_id = ContractID([0; 32].into());
+        let contract_id = ContractId([0; 32].into());
         let key = ScVal::I32(0);
         let key = Key { contract_id, key };
         fp.enforce_access(&key, AccessType::ReadOnly).unwrap();
@@ -211,7 +211,7 @@ mod test_footprint {
     #[test]
     #[should_panic(expected = "read-write access to read-only footprint entry")]
     fn footprint_attempt_to_write_readonly_entry() {
-        let contract_id = ContractID([0; 32].into());
+        let contract_id = ContractId([0; 32].into());
         let key = ScVal::I32(0);
         let key = Key { contract_id, key };
         let om = OrdMap::unit(key.clone(), AccessType::ReadOnly);

--- a/stellar-contract-env-host/src/test.rs
+++ b/stellar-contract-env-host/src/test.rs
@@ -9,7 +9,7 @@ use crate::storage::{AccessType, Footprint, Key, Storage};
 #[cfg(feature = "vm")]
 use crate::{xdr::ScStatic, Symbol};
 #[cfg(feature = "vm")]
-use crate::{ContractID, Vm};
+use crate::{ContractId, Vm};
 #[cfg(feature = "vm")]
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
@@ -394,7 +394,7 @@ fn invoke_single_contract_function() -> Result<(), ()> {
         0x04, 0x88, 0xa7, 0x22, 0x03, 0x6a, 0x22, 0x02, 0x20, 0x03, 0x48, 0x73, 0x45, 0x0d, 0x01,
         0x0b, 0x00, 0x0b, 0x20, 0x02, 0xad, 0x42, 0x04, 0x86, 0x42, 0x03, 0x84, 0x0b,
     ];
-    let id = ContractID([0; 32].into());
+    let id = ContractId([0; 32].into());
     let vm = Vm::new(&host, id, &code).unwrap();
     let a = 4i32;
     let b = 7i32;
@@ -419,7 +419,7 @@ fn invoke_single_contract_function() -> Result<(), ()> {
 fn contract_invoke_another_contract() -> Result<(), ()> {
     use im_rc::OrdMap;
 
-    let contract_id = ContractID([0; 32].into());
+    let contract_id = ContractId([0; 32].into());
     let key = ScVal::Static(ScStatic::Void); // TODO: replace with "SCS_LEDGER_KEY_CONTRACT_CODE_WASM"
     let storage_key = Key { contract_id, key };
     let code: [u8; 163] = [

--- a/stellar-contract-env-host/src/vm.rs
+++ b/stellar-contract-env-host/src/vm.rs
@@ -1,7 +1,7 @@
 mod dispatch;
 mod func_info;
 
-use crate::{host::Frame, ContractID, HostError};
+use crate::{host::Frame, ContractId, HostError};
 
 use super::{
     xdr::{ScVal, ScVec},
@@ -111,14 +111,14 @@ impl ImportResolver for Host {
 #[derive(Clone)]
 pub struct Vm {
     #[allow(dead_code)]
-    contract_id: ContractID,
+    contract_id: ContractId,
     instance: ModuleRef, // this is a cloneable Rc<ModuleInstance>
 }
 
 impl Vm {
     pub fn new(
         host: &Host,
-        contract_id: ContractID,
+        contract_id: ContractId,
         module_wasm_code: &[u8],
     ) -> Result<Self, HostError> {
         let module = Module::from_buffer(module_wasm_code)?;


### PR DESCRIPTION
### What

Rename `ContractID` => `ContractId` and make its internal type public.

### Why

The `ContractID` type is just a placeholder for when the same type appears in the XDR lib.

When it appears in the XDR lib it will have the name `ContractId` because xdrgen generates title case names for abbreviations. Xdrgen does this because Rust conventions specify names this way.

When it appears in the XDR lib the internal type will be public.

I need it to be public for the CLI.

See https://rust-lang.github.io/api-guidelines/naming.html#casing-conforms-to-rfc-430-c-case for more details.

### Known limitations

N/A