### PR TITLE
Revert "Revert "Refactor index validity-checking code into a new file ""

### DIFF
--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -1156,8 +1156,8 @@ impl CheckedEnv for Host {
         let start = self.u32_from_rawval_input("start", start)?;
         let end = self.u32_from_rawval_input("end", end)?;
         let vnew = self.visit_obj(v, move |hv: &HostVec| {
-            self.validate_start_end_bound(start, end, hv.len())?;
-            Ok(hv.clone().slice(start as usize..end as usize))
+            let range = self.valid_range_from_start_end_bound(start, end, hv.len())?;
+            Ok(hv.clone().slice(range))
         })?;
         Ok(self.add_host_object(vnew)?.into())
     }
@@ -1519,9 +1519,9 @@ impl CheckedEnv for Host {
             let VmSlice { vm, pos, len } = self.decode_vmslice(lm_pos, len)?;
             let b_pos = u32::try_from(b_pos)?;
             self.visit_obj(b, move |hv: &Vec<u8>| {
-                let end_idx = self.validate_start_span_bound(b_pos, len, hv.len())? as usize;
+                let range = self.valid_range_from_start_span_bound(b_pos, len, hv.len())?;
                 vm.with_memory_access(self, |mem| {
-                    self.map_err(mem.set(pos, &hv.as_slice()[b_pos as usize..end_idx]))
+                    self.map_err(mem.set(pos, &hv.as_slice()[range]))
                 })?;
                 Ok(().into())
             })
@@ -1684,8 +1684,8 @@ impl CheckedEnv for Host {
         let start = self.u32_from_rawval_input("start", start)?;
         let end = self.u32_from_rawval_input("end", end)?;
         let vnew = self.visit_obj(b, move |hv: &Vec<u8>| {
-            self.validate_start_end_bound(start, end, hv.len())?;
-            Ok(hv.as_slice()[start as usize..end as usize].to_vec())
+            let range = self.valid_range_from_start_end_bound(start, end, hv.len())?;
+            Ok(hv.as_slice()[range].to_vec())
         })?;
         Ok(self.add_host_object(vnew)?.into())
     }

--- a/soroban-env-host/src/host/validity.rs
+++ b/soroban-env-host/src/host/validity.rs
@@ -1,0 +1,72 @@
+use crate::xdr::{ScHostFnErrorCode, ScHostObjErrorCode};
+use crate::{Host, HostError};
+
+impl Host {
+    pub(crate) fn validate_index_lt_bound(
+        &self,
+        index: u32,
+        bound: usize,
+    ) -> Result<(), HostError> {
+        if index as usize >= bound {
+            return Err(self.err_status_msg(
+                ScHostObjErrorCode::VecIndexOutOfBound, // TODO: need to reconcile between InputArgsInvalid and VecIndexOutOfBound
+                "start index out of bound",
+            ));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn validate_index_le_bound(
+        &self,
+        index: u32,
+        bound: usize,
+    ) -> Result<(), HostError> {
+        if index as usize > bound {
+            return Err(self.err_status_msg(
+                ScHostObjErrorCode::VecIndexOutOfBound, // TODO: need to reconcile between InputArgsInvalid and VecIndexOutOfBound
+                "start index out of bound",
+            ));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn validate_start_end_bound(
+        &self,
+        start: u32,
+        end: u32,
+        bound: usize,
+    ) -> Result<(), HostError> {
+        if start as usize >= bound {
+            return Err(self.err_status_msg(
+                ScHostObjErrorCode::VecIndexOutOfBound,
+                "start index out of bound",
+            ));
+        }
+        if end as usize > bound {
+            return Err(self.err_status_msg(
+                ScHostObjErrorCode::VecIndexOutOfBound,
+                "end index out of bound",
+            ));
+        }
+        if start > end {
+            return Err(self.err_status_msg(
+                ScHostFnErrorCode::InputArgsInvalid,
+                "start greater than end",
+            ));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn validate_start_span_bound(
+        &self,
+        start: u32,
+        span: u32,
+        bound: usize,
+    ) -> Result<u32, HostError> {
+        let end = start.checked_add(span).ok_or_else(|| {
+            self.err_status_msg(ScHostFnErrorCode::InputArgsInvalid, "u32 overflow")
+        })?;
+        self.validate_start_end_bound(start, end, bound)?;
+        Ok(end)
+    }
+}

--- a/soroban-env-host/src/host/validity.rs
+++ b/soroban-env-host/src/host/validity.rs
@@ -1,5 +1,8 @@
+use std::ops::Range;
+
+use crate::events::DebugError;
 use crate::xdr::{ScHostFnErrorCode, ScHostObjErrorCode};
-use crate::{Host, HostError};
+use crate::{Host, HostError, RawVal};
 
 impl Host {
     pub(crate) fn validate_index_lt_bound(
@@ -30,13 +33,13 @@ impl Host {
         Ok(())
     }
 
-    pub(crate) fn validate_start_end_bound(
+    pub(crate) fn valid_range_from_start_end_bound(
         &self,
         start: u32,
         end: u32,
         bound: usize,
-    ) -> Result<(), HostError> {
-        if start as usize >= bound {
+    ) -> Result<Range<usize>, HostError> {
+        if start as usize > bound {
             return Err(self.err_status_msg(
                 ScHostObjErrorCode::VecIndexOutOfBound,
                 "start index out of bound",
@@ -49,24 +52,28 @@ impl Host {
             ));
         }
         if start > end {
-            return Err(self.err_status_msg(
-                ScHostFnErrorCode::InputArgsInvalid,
-                "start greater than end",
+            return Err(self.err(
+                DebugError::new(ScHostFnErrorCode::InputArgsInvalid)
+                    .msg("index starts at {} but ends at {}")
+                    .arg(RawVal::from_u32(start))
+                    .arg(RawVal::from_u32(end)),
             ));
         }
-        Ok(())
+        Ok(Range {
+            start: start as usize,
+            end: end as usize,
+        })
     }
 
-    pub(crate) fn validate_start_span_bound(
+    pub(crate) fn valid_range_from_start_span_bound(
         &self,
         start: u32,
         span: u32,
         bound: usize,
-    ) -> Result<u32, HostError> {
+    ) -> Result<Range<usize>, HostError> {
         let end = start.checked_add(span).ok_or_else(|| {
             self.err_status_msg(ScHostFnErrorCode::InputArgsInvalid, "u32 overflow")
         })?;
-        self.validate_start_end_bound(start, end, bound)?;
-        Ok(end)
+        self.valid_range_from_start_end_bound(start, end, bound)
     }
 }

--- a/soroban-env-host/src/test/binary.rs
+++ b/soroban-env-host/src/test/binary.rs
@@ -1,7 +1,9 @@
+use crate::xdr::ScHostFnErrorCode;
 use crate::{
     xdr::{ScHostObjErrorCode, ScObject, ScStatic, ScStatus, ScVal},
     CheckedEnv, Host, HostError, RawVal, RawValConvertible,
 };
+use soroban_env_common::EnvBase;
 
 #[cfg(feature = "vm")]
 use super::wasm_examples::LINEAR_MEMORY;
@@ -81,6 +83,26 @@ fn binary_suite_of_tests() -> Result<(), HostError> {
     let obj_back = host.binary_append(obj0, obj1)?;
     assert_eq!(host.obj_cmp(obj.into(), obj_back.into())?, 0);
 
+    Ok(())
+}
+
+#[test]
+fn binary_put_out_of_bound() -> Result<(), HostError> {
+    let host = Host::default();
+    let obj = host.binary_new()?;
+    let res = host.binary_put(obj, 0u32.into(), 1u32.into());
+    let code = ScHostObjErrorCode::VecIndexOutOfBound;
+    assert!(HostError::result_matches_err_status(res, code));
+    Ok(())
+}
+
+#[test]
+fn binary_slice_start_greater_than_end() -> Result<(), HostError> {
+    let host = Host::default();
+    let obj = host.binary_new_from_slice(&[1, 2, 3, 4]);
+    let res = host.binary_slice(obj, 2_u32.into(), 1_u32.into());
+    let code = ScHostFnErrorCode::InputArgsInvalid;
+    assert!(HostError::result_matches_err_status(res, code));
     Ok(())
 }
 

--- a/soroban-env-host/src/test/binary.rs
+++ b/soroban-env-host/src/test/binary.rs
@@ -107,6 +107,25 @@ fn binary_slice_start_greater_than_end() -> Result<(), HostError> {
 }
 
 #[test]
+fn binary_slice_start_equal_len() -> Result<(), HostError> {
+    let host = Host::default();
+    let obj = host.binary_new_from_slice(&[1, 2, 3, 4]);
+    let res = host.binary_slice(obj, 4_u32.into(), 4_u32.into())?;
+    assert_eq!(host.obj_cmp(res.into(), host.binary_new()?.into())?, 0);
+    Ok(())
+}
+
+#[test]
+fn binary_slice_start_greater_than_len() -> Result<(), HostError> {
+    let host = Host::default();
+    let obj = host.binary_new_from_slice(&[1, 2, 3, 4]);
+    let res = host.binary_slice(obj, 5_u32.into(), 10_u32.into());
+    let code = ScHostObjErrorCode::VecIndexOutOfBound;
+    assert!(HostError::result_matches_err_status(res, code));
+    Ok(())
+}
+
+#[test]
 fn binary_xdr_roundtrip() -> Result<(), HostError> {
     let host = Host::default();
     let roundtrip = |v: ScVal| -> Result<(), HostError> {


### PR DESCRIPTION
### What
Reopens https://github.com/stellar/rs-soroban-env/pull/291
- Reverts https://github.com/stellar/rs-soroban-env/pull/290, which reverted https://github.com/stellar/rs-soroban-env/pull/279. Bring back the index validity checking code.
- Adds the fix, improves interface, adds tests

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
