### PR TITLE
Add conversions between RawVal and [u8; N]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,12 +555,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
-name = "seq-macro"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0772c5c30e1a0d91f6834f8e545c69281c099dfa9a3ac58d96a9fd629c8d4898"
-
-[[package]]
 name = "serde"
 version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,7 +618,6 @@ dependencies = [
 name = "soroban-env-common"
 version = "0.0.3"
 dependencies = [
- "seq-macro",
  "soroban-env-host",
  "soroban-env-macros",
  "soroban-wasmi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -723,7 +723,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "stellar-xdr"
 version = "0.0.1"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=66436840#66436840ec4adcb871dac634d78568854b30dddb"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=f4fe3091#f4fe309136070c3d932bfcb8019ded953b842e5c"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,6 +555,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
+name = "seq-macro"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0772c5c30e1a0d91f6834f8e545c69281c099dfa9a3ac58d96a9fd629c8d4898"
+
+[[package]]
 name = "serde"
 version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,6 +624,8 @@ dependencies = [
 name = "soroban-env-common"
 version = "0.0.3"
 dependencies = [
+ "seq-macro",
+ "soroban-env-host",
  "soroban-env-macros",
  "soroban-wasmi",
  "static_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
 
 [patch.crates-io]
 soroban-env-common = { path = "soroban-env-common" }
+soroban-env-host = { path = "soroban-env-host" }
 soroban-env-macros = { path = "soroban-env-macros" }
 soroban-native-sdk-macros = { path = "soroban-native-sdk-macros" }
 stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "f4fe3091" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ members = [
 soroban-env-common = { path = "soroban-env-common" }
 soroban-env-macros = { path = "soroban-env-macros" }
 soroban-native-sdk-macros = { path = "soroban-native-sdk-macros" }
-stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "66436840" }
+stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "f4fe3091" }
 wasmi = { package = "soroban-wasmi", git = "https://github.com/stellar/wasmi", rev = "7b1f2355" }

--- a/soroban-env-common/Cargo.toml
+++ b/soroban-env-common/Cargo.toml
@@ -15,6 +15,10 @@ soroban-env-macros = { version = "0.0.3" }
 stellar-xdr = { version = "0.0.1", default-features = false, features = [ "next" ] }
 wasmi = { package = "soroban-wasmi", version = "0.11.0", optional = true }
 static_assertions = "1.1.0"
+seq-macro = "0.3.1"
+
+[dev_dependencies]
+soroban-env-host = { version = "0.0.3" }
 
 [features]
 std = ["stellar-xdr/std"]

--- a/soroban-env-common/Cargo.toml
+++ b/soroban-env-common/Cargo.toml
@@ -15,7 +15,6 @@ soroban-env-macros = { version = "0.0.3" }
 stellar-xdr = { version = "0.0.1", default-features = false, features = [ "next" ] }
 wasmi = { package = "soroban-wasmi", version = "0.11.0", optional = true }
 static_assertions = "1.1.0"
-seq-macro = "0.3.1"
 
 [dev_dependencies]
 soroban-env-host = { version = "0.0.3" }

--- a/soroban-env-common/src/array.rs
+++ b/soroban-env-common/src/array.rs
@@ -2,8 +2,6 @@ use stellar_xdr::ScObjectType;
 
 use crate::{ConversionError, Env, EnvVal, IntoVal, Object, RawVal, RawValConvertible, TryIntoVal};
 
-const U32_ZERO: RawVal = RawVal::from_u32(0);
-
 impl<E: Env, const N: usize> TryFrom<EnvVal<E, RawVal>> for [u8; N] {
     type Error = ConversionError;
 
@@ -18,7 +16,7 @@ impl<E: Env, const N: usize> TryFrom<EnvVal<E, RawVal>> for [u8; N] {
             return Err(ConversionError);
         }
         let mut arr = [0u8; N];
-        env.binary_copy_to_slice(bin, U32_ZERO, &mut arr);
+        env.binary_copy_to_slice(bin, RawVal::U32_ZERO, &mut arr);
         Ok(arr)
     }
 }
@@ -39,7 +37,7 @@ impl<E: Env> IntoVal<E, RawVal> for &[u8] {
     fn into_val(self, env: &E) -> RawVal {
         let env = env.clone();
         let mut bin = env.binary_new();
-        bin = env.binary_copy_from_slice(bin, U32_ZERO, self);
+        bin = env.binary_copy_from_slice(bin, RawVal::U32_ZERO, self);
         bin.to_raw()
     }
 }

--- a/soroban-env-common/src/array.rs
+++ b/soroban-env-common/src/array.rs
@@ -23,25 +23,6 @@ impl<E: Env, const N: usize> TryFrom<EnvVal<E, RawVal>> for [u8; N] {
     }
 }
 
-impl<E: Env, const N: usize> IntoVal<E, RawVal> for [u8; N] {
-    fn into_val(self, env: &E) -> RawVal {
-        let env = env.clone();
-        let mut bin = env.binary_new();
-        bin = env.binary_copy_from_slice(bin, U32_ZERO, &self);
-        bin.to_raw()
-    }
-}
-
-impl<E: Env, const N: usize> IntoVal<E, EnvVal<E, RawVal>> for [u8; N] {
-    fn into_val(self, env: &E) -> EnvVal<E, RawVal> {
-        let rv: RawVal = self.into_val(env);
-        EnvVal {
-            env: env.clone(),
-            val: rv,
-        }
-    }
-}
-
 impl<E: Env, const N: usize> TryIntoVal<E, [u8; N]> for RawVal {
     type Error = ConversionError;
     #[inline(always)]
@@ -51,5 +32,50 @@ impl<E: Env, const N: usize> TryIntoVal<E, [u8; N]> for RawVal {
             val: self,
         }
         .try_into()
+    }
+}
+
+impl<E: Env> IntoVal<E, RawVal> for &[u8] {
+    fn into_val(self, env: &E) -> RawVal {
+        let env = env.clone();
+        let mut bin = env.binary_new();
+        bin = env.binary_copy_from_slice(bin, U32_ZERO, self);
+        bin.to_raw()
+    }
+}
+
+impl<E: Env> IntoVal<E, EnvVal<E, RawVal>> for &[u8] {
+    fn into_val(self, env: &E) -> EnvVal<E, RawVal> {
+        let rv: RawVal = self.into_val(env);
+        EnvVal {
+            env: env.clone(),
+            val: rv,
+        }
+    }
+}
+
+impl<E: Env, const N: usize> IntoVal<E, RawVal> for &[u8; N] {
+    fn into_val(self, env: &E) -> RawVal {
+        let slice: &[u8] = self;
+        slice.into_val(env)
+    }
+}
+
+impl<E: Env, const N: usize> IntoVal<E, EnvVal<E, RawVal>> for &[u8; N] {
+    fn into_val(self, env: &E) -> EnvVal<E, RawVal> {
+        let slice: &[u8] = self;
+        slice.into_val(env)
+    }
+}
+
+impl<E: Env, const N: usize> IntoVal<E, RawVal> for [u8; N] {
+    fn into_val(self, env: &E) -> RawVal {
+        (&self).into_val(env)
+    }
+}
+
+impl<E: Env, const N: usize> IntoVal<E, EnvVal<E, RawVal>> for [u8; N] {
+    fn into_val(self, env: &E) -> EnvVal<E, RawVal> {
+        (&self).into_val(env)
     }
 }

--- a/soroban-env-common/src/array.rs
+++ b/soroban-env-common/src/array.rs
@@ -1,0 +1,90 @@
+use stellar_xdr::ScObjectType;
+
+use crate::{
+    ConversionError, Env, EnvVal, IntoVal, Object, RawVal, RawValConvertible, TryFromVal,
+    TryIntoVal,
+};
+
+use seq_macro::seq;
+
+macro_rules! impl_for_array {
+    ( $count:literal ) => {
+        impl<E: Env, T> TryFrom<EnvVal<E, RawVal>> for [T; $count]
+        where
+            T: TryFrom<EnvVal<E, RawVal>>,
+        {
+            type Error = ConversionError;
+
+            fn try_from(ev: EnvVal<E, RawVal>) -> Result<Self, Self::Error> {
+                const COUNT: u32 = $count;
+                if !Object::val_is_obj_type(ev.val, ScObjectType::Vec) {
+                    return Err(ConversionError);
+                }
+                let env = ev.env.clone();
+                let vec = unsafe { Object::unchecked_from_val(ev.val) };
+                let len: u32 = env.vec_len(vec).try_into()?;
+                if len != COUNT {
+                    return Err(ConversionError);
+                }
+                Ok(seq!(INDEX in 0..$count {
+                    [
+                        #({
+                            const IDX: u32 = INDEX;
+                            T::try_from_val(&env, env.vec_get(vec, IDX.into())).map_err(|_| ConversionError)?
+                        },)*
+                    ]
+                }))
+            }
+        }
+
+        impl<E: Env, T> IntoVal<E, RawVal> for [T; $count]
+        where
+            T: IntoVal<E, RawVal>
+        {
+            fn into_val(self, env: &E) -> RawVal {
+                const COUNT: u32 = $count;
+                let env = env.clone();
+                let mut vec = env.vec_new(COUNT.into());
+                for t in self {
+                    vec = env.vec_push(vec, t.into_val(&env));
+                }
+                vec.to_raw()
+            }
+        }
+
+        impl<E: Env, T> IntoVal<E, EnvVal<E, RawVal>> for [T; $count]
+        where
+            T: IntoVal<E, RawVal>
+        {
+            fn into_val(self, env: &E) -> EnvVal<E, RawVal> {
+                let rv: RawVal = self.into_val(env);
+                EnvVal{
+                    env: env.clone(),
+                    val: rv,
+                }
+            }
+        }
+
+        impl<E: Env, T> TryIntoVal<E, [T; $count]> for RawVal
+        where
+            T: TryFrom<EnvVal<E, RawVal>>
+        {
+            type Error = ConversionError;
+            #[inline(always)]
+            fn try_into_val(self, env: &E) -> Result<[T; $count], Self::Error> {
+                EnvVal{ env: env.clone(), val: self }.try_into()
+            }
+        }
+
+        // TODO: Add [u8; $count] impls as well to and from Bytes.
+    };
+}
+
+seq!(COUNT in 0..31 {
+    impl_for_array! { COUNT }
+});
+impl_for_array! { 32 }
+impl_for_array! { 64 }
+impl_for_array! { 128 }
+impl_for_array! { 256 }
+impl_for_array! { 512 }

--- a/soroban-env-common/src/array.rs
+++ b/soroban-env-common/src/array.rs
@@ -2,75 +2,61 @@ use stellar_xdr::ScObjectType;
 
 use crate::{ConversionError, Env, EnvVal, IntoVal, Object, RawVal, RawValConvertible, TryIntoVal};
 
-use seq_macro::seq;
+impl<E: Env, const N: usize> TryFrom<EnvVal<E, RawVal>> for [u8; N] {
+    type Error = ConversionError;
 
-macro_rules! impl_for_u8_array {
-    ( $count:literal ) => {
-        impl<E: Env> TryFrom<EnvVal<E, RawVal>> for [u8; $count] {
-            type Error = ConversionError;
-
-            fn try_from(ev: EnvVal<E, RawVal>) -> Result<Self, Self::Error> {
-                const COUNT: u32 = $count;
-                if !Object::val_is_obj_type(ev.val, ScObjectType::Bytes) {
-                    return Err(ConversionError);
-                }
-                let env = ev.env.clone();
-                let bin = unsafe { Object::unchecked_from_val(ev.val) };
-                let len: u32 = env.binary_len(bin).try_into()?;
-                if len != COUNT {
-                    return Err(ConversionError);
-                }
-                // TODO: Use memory copy instead of individual gets.
-                Ok(seq!(INDEX in 0..$count {
-                    [
-                        #({
-                            const IDX: u32 = INDEX;
-                            let val = env.binary_get(bin, IDX.into());
-                            let val_u32 = unsafe { u32::unchecked_from_val(val) };
-                            val_u32 as u8
-                        },)*
-                    ]
-                }))
-            }
+    fn try_from(ev: EnvVal<E, RawVal>) -> Result<Self, Self::Error> {
+        if !Object::val_is_obj_type(ev.val, ScObjectType::Bytes) {
+            return Err(ConversionError);
         }
-
-        impl<E: Env> IntoVal<E, RawVal> for [u8; $count] {
-            fn into_val(self, env: &E) -> RawVal {
-                let env = env.clone();
-                let mut bin = env.binary_new();
-                for b in self {
-                    let b_u32 = Into::<u32>::into(b);
-                    bin = env.binary_push(bin, b_u32.into_val(&env));
-                }
-                bin.to_raw()
-            }
+        let env = ev.env.clone();
+        let bin = unsafe { Object::unchecked_from_val(ev.val) };
+        let len = unsafe { u32::unchecked_from_val(env.binary_len(bin)) };
+        if len as usize != N {
+            return Err(ConversionError);
         }
-
-        impl<E: Env> IntoVal<E, EnvVal<E, RawVal>> for [u8; $count] {
-            fn into_val(self, env: &E) -> EnvVal<E, RawVal> {
-                let rv: RawVal = self.into_val(env);
-                EnvVal{
-                    env: env.clone(),
-                    val: rv,
-                }
-            }
+        let mut arr = [0u8; N];
+        // TODO: Perform copy using linear memory copy.
+        for (i, b) in arr.iter_mut().enumerate() {
+            let b_val = env.binary_get(bin, (i as u32).into());
+            let b_u32 = unsafe { u32::unchecked_from_val(b_val) };
+            *b = b_u32 as u8;
         }
-
-        impl<E: Env> TryIntoVal<E, [u8; $count]> for RawVal {
-            type Error = ConversionError;
-            #[inline(always)]
-            fn try_into_val(self, env: &E) -> Result<[u8; $count], Self::Error> {
-                EnvVal{ env: env.clone(), val: self }.try_into()
-            }
-        }
-    };
+        Ok(arr)
+    }
 }
 
-seq!(COUNT in 0..31 {
-    impl_for_u8_array! { COUNT }
-});
-impl_for_u8_array! { 32 }
-impl_for_u8_array! { 64 }
-impl_for_u8_array! { 128 }
-impl_for_u8_array! { 256 }
-impl_for_u8_array! { 512 }
+impl<E: Env, const N: usize> IntoVal<E, RawVal> for [u8; N] {
+    fn into_val(self, env: &E) -> RawVal {
+        let env = env.clone();
+        let mut bin = env.binary_new();
+        for b in self {
+            let b_u32 = b as u32;
+            let b_val = b_u32.into_val(&env);
+            bin = env.binary_push(bin, b_val);
+        }
+        bin.to_raw()
+    }
+}
+
+impl<E: Env, const N: usize> IntoVal<E, EnvVal<E, RawVal>> for [u8; N] {
+    fn into_val(self, env: &E) -> EnvVal<E, RawVal> {
+        let rv: RawVal = self.into_val(env);
+        EnvVal {
+            env: env.clone(),
+            val: rv,
+        }
+    }
+}
+
+impl<E: Env, const N: usize> TryIntoVal<E, [u8; N]> for RawVal {
+    type Error = ConversionError;
+    #[inline(always)]
+    fn try_into_val(self, env: &E) -> Result<[u8; N], Self::Error> {
+        EnvVal {
+            env: env.clone(),
+            val: self,
+        }
+        .try_into()
+    }
+}

--- a/soroban-env-common/src/array.rs
+++ b/soroban-env-common/src/array.rs
@@ -1,61 +1,52 @@
 use stellar_xdr::ScObjectType;
 
-use crate::{
-    ConversionError, Env, EnvVal, IntoVal, Object, RawVal, RawValConvertible, TryFromVal,
-    TryIntoVal,
-};
+use crate::{ConversionError, Env, EnvVal, IntoVal, Object, RawVal, RawValConvertible, TryIntoVal};
 
 use seq_macro::seq;
 
-macro_rules! impl_for_array {
+macro_rules! impl_for_u8_array {
     ( $count:literal ) => {
-        impl<E: Env, T> TryFrom<EnvVal<E, RawVal>> for [T; $count]
-        where
-            T: TryFrom<EnvVal<E, RawVal>>,
-        {
+        impl<E: Env> TryFrom<EnvVal<E, RawVal>> for [u8; $count] {
             type Error = ConversionError;
 
             fn try_from(ev: EnvVal<E, RawVal>) -> Result<Self, Self::Error> {
                 const COUNT: u32 = $count;
-                if !Object::val_is_obj_type(ev.val, ScObjectType::Vec) {
+                if !Object::val_is_obj_type(ev.val, ScObjectType::Bytes) {
                     return Err(ConversionError);
                 }
                 let env = ev.env.clone();
-                let vec = unsafe { Object::unchecked_from_val(ev.val) };
-                let len: u32 = env.vec_len(vec).try_into()?;
+                let bin = unsafe { Object::unchecked_from_val(ev.val) };
+                let len: u32 = env.binary_len(bin).try_into()?;
                 if len != COUNT {
                     return Err(ConversionError);
                 }
+                // TODO: Use memory copy instead of individual gets.
                 Ok(seq!(INDEX in 0..$count {
                     [
                         #({
                             const IDX: u32 = INDEX;
-                            T::try_from_val(&env, env.vec_get(vec, IDX.into())).map_err(|_| ConversionError)?
+                            let val = env.binary_get(bin, IDX.into());
+                            let val_u32 = unsafe { u32::unchecked_from_val(val) };
+                            val_u32 as u8
                         },)*
                     ]
                 }))
             }
         }
 
-        impl<E: Env, T> IntoVal<E, RawVal> for [T; $count]
-        where
-            T: IntoVal<E, RawVal>
-        {
+        impl<E: Env> IntoVal<E, RawVal> for [u8; $count] {
             fn into_val(self, env: &E) -> RawVal {
-                const COUNT: u32 = $count;
                 let env = env.clone();
-                let mut vec = env.vec_new(COUNT.into());
-                for t in self {
-                    vec = env.vec_push(vec, t.into_val(&env));
+                let mut bin = env.binary_new();
+                for b in self {
+                    let b_u32 = Into::<u32>::into(b);
+                    bin = env.binary_push(bin, b_u32.into_val(&env));
                 }
-                vec.to_raw()
+                bin.to_raw()
             }
         }
 
-        impl<E: Env, T> IntoVal<E, EnvVal<E, RawVal>> for [T; $count]
-        where
-            T: IntoVal<E, RawVal>
-        {
+        impl<E: Env> IntoVal<E, EnvVal<E, RawVal>> for [u8; $count] {
             fn into_val(self, env: &E) -> EnvVal<E, RawVal> {
                 let rv: RawVal = self.into_val(env);
                 EnvVal{
@@ -65,26 +56,21 @@ macro_rules! impl_for_array {
             }
         }
 
-        impl<E: Env, T> TryIntoVal<E, [T; $count]> for RawVal
-        where
-            T: TryFrom<EnvVal<E, RawVal>>
-        {
+        impl<E: Env> TryIntoVal<E, [u8; $count]> for RawVal {
             type Error = ConversionError;
             #[inline(always)]
-            fn try_into_val(self, env: &E) -> Result<[T; $count], Self::Error> {
+            fn try_into_val(self, env: &E) -> Result<[u8; $count], Self::Error> {
                 EnvVal{ env: env.clone(), val: self }.try_into()
             }
         }
-
-        // TODO: Add [u8; $count] impls as well to and from Bytes.
     };
 }
 
 seq!(COUNT in 0..31 {
-    impl_for_array! { COUNT }
+    impl_for_u8_array! { COUNT }
 });
-impl_for_array! { 32 }
-impl_for_array! { 64 }
-impl_for_array! { 128 }
-impl_for_array! { 256 }
-impl_for_array! { 512 }
+impl_for_u8_array! { 32 }
+impl_for_u8_array! { 64 }
+impl_for_u8_array! { 128 }
+impl_for_u8_array! { 256 }
+impl_for_u8_array! { 512 }

--- a/soroban-env-common/src/lib.rs
+++ b/soroban-env-common/src/lib.rs
@@ -20,6 +20,7 @@
 
 mod val_wrapper;
 
+mod array;
 mod bitset;
 mod checked_env;
 mod convert;

--- a/soroban-env-common/src/raw_val.rs
+++ b/soroban-env-common/src/raw_val.rs
@@ -364,6 +364,13 @@ impl From<&ScStatus> for RawVal {
     }
 }
 
+impl From<u8> for RawVal {
+    #[inline(always)]
+    fn from(u: u8) -> Self {
+        RawVal::from_u32(u.into())
+    }
+}
+
 impl RawVal {
     pub fn in_env<E: Env>(self, env: &E) -> EnvVal<E, RawVal> {
         EnvVal {

--- a/soroban-env-common/src/raw_val.rs
+++ b/soroban-env-common/src/raw_val.rs
@@ -491,28 +491,37 @@ impl RawVal {
     }
 
     #[inline(always)]
+    pub const fn is_i32_zero(self) -> bool {
+        self.0 == Self::I32_ZERO.0
+    }
+
+    #[inline(always)]
     pub const fn is_u32_zero(self) -> bool {
-        const ZERO: RawVal = RawVal::from_u32(0);
-        self.0 == ZERO.0
+        self.0 == Self::U32_ZERO.0
     }
 
     #[inline(always)]
     pub const fn is_void(self) -> bool {
-        const VOID: RawVal = RawVal::from_other_static(ScStatic::Void);
-        self.0 == VOID.0
+        self.0 == Self::VOID.0
     }
 
     #[inline(always)]
     pub const fn is_true(self) -> bool {
-        const TRUE: RawVal = RawVal::from_bool(true);
-        self.0 == TRUE.0
+        self.0 == Self::TRUE.0
     }
 
     #[inline(always)]
     pub const fn is_false(self) -> bool {
-        const FALSE: RawVal = RawVal::from_bool(false);
-        self.0 == FALSE.0
+        self.0 == Self::FALSE.0
     }
+}
+
+impl RawVal {
+    pub const I32_ZERO: RawVal = RawVal::from_i32(0);
+    pub const U32_ZERO: RawVal = RawVal::from_u32(0);
+    pub const VOID: RawVal = RawVal::from_other_static(ScStatic::Void);
+    pub const TRUE: RawVal = RawVal::from_bool(true);
+    pub const FALSE: RawVal = RawVal::from_bool(false);
 }
 
 impl Debug for RawVal {

--- a/soroban-env-common/tests/array.rs
+++ b/soroban-env-common/tests/array.rs
@@ -25,10 +25,10 @@ fn array() {
 //     let val: RawVal = [1u8, 2, 3].into_val(&host);
 //     let obj: Object = val.try_into().unwrap();
 //     assert!(obj.is_obj_type(ScObjectType::Bytes));
-//     assert_eq!(3u32, host.vec_len(obj).try_into().unwrap());
-//     assert_eq!(1u8, host.vec_get(obj, 0u32.into()).try_into().unwrap());
-//     assert_eq!(2u8, host.vec_get(obj, 1u32.into()).try_into().unwrap());
-//     assert_eq!(3u8, host.vec_get(obj, 2u32.into()).try_into().unwrap());
+//     assert_eq!(3u32, host.binary_len(obj).try_into().unwrap());
+//     assert_eq!(1u32, host.binary_get(obj, 0u32.into()).try_into().unwrap());
+//     assert_eq!(2u32, host.binary_get(obj, 1u32.into()).try_into().unwrap());
+//     assert_eq!(3u32, host.binary_get(obj, 2u32.into()).try_into().unwrap());
 
 //     let arr: [u8; 3] = val.try_into_val(&host).unwrap();
 //     assert_eq!(arr, [1, 2, 3]);

--- a/soroban-env-common/tests/array.rs
+++ b/soroban-env-common/tests/array.rs
@@ -1,0 +1,35 @@
+use soroban_env_host::Host;
+
+use soroban_env_common::{xdr::ScObjectType, Env, IntoVal, Object, RawVal, TryIntoVal};
+
+#[test]
+fn array() {
+    let host = Host::default();
+
+    let val: RawVal = [1i32, 2, 3].into_val(&host);
+    let obj: Object = val.try_into().unwrap();
+    assert!(obj.is_obj_type(ScObjectType::Vec));
+    assert_eq!(3u32, host.vec_len(obj).try_into().unwrap());
+    assert_eq!(1i32, host.vec_get(obj, 0u32.into()).try_into().unwrap());
+    assert_eq!(2i32, host.vec_get(obj, 1u32.into()).try_into().unwrap());
+    assert_eq!(3i32, host.vec_get(obj, 2u32.into()).try_into().unwrap());
+
+    let arr: [i32; 3] = val.try_into_val(&host).unwrap();
+    assert_eq!(arr, [1, 2, 3]);
+}
+
+#[test]
+fn array_u8() {
+    let host = Host::default();
+
+    let val: RawVal = [1u8, 2, 3].into_val(&host);
+    let obj: Object = val.try_into().unwrap();
+    assert!(obj.is_obj_type(ScObjectType::Bytes));
+    // assert_eq!(3u32, host.vec_len(obj).try_into().unwrap());
+    // assert_eq!(1u8, host.vec_get(obj, 0u32.into()).try_into().unwrap());
+    // assert_eq!(2u8, host.vec_get(obj, 1u32.into()).try_into().unwrap());
+    // assert_eq!(3u8, host.vec_get(obj, 2u32.into()).try_into().unwrap());
+
+    // let arr: [u8; 3] = val.try_into_val(&host).unwrap();
+    // assert_eq!(arr, [1, 2, 3]);
+}

--- a/soroban-env-common/tests/array.rs
+++ b/soroban-env-common/tests/array.rs
@@ -3,10 +3,28 @@ use soroban_env_host::Host;
 use soroban_env_common::{xdr::ScObjectType, Env, IntoVal, Object, RawVal, TryIntoVal};
 
 #[test]
-fn array_u8() {
+fn u8_array() {
     let host = Host::default();
 
-    let val: RawVal = [1u8, 2, 3].into_val(&host);
+    let arr = [1u8, 2, 3];
+    let val: RawVal = arr.into_val(&host);
+    let obj: Object = val.try_into().unwrap();
+    assert!(obj.is_obj_type(ScObjectType::Bytes));
+    assert_eq!(3u32, host.binary_len(obj).try_into().unwrap());
+    assert_eq!(1u32, host.binary_get(obj, 0u32.into()).try_into().unwrap());
+    assert_eq!(2u32, host.binary_get(obj, 1u32.into()).try_into().unwrap());
+    assert_eq!(3u32, host.binary_get(obj, 2u32.into()).try_into().unwrap());
+
+    let arr: [u8; 3] = val.try_into_val(&host).unwrap();
+    assert_eq!(arr, [1, 2, 3]);
+}
+
+#[test]
+fn u8_slice() {
+    let host = Host::default();
+
+    let slice: &[u8] = &[1u8, 2, 3];
+    let val: RawVal = slice.into_val(&host);
     let obj: Object = val.try_into().unwrap();
     assert!(obj.is_obj_type(ScObjectType::Bytes));
     assert_eq!(3u32, host.binary_len(obj).try_into().unwrap());

--- a/soroban-env-common/tests/array.rs
+++ b/soroban-env-common/tests/array.rs
@@ -18,18 +18,18 @@ fn array() {
     assert_eq!(arr, [1, 2, 3]);
 }
 
-#[test]
-fn array_u8() {
-    let host = Host::default();
+// #[test]
+// fn array_u8() {
+//     let host = Host::default();
 
-    let val: RawVal = [1u8, 2, 3].into_val(&host);
-    let obj: Object = val.try_into().unwrap();
-    assert!(obj.is_obj_type(ScObjectType::Bytes));
-    // assert_eq!(3u32, host.vec_len(obj).try_into().unwrap());
-    // assert_eq!(1u8, host.vec_get(obj, 0u32.into()).try_into().unwrap());
-    // assert_eq!(2u8, host.vec_get(obj, 1u32.into()).try_into().unwrap());
-    // assert_eq!(3u8, host.vec_get(obj, 2u32.into()).try_into().unwrap());
+//     let val: RawVal = [1u8, 2, 3].into_val(&host);
+//     let obj: Object = val.try_into().unwrap();
+//     assert!(obj.is_obj_type(ScObjectType::Bytes));
+//     assert_eq!(3u32, host.vec_len(obj).try_into().unwrap());
+//     assert_eq!(1u8, host.vec_get(obj, 0u32.into()).try_into().unwrap());
+//     assert_eq!(2u8, host.vec_get(obj, 1u32.into()).try_into().unwrap());
+//     assert_eq!(3u8, host.vec_get(obj, 2u32.into()).try_into().unwrap());
 
-    // let arr: [u8; 3] = val.try_into_val(&host).unwrap();
-    // assert_eq!(arr, [1, 2, 3]);
-}
+//     let arr: [u8; 3] = val.try_into_val(&host).unwrap();
+//     assert_eq!(arr, [1, 2, 3]);
+// }

--- a/soroban-env-common/tests/array.rs
+++ b/soroban-env-common/tests/array.rs
@@ -3,33 +3,17 @@ use soroban_env_host::Host;
 use soroban_env_common::{xdr::ScObjectType, Env, IntoVal, Object, RawVal, TryIntoVal};
 
 #[test]
-fn array() {
+fn array_u8() {
     let host = Host::default();
 
-    let val: RawVal = [1i32, 2, 3].into_val(&host);
+    let val: RawVal = [1u8, 2, 3].into_val(&host);
     let obj: Object = val.try_into().unwrap();
-    assert!(obj.is_obj_type(ScObjectType::Vec));
-    assert_eq!(3u32, host.vec_len(obj).try_into().unwrap());
-    assert_eq!(1i32, host.vec_get(obj, 0u32.into()).try_into().unwrap());
-    assert_eq!(2i32, host.vec_get(obj, 1u32.into()).try_into().unwrap());
-    assert_eq!(3i32, host.vec_get(obj, 2u32.into()).try_into().unwrap());
+    assert!(obj.is_obj_type(ScObjectType::Bytes));
+    assert_eq!(3u32, host.binary_len(obj).try_into().unwrap());
+    assert_eq!(1u32, host.binary_get(obj, 0u32.into()).try_into().unwrap());
+    assert_eq!(2u32, host.binary_get(obj, 1u32.into()).try_into().unwrap());
+    assert_eq!(3u32, host.binary_get(obj, 2u32.into()).try_into().unwrap());
 
-    let arr: [i32; 3] = val.try_into_val(&host).unwrap();
+    let arr: [u8; 3] = val.try_into_val(&host).unwrap();
     assert_eq!(arr, [1, 2, 3]);
 }
-
-// #[test]
-// fn array_u8() {
-//     let host = Host::default();
-
-//     let val: RawVal = [1u8, 2, 3].into_val(&host);
-//     let obj: Object = val.try_into().unwrap();
-//     assert!(obj.is_obj_type(ScObjectType::Bytes));
-//     assert_eq!(3u32, host.binary_len(obj).try_into().unwrap());
-//     assert_eq!(1u32, host.binary_get(obj, 0u32.into()).try_into().unwrap());
-//     assert_eq!(2u32, host.binary_get(obj, 1u32.into()).try_into().unwrap());
-//     assert_eq!(3u32, host.binary_get(obj, 2u32.into()).try_into().unwrap());
-
-//     let arr: [u8; 3] = val.try_into_val(&host).unwrap();
-//     assert_eq!(arr, [1, 2, 3]);
-// }

--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -1581,7 +1581,7 @@ impl CheckedEnv for Host {
         let i = self.usize_from_rawval_u32_input("i", i)?;
         self.visit_obj(b, |hv: &Vec<u8>| {
             hv.get(i)
-                .map(|u| Into::<RawVal>::into(Into::<u32>::into(*u)))
+                .map(|u| Into::<RawVal>::into(*u))
                 .ok_or_else(|| self.err_status(ScHostObjErrorCode::VecIndexOutOfBound))
         })
     }
@@ -1625,7 +1625,7 @@ impl CheckedEnv for Host {
     fn binary_front(&self, b: Object) -> Result<RawVal, HostError> {
         self.visit_obj(b, |hv: &Vec<u8>| {
             hv.first()
-                .map(|u| Into::<RawVal>::into(Into::<u32>::into(*u)))
+                .map(|u| Into::<RawVal>::into(*u))
                 .ok_or_else(|| self.err_status(ScHostObjErrorCode::VecIndexOutOfBound))
         })
     }
@@ -1633,7 +1633,7 @@ impl CheckedEnv for Host {
     fn binary_back(&self, b: Object) -> Result<RawVal, HostError> {
         self.visit_obj(b, |hv: &Vec<u8>| {
             hv.last()
-                .map(|u| Into::<RawVal>::into(Into::<u32>::into(*u)))
+                .map(|u| Into::<RawVal>::into(*u))
                 .ok_or_else(|| self.err_status(ScHostObjErrorCode::VecIndexOutOfBound))
         })
     }
@@ -1704,21 +1704,15 @@ impl CheckedEnv for Host {
     }
 
     fn account_get_low_threshold(&self, a: Object) -> Result<RawVal, Self::Error> {
-        let threshold = self.load_account(a)?.thresholds.0[ThresholdIndexes::Low as usize];
-        let threshold = Into::<u32>::into(threshold);
-        Ok(threshold.into())
+        Ok(self.load_account(a)?.thresholds.0[ThresholdIndexes::Low as usize].into())
     }
 
     fn account_get_medium_threshold(&self, a: Object) -> Result<RawVal, Self::Error> {
-        let threshold = self.load_account(a)?.thresholds.0[ThresholdIndexes::Med as usize];
-        let threshold = Into::<u32>::into(threshold);
-        Ok(threshold.into())
+        Ok(self.load_account(a)?.thresholds.0[ThresholdIndexes::Med as usize].into())
     }
 
     fn account_get_high_threshold(&self, a: Object) -> Result<RawVal, Self::Error> {
-        let threshold = self.load_account(a)?.thresholds.0[ThresholdIndexes::High as usize];
-        let threshold = Into::<u32>::into(threshold);
-        Ok(threshold.into())
+        Ok(self.load_account(a)?.thresholds.0[ThresholdIndexes::High as usize].into())
     }
 
     fn account_get_signer_weight(&self, a: Object, s: Object) -> Result<RawVal, Self::Error> {
@@ -1729,9 +1723,7 @@ impl CheckedEnv for Host {
         let ae = self.load_account(a)?;
         if ae.account_id == AccountId(PublicKey::PublicKeyTypeEd25519(target_signer.clone())) {
             // Target signer is the master key, so return the master weight
-            let threshold = ae.thresholds.0[ThresholdIndexes::MasterWeight as usize];
-            let threshold = Into::<u32>::into(threshold);
-            Ok(threshold.into())
+            Ok(ae.thresholds.0[ThresholdIndexes::MasterWeight as usize].into())
         } else {
             // Target signer is not the master key, so search the account signers
             let signers: &Vec<Signer> = ae.signers.as_ref();


### PR DESCRIPTION
### What

Add conversions between RawVal and fixed-size u8 arrays and slices.

### Why

Convenience.

Close #303 

### Known limitations

I originally intended to do all fixed-size arrays, not just u8, but because IntoVal contains generics in its type, we can't implement both T and u8 even though u8 is not a RawVal because of limitations in the compiler not checking generic types in traits. I've opted for u8 because I think it's the type that will benefit most from having fixed array val conversion. 
