### PR TITLE
Expose LedgerInfo only with testutils

### DIFF
--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -16,7 +16,6 @@ use soroban_env_common::xdr::{AccountId, Hash, PublicKey, ReadXdr, ThresholdInde
 
 use crate::budget::{Budget, CostType};
 use crate::events::{DebugError, DebugEvent, Events};
-use crate::ledger_info::LedgerInfo;
 use crate::storage::Storage;
 use crate::weak_host::WeakHost;
 
@@ -84,6 +83,14 @@ struct VmSlice {
     vm: Rc<Vm>,
     pos: u32,
     len: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct LedgerInfo {
+    pub protocol_version: u32,
+    pub sequence_number: u32,
+    pub timestamp: u64,
+    pub network_id: Vec<u8>,
 }
 
 #[derive(Clone, Default)]

--- a/soroban-env-host/src/ledger_info.rs
+++ b/soroban-env-host/src/ledger_info.rs
@@ -1,7 +1,0 @@
-#[derive(Debug, Clone)]
-pub struct LedgerInfo {
-    pub protocol_version: u32,
-    pub sequence_number: u32,
-    pub timestamp: u64,
-    pub network_id: Vec<u8>,
-}

--- a/soroban-env-host/src/lib.rs
+++ b/soroban-env-host/src/lib.rs
@@ -46,7 +46,8 @@ mod test;
 
 #[cfg(feature = "testutils")]
 pub use host::ContractFunctionSet;
+#[cfg(feature = "testutils")]
+pub use host::LedgerInfo;
 pub use host::{Host, HostError};
 pub use im_rc;
 pub use soroban_env_common::*;
-pub mod ledger_info;


### PR DESCRIPTION
Reverts part of #350 and only exposes `LedgerInfo` in `testutils`.
