### PR TITLE
Add Option<T> <=> RawVal conversions

### DIFF
--- a/soroban-env-common/src/lib.rs
+++ b/soroban-env-common/src/lib.rs
@@ -28,6 +28,7 @@ mod env;
 mod env_val;
 pub mod meta;
 mod object;
+mod option;
 mod raw_val;
 mod r#static;
 mod status;

--- a/soroban-env-common/src/option.rs
+++ b/soroban-env-common/src/option.rs
@@ -1,0 +1,64 @@
+use crate::{Env, EnvVal, IntoVal, RawVal};
+
+// impl<E: Env, T: TryFrom<EnvVal<E, RawVal>>> TryFrom<EnvVal<E, RawVal>> for Option<T> {
+//     type Error = ConversionError;
+
+//     fn try_from(ev: EnvVal<E, RawVal>) -> Result<Self, Self::Error> {
+//         todo!()
+//     }
+// }
+
+// impl<E: Env, T: TryFrom<EnvVal<E, RawVal>>> TryIntoVal<E, Option<T>> for RawVal {
+//     type Error = ConversionError;
+//     #[inline(always)]
+//     fn try_into_val(self, env: &E) -> Result<Option<T>, Self::Error> {
+//         EnvVal {
+//             env: env.clone(),
+//             val: self,
+//         }
+//         .try_into()
+//     }
+// }
+
+impl<E: Env, T> IntoVal<E, RawVal> for &Option<T>
+where
+    for<'a> &'a T: IntoVal<E, RawVal>,
+{
+    fn into_val(self, env: &E) -> RawVal {
+        match self {
+            Some(t) => t.into_val(env),
+            None => RawVal::from_void(),
+        }
+    }
+}
+
+impl<E: Env, T> IntoVal<E, EnvVal<E, RawVal>> for &Option<T>
+where
+    for<'a> &'a Option<T>: IntoVal<E, RawVal>,
+{
+    fn into_val(self, env: &E) -> EnvVal<E, RawVal> {
+        let rv: RawVal = self.into_val(env);
+        EnvVal {
+            env: env.clone(),
+            val: rv,
+        }
+    }
+}
+
+impl<E: Env, T> IntoVal<E, RawVal> for Option<T>
+where
+    for<'a> &'a Option<T>: IntoVal<E, RawVal>,
+{
+    fn into_val(self, env: &E) -> RawVal {
+        (&self).into_val(env)
+    }
+}
+
+impl<E: Env, T> IntoVal<E, EnvVal<E, RawVal>> for Option<T>
+where
+    for<'a> &'a Option<T>: IntoVal<E, EnvVal<E, RawVal>>,
+{
+    fn into_val(self, env: &E) -> EnvVal<E, RawVal> {
+        (&self).into_val(env)
+    }
+}

--- a/soroban-env-common/src/option.rs
+++ b/soroban-env-common/src/option.rs
@@ -1,30 +1,60 @@
-use crate::{Env, EnvVal, IntoVal, RawVal, TryFromVal, TryIntoVal};
+use crate::{Env, EnvVal, IntoVal, RawVal};
 
-impl<E: Env, T> TryFromVal<E, RawVal> for Option<T>
-where
-    T: TryFromVal<E, RawVal>,
-{
-    type Error = T::Error;
+// We can't add conversions from RawVal to Option<T> because Option<T>
+// has a blanket implementation for converting any T to Option<T>.
+//
+// We drive TryFromVal impls from a TryFrom<EnvVal<>>, and so there is a
+// conflict for TryFrom<EnvVal<>> for Option<T> since T could be EnvVal<>.
+//
+// What to do? There are two options:
+//
+//   1) Stop driving TryFromVal from TryFrom<EnvVal<>> and impl TryFromVal
+//   manually. This is probably fine, just tedious to go and rewrite all the
+//   impls. But, the oddity remains that you still can't convert from an
+//   EnvVal<> to an Option<T>.
+//
+//   2) Or, manually impl TryFrom<EnvVal<>> for every type, including user
+//   defined types. (See example below of doing u32.) The good news is this can
+//   be macrod.
+//
+// An oddity remains in both cases that converting RawVal => Option<RawVal> will
+// simply wrap it, it won't actually unwrap a RawVal/EnvVal Void to None. So
+// there's two types that will behave differently to all other types.
+//
+// Here we go with option (2), and provide a macro that does the impl for any
+// type.
 
-    fn try_from_val(env: &E, v: RawVal) -> Result<Self, Self::Error> {
-        if v.is_void() {
-            Ok(None)
-        } else {
-            Ok(Some(T::try_from_val(env, v)?))
+#[macro_export]
+macro_rules! impl_try_from_option {
+    ( $T:ty ) => {
+        impl<E: Env> TryFrom<EnvVal<E, RawVal>> for Option<$T> {
+            type Error = <$T as TryFrom<EnvVal<E, RawVal>>>::Error;
+
+            fn try_from(ev: EnvVal<E, RawVal>) -> Result<Self, Self::Error> {
+                if ev.val.is_void() {
+                    Ok(None)
+                } else {
+                    Ok(Some(<$T>::try_from(ev)?))
+                }
+            }
         }
-    }
+
+        impl<E: Env> $crate::TryIntoVal<E, Option<$T>> for RawVal {
+            type Error = <$T as TryFrom<EnvVal<E, RawVal>>>::Error;
+            #[inline(always)]
+            fn try_into_val(self, env: &E) -> Result<Option<$T>, Self::Error> {
+                <_ as TryFrom<EnvVal<E, RawVal>>>::try_from(EnvVal {
+                    env: env.clone(),
+                    val: self,
+                })
+            }
+        }
+    };
 }
 
-impl<E: Env, T> TryIntoVal<E, Option<T>> for RawVal
-where
-    T: TryFromVal<E, RawVal>,
-{
-    type Error = T::Error;
-    #[inline(always)]
-    fn try_into_val(self, env: &E) -> Result<Option<T>, Self::Error> {
-        <_ as TryFromVal<E, RawVal>>::try_from_val(env, self)
-    }
-}
+// TODO: Move this to the appropriate place. It is just here as an example for
+// the moment.
+impl_try_from_option!(u32);
 
 impl<E: Env, T> IntoVal<E, RawVal> for &Option<T>
 where

--- a/soroban-env-common/src/option.rs
+++ b/soroban-env-common/src/option.rs
@@ -52,10 +52,6 @@ macro_rules! impl_try_from_option {
     };
 }
 
-// TODO: Move this to the appropriate place. It is just here as an example for
-// the moment.
-impl_try_from_option!(u32);
-
 impl<E: Env, T> IntoVal<E, RawVal> for &Option<T>
 where
     for<'a> &'a T: IntoVal<E, RawVal>,

--- a/soroban-env-common/src/option.rs
+++ b/soroban-env-common/src/option.rs
@@ -83,18 +83,25 @@ where
 
 impl<E: Env, T> IntoVal<E, RawVal> for Option<T>
 where
-    for<'a> &'a Option<T>: IntoVal<E, RawVal>,
+    T: IntoVal<E, RawVal>,
 {
     fn into_val(self, env: &E) -> RawVal {
-        (&self).into_val(env)
+        match self {
+            Some(t) => t.into_val(env),
+            None => RawVal::from_void(),
+        }
     }
 }
 
 impl<E: Env, T> IntoVal<E, EnvVal<E, RawVal>> for Option<T>
 where
-    for<'a> &'a Option<T>: IntoVal<E, EnvVal<E, RawVal>>,
+    T: IntoVal<E, RawVal>,
 {
     fn into_val(self, env: &E) -> EnvVal<E, RawVal> {
-        (&self).into_val(env)
+        let rv: RawVal = self.into_val(env);
+        EnvVal {
+            env: env.clone(),
+            val: rv,
+        }
     }
 }

--- a/soroban-env-common/src/raw_val.rs
+++ b/soroban-env-common/src/raw_val.rs
@@ -185,6 +185,7 @@ macro_rules! declare_tryfrom {
                 Self::try_from(v.to_raw())
             }
         }
+        $crate::impl_try_from_option!($T);
         impl<E: Env> TryFrom<EnvVal<E, RawVal>> for EnvVal<E, $T> {
             type Error = crate::ConversionError;
             fn try_from(ev: EnvVal<E, RawVal>) -> Result<Self, Self::Error> {

--- a/soroban-env-common/tests/option.rs
+++ b/soroban-env-common/tests/option.rs
@@ -12,6 +12,8 @@ fn some() {
     assert!(val.is::<u32>());
     let u32: u32 = val.try_into_val(&host).unwrap();
     assert_eq!(u32, 1);
+
+    assert_eq!(some, val.try_into_val(&host).unwrap());
 }
 
 #[test]
@@ -23,4 +25,6 @@ fn none() {
     assert!(val.is::<Static>());
     let r#static: Static = val.try_into_val(&host).unwrap();
     assert!(r#static.is_type(ScStatic::Void));
+
+    assert_eq!(none, val.try_into_val(&host).unwrap());
 }

--- a/soroban-env-common/tests/option.rs
+++ b/soroban-env-common/tests/option.rs
@@ -1,0 +1,26 @@
+use soroban_env_host::Host;
+
+use soroban_env_common::{IntoVal, RawVal, Static, TryIntoVal};
+use stellar_xdr::ScStatic;
+
+#[test]
+fn some() {
+    let host = Host::default();
+
+    let some = Some(1u32);
+    let val: RawVal = some.into_val(&host);
+    assert!(val.is::<u32>());
+    let u32: u32 = val.try_into_val(&host).unwrap();
+    assert_eq!(u32, 1);
+}
+
+#[test]
+fn none() {
+    let host = Host::default();
+
+    let none: Option<u32> = None;
+    let val: RawVal = none.into_val(&host);
+    assert!(val.is::<Static>());
+    let r#static: Static = val.try_into_val(&host).unwrap();
+    assert!(r#static.is_type(ScStatic::Void));
+}


### PR DESCRIPTION
### What
Add Option<T> <=> RawVal conversions.

### Why
Developers should be able to use Option<T> in their contract types, as well as in storage and as inputs and outputs.

Close #302