### PR TITLE
Add Host::register_test_contract_wasm

### DIFF
--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -39,6 +39,7 @@ tabwriter = "1.2.1"
 thousands = "0.2.0"
 
 [features]
+default = ["vm"]
 vm = ["wasmi", "parity-wasm", "soroban-env-common/vm"]
 serde = ["soroban-env-common/serde"]
 testutils = []


### PR DESCRIPTION
### What
Add Host::register_test_contract_wasm, which accepts a WASM byte slice and a contract ID to register it against.

### Why
When writing tests, developers will want to register not only their own contract, as is doable via `Host::register_test_contract`, but also other contracts for which they have only the WASM for so that they can do broader integration testing.

Some examples in the soroban-examples repo have achieved this by creating the other contract with the `Host::create_contract_from_contract` function. The problem with this approach is that the contract being created is created as if it was created by the developers contract. This is conceptually not aligned with how a developer thinks about deploying the other contract, because a contract that a developer writes won't always be deploying the contract it is interacting with.

Therefore it is helpful if we allow developers to simply register contracts without going through all the steps to deploy that contracts from within their own.

This is only for tests infrastructure and is gated behind the testutils feature.