### PR TITLE
Add panic! messages to Symbol::from_str panics

### DIFF
--- a/soroban-env-common/src/symbol.rs
+++ b/soroban-env-common/src/symbol.rs
@@ -157,7 +157,8 @@ impl Symbol {
     pub const fn from_str(s: &str) -> Symbol {
         match Self::try_from_str(s) {
             Ok(sym) => sym,
-            Err(_) => panic!(),
+            Err(SymbolError::TooLong(_)) => panic!("symbol too long"),
+            Err(SymbolError::BadChar(_)) => panic!("symbol bad char"),
         }
     }
 


### PR DESCRIPTION
### What
Add panic! messages to Symbol::from_str panics.

### Why
To better communicate why the panic has occurred.

Note that because the function these panics occur in is a const function, there are limitations for the inputs to the panic! calls meaning the strings must be simpler.