### PR TITLE
Update cargo-hack used in ci

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -67,7 +67,7 @@ jobs:
           ${{ github.job }}-target-
     - if: github.ref_protected
       run: rm -fr target
-    - run: cargo install --locked --version 0.5.14 cargo-hack
+    - run: cargo install --locked --version 0.5.16 cargo-hack
     - run: cargo hack --feature-powerset check --locked --target ${{ matrix.sys.target }}
     - if: matrix.sys.test
       run: cargo hack --feature-powerset test --locked --target ${{ matrix.sys.target }}


### PR DESCRIPTION
### What
Update cargo-hack used in ci to 0.5.16.

### Why
To get fixes that remove unnecessary warnings.