### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-# Contract commits owns the repo as a whole.
+# Contract committers owns the repo as a whole.
 *                             @stellar/contract-committers
 
 # Members of contract committers who are on the core team own the host

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 # Contract commits owns the repo as a whole.
 *                             @stellar/contract-committers
 
-# Core committers own the host implementation.
-/soroban-env-host/            @stellar/core-committers
+# Members of contract committers who are on the core team own the host
+# implementation.
+/soroban-env-host/            @graydon @jonjove @sisuresh

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Contract commits owns the repo as a whole.
+*                             @stellar/contract-committers
+
+# Core committers own the host implementation.
+/soroban-env-host/            @stellar/core-committers


### PR DESCRIPTION
### What
Add a CODEOWNERS file that automatically adds @stellar/contract-committers as a reviewer of PRs, and @stellar/core-committers as a reviewer of the host crate.

### Why
To set some signal of who should likely be involved with or have some eyes on different areas of the code base. The host crate is somewhat specialized in that its design and implementation will be cared more about by the stellar-core team than anyone else.

This won't require reviews by these people, but it by default will ensure they are tagged on PRs that touch different areas.

We can expand and specialize this over time.