### PR TITLE
Replace FrameGuard drop trait with guarded closure; add metering

### DIFF
--- a/soroban-env-host/src/budget.rs
+++ b/soroban-env-host/src/budget.rs
@@ -13,6 +13,8 @@ pub enum CostType {
     HostEventDebug = 6,
     HostFunction = 7,
     VisitObject = 8,
+    PushFrame = 9,
+    PopFrame = 10,
 }
 
 // TODO: add XDR support for iterating over all the elements of an enum
@@ -28,6 +30,8 @@ impl CostType {
             CostType::HostEventDebug,
             CostType::HostFunction,
             CostType::VisitObject,
+            CostType::PushFrame,
+            CostType::PopFrame,
         ];
         VARIANTS.iter()
     }
@@ -246,6 +250,7 @@ impl Default for Budget {
         b.cpu_insns
             .get_cost_model_mut(CostType::WasmInsnExec)
             .lin_param = 73;
+        // TODO: set cpu, mem model parameters for other CostTypes
 
         // Some "reasonable defaults": 640k of RAM and 100usec.
         //

--- a/soroban-env-host/src/test/lifecycle.rs
+++ b/soroban-env-host/src/test/lifecycle.rs
@@ -141,20 +141,20 @@ fn create_contract_test() -> Result<(), HostError> {
     let hash = sha256_hash_id_preimage(id_pre_image);
 
     //Push the contract id onto the stack to simulate a contract call
-    let _frame_guard = host.push_frame(Frame::TestContract(hash));
+    host.with_frame(Frame::TestContract(hash), || {
+        let key = ScVal::Static(ScStatic::LedgerKeyContractCodeWasm);
 
-    let key = ScVal::Static(ScStatic::LedgerKeyContractCodeWasm);
+        // update
+        let put_res = host.put_contract_data(host.to_host_val(&key)?.to_raw(), ().into());
+        let code = ScHostFnErrorCode::InputArgsInvalid;
+        assert!(HostError::result_matches_err_status(put_res, code));
 
-    // update
-    let put_res = host.put_contract_data(host.to_host_val(&key)?.to_raw(), ().into());
-    let code = ScHostFnErrorCode::InputArgsInvalid;
-    assert!(HostError::result_matches_err_status(put_res, code));
-
-    // delete
-    let del_res = host.del_contract_data(host.to_host_val(&key)?.to_raw());
-    let code = ScHostFnErrorCode::InputArgsInvalid;
-    assert!(HostError::result_matches_err_status(del_res, code));
-    Ok(())
+        // delete
+        let del_res = host.del_contract_data(host.to_host_val(&key)?.to_raw());
+        let code = ScHostFnErrorCode::InputArgsInvalid;
+        assert!(HostError::result_matches_err_status(del_res, code));
+        Ok(())
+    })
 }
 
 /// VM tests

--- a/soroban-env-host/src/test/lifecycle.rs
+++ b/soroban-env-host/src/test/lifecycle.rs
@@ -1,5 +1,6 @@
 use super::wasm_examples::CREATE_CONTRACT;
 use crate::{
+    host::Frame,
     storage::{AccessType, Footprint, Storage},
     xdr::{self, LedgerKeyContractData, ScHostFnErrorCode, ScStatic},
     xdr::{LedgerEntryData, LedgerKey, ScObject, ScVal, ScVec},
@@ -140,7 +141,7 @@ fn create_contract_test() -> Result<(), HostError> {
     let hash = sha256_hash_id_preimage(id_pre_image);
 
     //Push the contract id onto the stack to simulate a contract call
-    let _frame_guard = host.push_test_frame(hash);
+    let _frame_guard = host.push_frame(Frame::TestContract(hash));
 
     let key = ScVal::Static(ScStatic::LedgerKeyContractCodeWasm);
 

--- a/soroban-env-host/src/vm.rs
+++ b/soroban-env-host/src/vm.rs
@@ -11,7 +11,7 @@
 mod dispatch;
 mod func_info;
 
-use crate::{budget::CostType, HostError};
+use crate::{budget::CostType, host::Frame, HostError};
 use std::{io::Cursor, rc::Rc};
 
 use super::{
@@ -254,7 +254,7 @@ impl Vm {
         func: &str,
         args: &[RawVal],
     ) -> Result<RawVal, HostError> {
-        host.with_frame_guard(host.push_vm_frame(self.clone())?, || {
+        host.with_frame_guard(host.push_frame(Frame::ContractVM(self.clone()))?, || {
             let wasm_args: Vec<_> = args
                 .iter()
                 .map(|i| RuntimeValue::I64(i.get_payload() as i64))

--- a/soroban-env-host/src/vm.rs
+++ b/soroban-env-host/src/vm.rs
@@ -254,7 +254,7 @@ impl Vm {
         func: &str,
         args: &[RawVal],
     ) -> Result<RawVal, HostError> {
-        host.with_frame_guard(host.push_frame(Frame::ContractVM(self.clone()))?, || {
+        host.with_frame(Frame::ContractVM(self.clone()), || {
             let wasm_args: Vec<_> = args
                 .iter()
                 .map(|i| RuntimeValue::I64(i.get_payload() as i64))


### PR DESCRIPTION
### What

- Remove the `drop` trait from `FrameGuard` which automatically cleans up after frame goes out of scope. 
- Add a `roll_back` function that does the clean up.
- Wrap all push_frame calls in `with_frame_guard`, which automatically calls `commit` on success and `roll_back` on err. 
- Add metering to frame pushing and popping.

### Why

Preparing for the metering change. 
The frame guard functions needs to be metered (it needs to copy data), which may fail due to reaching budget limit, therefore they need to return `Result`. `drop` function does not allow that.
As discussed with @graydon , this is the alternative "cleanup-upon-going-out-of-score" pattern to `drop`. 

### Known limitations

[TODO or N/A]
