### PR TITLE
read tickets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,12 +15,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bit-set"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitmaps"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "bs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af0f70f64b53a02c58134d6e8b17a7d0cd7fd53ae20ec9a9aeb84a912594e2a1"
+dependencies = [
+ "bit-set",
+ "bit-vec",
 ]
 
 [[package]]
@@ -197,6 +222,7 @@ dependencies = [
 name = "stellar-contract-env-host"
 version = "0.0.0"
 dependencies = [
+ "bs",
  "im-rc",
  "num-bigint",
  "num-rational",

--- a/stellar-contract-env-host/Cargo.toml
+++ b/stellar-contract-env-host/Cargo.toml
@@ -12,6 +12,7 @@ im-rc = "15.0.0"
 num-bigint = "0.4"
 num-rational = "0.4"
 thiserror = "1.0.31"
+bs = "0.1.0"
 wasmi = { git = "https://github.com/stellar/wasmi", rev = "4f35508c1a2475ed5d33955023f073639e7ff7df", optional = true }
 parity-wasm = { version = "0.42.0", optional = true }
 

--- a/stellar-contract-env-host/src/host_object.rs
+++ b/stellar-contract-env-host/src/host_object.rs
@@ -1,3 +1,5 @@
+use crate::host::Tickets;
+
 use super::{weak_host::WeakHost, xdr::ScObjectType, EnvVal, Object, RawVal};
 
 use im_rc::{OrdMap, Vector};
@@ -7,8 +9,14 @@ pub(crate) type HostVal = EnvVal<WeakHost, RawVal>;
 pub(crate) type HostMap = OrdMap<HostVal, HostVal>;
 pub(crate) type HostVec = Vector<HostVal>;
 
+#[derive(Clone)]
+pub(crate) struct HostObject {
+    pub(crate) tickets: Tickets,
+    pub(crate) body: HostObjectBody,
+}
+
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) enum HostObject {
+pub(crate) enum HostObjectBody {
     Vec(HostVec),
     Map(HostMap),
     U64(u64),
@@ -18,8 +26,8 @@ pub(crate) enum HostObject {
 
 pub(crate) trait HostObjectType: Sized {
     fn get_type() -> ScObjectType;
-    fn inject(self) -> HostObject;
-    fn try_extract(obj: &HostObject) -> Option<&Self>;
+    fn inject(self) -> HostObjectBody;
+    fn try_extract(obj: &HostObjectBody) -> Option<&Self>;
 }
 
 macro_rules! declare_host_object_type {
@@ -29,13 +37,13 @@ macro_rules! declare_host_object_type {
                 ScObjectType::$CODE
             }
 
-            fn inject(self) -> HostObject {
-                HostObject::$CASE(self)
+            fn inject(self) -> HostObjectBody {
+                HostObjectBody::$CASE(self)
             }
 
-            fn try_extract(obj: &HostObject) -> Option<&Self> {
+            fn try_extract(obj: &HostObjectBody) -> Option<&Self> {
                 match obj {
-                    HostObject::$CASE(v) => Some(v),
+                    HostObjectBody::$CASE(ref v) => Some(v),
                     _ => None,
                 }
             }

--- a/stellar-contract-env-host/src/vm.rs
+++ b/stellar-contract-env-host/src/vm.rs
@@ -179,7 +179,7 @@ impl Vm {
         func: &str,
         args: &[RawVal],
     ) -> Result<RawVal, HostError> {
-        let mut frame_guard = host.push_vm_frame(self.clone());
+        let mut frame_guard = host.push_vm_frame(self.clone())?;
         let wasm_args: Vec<_> = args
             .iter()
             .map(|i| RuntimeValue::I64(i.get_payload() as i64))


### PR DESCRIPTION
This is a WIP implementation of "read tickets", a mechanism for associating read permissions with objects and enforcing that only context frames granted access to an object can read it. It doesn't currently perform the permission-transfer necessary when handing an object handle from a contract caller to callee, so at the moment it _completely_ isolates objects allocated by frame X from those allocated by frame Y, but I'll finish this up tomorrow to allow such transfers.

I _think_ this is about the cheapest/simplest way to enforce this sort of thing. I sketched a few designs based on frame-local aliases / forwarding proxies and they just wind up messier and using more memory & CPU. Most of the time this just adds ~2 words to every object and does a couple bitmask tests.

- [ ] Ensure that the read ticket mask for every object allocated in an aborted subtransaction is set to "unreadable"
- [ ] Figure out how read tickets relate to debug events -- probably "should ignore them when formatting values for debug strings"