### PR TITLE
Remove u8 as a RawVal

### DIFF
--- a/soroban-env-common/src/raw_val.rs
+++ b/soroban-env-common/src/raw_val.rs
@@ -364,13 +364,6 @@ impl From<&ScStatus> for RawVal {
     }
 }
 
-impl From<u8> for RawVal {
-    #[inline(always)]
-    fn from(u: u8) -> Self {
-        RawVal::from_u32(u.into())
-    }
-}
-
 impl RawVal {
     pub fn in_env<E: Env>(self, env: &E) -> EnvVal<E, RawVal> {
         EnvVal {

--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -1581,7 +1581,7 @@ impl CheckedEnv for Host {
         let i = self.usize_from_rawval_u32_input("i", i)?;
         self.visit_obj(b, |hv: &Vec<u8>| {
             hv.get(i)
-                .map(|u| Into::<RawVal>::into(*u))
+                .map(|u| Into::<RawVal>::into(Into::<u32>::into(*u)))
                 .ok_or_else(|| self.err_status(ScHostObjErrorCode::VecIndexOutOfBound))
         })
     }
@@ -1625,7 +1625,7 @@ impl CheckedEnv for Host {
     fn binary_front(&self, b: Object) -> Result<RawVal, HostError> {
         self.visit_obj(b, |hv: &Vec<u8>| {
             hv.first()
-                .map(|u| Into::<RawVal>::into(*u))
+                .map(|u| Into::<RawVal>::into(Into::<u32>::into(*u)))
                 .ok_or_else(|| self.err_status(ScHostObjErrorCode::VecIndexOutOfBound))
         })
     }
@@ -1633,7 +1633,7 @@ impl CheckedEnv for Host {
     fn binary_back(&self, b: Object) -> Result<RawVal, HostError> {
         self.visit_obj(b, |hv: &Vec<u8>| {
             hv.last()
-                .map(|u| Into::<RawVal>::into(*u))
+                .map(|u| Into::<RawVal>::into(Into::<u32>::into(*u)))
                 .ok_or_else(|| self.err_status(ScHostObjErrorCode::VecIndexOutOfBound))
         })
     }
@@ -1704,15 +1704,21 @@ impl CheckedEnv for Host {
     }
 
     fn account_get_low_threshold(&self, a: Object) -> Result<RawVal, Self::Error> {
-        Ok(self.load_account(a)?.thresholds.0[ThresholdIndexes::Low as usize].into())
+        let threshold = self.load_account(a)?.thresholds.0[ThresholdIndexes::Low as usize];
+        let threshold = Into::<u32>::into(threshold);
+        Ok(threshold.into())
     }
 
     fn account_get_medium_threshold(&self, a: Object) -> Result<RawVal, Self::Error> {
-        Ok(self.load_account(a)?.thresholds.0[ThresholdIndexes::Med as usize].into())
+        let threshold = self.load_account(a)?.thresholds.0[ThresholdIndexes::Med as usize];
+        let threshold = Into::<u32>::into(threshold);
+        Ok(threshold.into())
     }
 
     fn account_get_high_threshold(&self, a: Object) -> Result<RawVal, Self::Error> {
-        Ok(self.load_account(a)?.thresholds.0[ThresholdIndexes::High as usize].into())
+        let threshold = self.load_account(a)?.thresholds.0[ThresholdIndexes::High as usize];
+        let threshold = Into::<u32>::into(threshold);
+        Ok(threshold.into())
     }
 
     fn account_get_signer_weight(&self, a: Object, s: Object) -> Result<RawVal, Self::Error> {
@@ -1723,7 +1729,9 @@ impl CheckedEnv for Host {
         let ae = self.load_account(a)?;
         if ae.account_id == AccountId(PublicKey::PublicKeyTypeEd25519(target_signer.clone())) {
             // Target signer is the master key, so return the master weight
-            Ok(ae.thresholds.0[ThresholdIndexes::MasterWeight as usize].into())
+            let threshold = ae.thresholds.0[ThresholdIndexes::MasterWeight as usize];
+            let threshold = Into::<u32>::into(threshold);
+            Ok(threshold.into())
         } else {
             // Target signer is not the master key, so search the account signers
             let signers: &Vec<Signer> = ae.signers.as_ref();


### PR DESCRIPTION
### What
Remove the implementation of conversions from u8 to RawVal.

### Why
We previously removed conversions between u8 and RawVal in https://github.com/stellar/rs-soroban-env/pull/258, but missed this one implementation being removed in this PR. The reason for this change is also the same as in that change. RawVal / ScVal types don't specify u8 as a val type. Whilst we can add these functions as a convenience, it creates some problems. For example, it allows a developer to very easily mistakenly use the u8 type with Vec in the SDK, which is highly inefficient.