### PR TITLE
Replace TryFrom<EnvVal<>> with TryFromVal<>

### DIFF
--- a/soroban-env-common/src/env_val.rs
+++ b/soroban-env-common/src/env_val.rs
@@ -83,15 +83,6 @@ pub trait IntoVal<E: Env, V>: Sized {
     }
 }
 
-impl<E: Env, F, T> IntoVal<E, T> for F
-where
-    F: Into<T>,
-{
-    fn into_val(self, _: &E) -> T {
-        self.into()
-    }
-}
-
 pub trait TryIntoVal<E: Env, V>: Sized {
     type Error;
     fn try_into_val(self, env: &E) -> Result<V, Self::Error>;
@@ -104,34 +95,10 @@ pub trait TryIntoVal<E: Env, V>: Sized {
     }
 }
 
-// impl<E: Env, F, T> TryIntoVal<E, T> for F
-// where
-//     F: TryInto<T>,
-// {
-//     type Error = F::Error;
-
-//     fn try_into_val(self, _: &E) -> Result<T, Self::Error> {
-//         self.try_into()
-//     }
-// }
-
 pub trait TryFromVal<E: Env, V>: Sized {
     type Error;
     fn try_from_val(env: &E, v: V) -> Result<Self, Self::Error>;
 }
-
-// impl<E: Env, V, T> TryFromVal<E, V> for T
-// where
-//     T: TryFrom<EnvVal<E, V>>,
-// {
-//     type Error = T::Error;
-//     fn try_from_val(env: &E, v: V) -> Result<Self, Self::Error> {
-//         Self::try_from(EnvVal {
-//             env: env.clone(),
-//             val: v,
-//         })
-//     }
-// }
 
 impl<E: Env> From<EnvVal<E, RawVal>> for RawVal {
     fn from(ev: EnvVal<E, RawVal>) -> Self {

--- a/soroban-env-common/src/env_val.rs
+++ b/soroban-env-common/src/env_val.rs
@@ -11,7 +11,7 @@ use super::{
     raw_val::{RawVal, RawValConvertible},
     Env,
 };
-use core::{cmp::Ordering, fmt::Debug};
+use core::{cmp::Ordering, convert::Infallible, fmt::Debug};
 
 /// Some type of value coupled to a specific instance of [Env], which some of
 /// the value's methods may call into to support some conversion and comparison
@@ -103,6 +103,22 @@ pub trait TryFromVal<E: Env, V>: Sized {
 impl<E: Env> From<EnvVal<E, RawVal>> for RawVal {
     fn from(ev: EnvVal<E, RawVal>) -> Self {
         ev.val
+    }
+}
+
+impl<E: Env, V> IntoVal<E, V> for EnvVal<E, V> {
+    fn into_val(self, _env: &E) -> V {
+        self.val
+    }
+}
+
+impl<E: Env, V> TryFromVal<E, V> for EnvVal<E, V> {
+    type Error = Infallible;
+    fn try_from_val(env: &E, val: V) -> Result<Self, Self::Error> {
+        Ok(EnvVal {
+            env: env.clone(),
+            val,
+        })
     }
 }
 

--- a/soroban-env-common/src/env_val.rs
+++ b/soroban-env-common/src/env_val.rs
@@ -104,34 +104,34 @@ pub trait TryIntoVal<E: Env, V>: Sized {
     }
 }
 
-impl<E: Env, F, T> TryIntoVal<E, T> for F
-where
-    F: TryInto<T>,
-{
-    type Error = F::Error;
+// impl<E: Env, F, T> TryIntoVal<E, T> for F
+// where
+//     F: TryInto<T>,
+// {
+//     type Error = F::Error;
 
-    fn try_into_val(self, _: &E) -> Result<T, Self::Error> {
-        self.try_into()
-    }
-}
+//     fn try_into_val(self, _: &E) -> Result<T, Self::Error> {
+//         self.try_into()
+//     }
+// }
 
 pub trait TryFromVal<E: Env, V>: Sized {
     type Error;
     fn try_from_val(env: &E, v: V) -> Result<Self, Self::Error>;
 }
 
-impl<E: Env, V, T> TryFromVal<E, V> for T
-where
-    T: TryFrom<EnvVal<E, V>>,
-{
-    type Error = T::Error;
-    fn try_from_val(env: &E, v: V) -> Result<Self, Self::Error> {
-        Self::try_from(EnvVal {
-            env: env.clone(),
-            val: v,
-        })
-    }
-}
+// impl<E: Env, V, T> TryFromVal<E, V> for T
+// where
+//     T: TryFrom<EnvVal<E, V>>,
+// {
+//     type Error = T::Error;
+//     fn try_from_val(env: &E, v: V) -> Result<Self, Self::Error> {
+//         Self::try_from(EnvVal {
+//             env: env.clone(),
+//             val: v,
+//         })
+//     }
+// }
 
 impl<E: Env> From<EnvVal<E, RawVal>> for RawVal {
     fn from(ev: EnvVal<E, RawVal>) -> Self {

--- a/soroban-env-common/src/lib.rs
+++ b/soroban-env-common/src/lib.rs
@@ -28,6 +28,7 @@ mod env;
 mod env_val;
 pub mod meta;
 mod object;
+mod option;
 mod raw_val;
 mod r#static;
 mod status;

--- a/soroban-env-common/src/object.rs
+++ b/soroban-env-common/src/object.rs
@@ -1,6 +1,6 @@
 use crate::{
     decl_tagged_val_wrapper_methods, xdr::ScObjectType, Env, EnvVal, RawVal, Tag, TryConvert,
-    TryIntoVal,
+    TryFromVal, TryIntoVal,
 };
 use core::fmt::Debug;
 use stellar_xdr::{ScObject, ScVal};
@@ -53,23 +53,13 @@ impl Object {
     }
 }
 
-impl<E> TryFrom<EnvVal<E, Object>> for ScObject
+impl<E> TryFromVal<E, Object> for ScObject
 where
     E: Env + TryConvert<Object, ScObject>,
 {
     type Error = E::Error;
-    fn try_from(ev: EnvVal<E, Object>) -> Result<Self, Self::Error> {
-        ev.env.convert(ev.val)
-    }
-}
-
-impl<E> TryFrom<&EnvVal<E, Object>> for ScObject
-where
-    E: Env + TryConvert<Object, ScObject>,
-{
-    type Error = E::Error;
-    fn try_from(ev: &EnvVal<E, Object>) -> Result<Self, Self::Error> {
-        ev.env.convert(ev.val)
+    fn try_from_val(env: &E, val: Object) -> Result<Self, Self::Error> {
+        env.convert(val)
     }
 }
 
@@ -90,26 +80,6 @@ where
     type Error = E::Error;
     fn try_into_val(self, env: &E) -> Result<Object, Self::Error> {
         env.convert(self)
-    }
-}
-
-impl<E> TryFrom<EnvVal<E, Object>> for ScVal
-where
-    E: Env + TryConvert<Object, ScObject>,
-{
-    type Error = E::Error;
-    fn try_from(ev: EnvVal<E, Object>) -> Result<Self, Self::Error> {
-        (&ev).try_into()
-    }
-}
-
-impl<E> TryFrom<&EnvVal<E, Object>> for ScVal
-where
-    E: Env + TryConvert<Object, ScObject>,
-{
-    type Error = E::Error;
-    fn try_from(ev: &EnvVal<E, Object>) -> Result<Self, Self::Error> {
-        Ok(ScVal::Object(Some(ev.env.convert(ev.val)?)))
     }
 }
 

--- a/soroban-env-common/src/option.rs
+++ b/soroban-env-common/src/option.rs
@@ -1,0 +1,101 @@
+use crate::{Env, EnvVal, IntoVal, RawVal, TryFromVal, TryIntoVal};
+
+// We can't add conversions from RawVal to Option<T> because Option<T>
+// has a blanket implementation for converting any T to Option<T>.
+//
+// We drive TryFromVal impls from a TryFrom<EnvVal<>>, and so there is a
+// conflict for TryFrom<EnvVal<>> for Option<T> since T could be EnvVal<>.
+//
+// What to do? There are two options:
+//
+//   1) Stop driving TryFromVal from TryFrom<EnvVal<>> and impl TryFromVal
+//   manually. This is probably fine, just tedious to go and rewrite all the
+//   impls. But, the oddity remains that you still can't convert from an
+//   EnvVal<> to an Option<T>.
+//
+//   2) Or, manually impl TryFrom<EnvVal<>> for every type, including user
+//   defined types. (See example below of doing u32.) The good news is this can
+//   be macrod.
+//
+// An oddity remains in both cases that converting RawVal => Option<RawVal> will
+// simply wrap it, it won't actually unwrap a RawVal/EnvVal Void to None. So
+// there's two types that will behave differently to all other types.
+//
+// Here we go with option (2), and provide a macro that does the impl for any
+// type.
+
+impl<E: Env, T> TryFromVal<E, RawVal> for Option<T>
+where
+    T: TryFromVal<E, RawVal>,
+{
+    type Error = T::Error;
+
+    fn try_from_val(env: &E, val: RawVal) -> Result<Self, Self::Error> {
+        if val.is_void() {
+            Ok(None)
+        } else {
+            Ok(Some(T::try_from_val(env, val)?))
+        }
+    }
+}
+
+impl<E: Env, T> TryIntoVal<E, Option<T>> for RawVal
+where
+    T: TryFromVal<E, RawVal>,
+{
+    type Error = T::Error;
+    #[inline(always)]
+    fn try_into_val(self, env: &E) -> Result<Option<T>, Self::Error> {
+        <_ as TryFromVal<E, RawVal>>::try_from_val(env, self)
+    }
+}
+
+impl<E: Env, T> IntoVal<E, RawVal> for &Option<T>
+where
+    for<'a> &'a T: IntoVal<E, RawVal>,
+{
+    fn into_val(self, env: &E) -> RawVal {
+        match self {
+            Some(t) => t.into_val(env),
+            None => RawVal::from_void(),
+        }
+    }
+}
+
+impl<E: Env, T> IntoVal<E, EnvVal<E, RawVal>> for &Option<T>
+where
+    for<'a> &'a Option<T>: IntoVal<E, RawVal>,
+{
+    fn into_val(self, env: &E) -> EnvVal<E, RawVal> {
+        let rv: RawVal = self.into_val(env);
+        EnvVal {
+            env: env.clone(),
+            val: rv,
+        }
+    }
+}
+
+impl<E: Env, T> IntoVal<E, RawVal> for Option<T>
+where
+    T: IntoVal<E, RawVal>,
+{
+    fn into_val(self, env: &E) -> RawVal {
+        match self {
+            Some(t) => t.into_val(env),
+            None => RawVal::from_void(),
+        }
+    }
+}
+
+impl<E: Env, T> IntoVal<E, EnvVal<E, RawVal>> for Option<T>
+where
+    T: IntoVal<E, RawVal>,
+{
+    fn into_val(self, env: &E) -> EnvVal<E, RawVal> {
+        let rv: RawVal = self.into_val(env);
+        EnvVal {
+            env: env.clone(),
+            val: rv,
+        }
+    }
+}

--- a/soroban-env-common/src/option.rs
+++ b/soroban-env-common/src/option.rs
@@ -1,4 +1,4 @@
-use crate::{Env, EnvVal, IntoVal, RawVal, TryFromVal, TryIntoVal};
+use crate::{Env, IntoVal, RawVal, TryFromVal, TryIntoVal};
 
 impl<E: Env, T> TryFromVal<E, RawVal> for Option<T>
 where
@@ -38,19 +38,6 @@ where
     }
 }
 
-impl<E: Env, T> IntoVal<E, EnvVal<E, RawVal>> for &Option<T>
-where
-    for<'a> &'a Option<T>: IntoVal<E, RawVal>,
-{
-    fn into_val(self, env: &E) -> EnvVal<E, RawVal> {
-        let rv: RawVal = self.into_val(env);
-        EnvVal {
-            env: env.clone(),
-            val: rv,
-        }
-    }
-}
-
 impl<E: Env, T> IntoVal<E, RawVal> for Option<T>
 where
     T: IntoVal<E, RawVal>,
@@ -59,19 +46,6 @@ where
         match self {
             Some(t) => t.into_val(env),
             None => RawVal::from_void(),
-        }
-    }
-}
-
-impl<E: Env, T> IntoVal<E, EnvVal<E, RawVal>> for Option<T>
-where
-    T: IntoVal<E, RawVal>,
-{
-    fn into_val(self, env: &E) -> EnvVal<E, RawVal> {
-        let rv: RawVal = self.into_val(env);
-        EnvVal {
-            env: env.clone(),
-            val: rv,
         }
     }
 }

--- a/soroban-env-common/src/option.rs
+++ b/soroban-env-common/src/option.rs
@@ -1,29 +1,5 @@
 use crate::{Env, EnvVal, IntoVal, RawVal, TryFromVal, TryIntoVal};
 
-// We can't add conversions from RawVal to Option<T> because Option<T>
-// has a blanket implementation for converting any T to Option<T>.
-//
-// We drive TryFromVal impls from a TryFrom<EnvVal<>>, and so there is a
-// conflict for TryFrom<EnvVal<>> for Option<T> since T could be EnvVal<>.
-//
-// What to do? There are two options:
-//
-//   1) Stop driving TryFromVal from TryFrom<EnvVal<>> and impl TryFromVal
-//   manually. This is probably fine, just tedious to go and rewrite all the
-//   impls. But, the oddity remains that you still can't convert from an
-//   EnvVal<> to an Option<T>.
-//
-//   2) Or, manually impl TryFrom<EnvVal<>> for every type, including user
-//   defined types. (See example below of doing u32.) The good news is this can
-//   be macrod.
-//
-// An oddity remains in both cases that converting RawVal => Option<RawVal> will
-// simply wrap it, it won't actually unwrap a RawVal/EnvVal Void to None. So
-// there's two types that will behave differently to all other types.
-//
-// Here we go with option (2), and provide a macro that does the impl for any
-// type.
-
 impl<E: Env, T> TryFromVal<E, RawVal> for Option<T>
 where
     T: TryFromVal<E, RawVal>,

--- a/soroban-env-common/src/raw_val.rs
+++ b/soroban-env-common/src/raw_val.rs
@@ -1,6 +1,6 @@
 use stellar_xdr::{ScStatic, ScStatus, ScStatusType};
 
-use super::{BitSet, Env, EnvVal, Object, Static, Status, Symbol, TryFromVal, TryIntoVal};
+use super::{BitSet, Env, EnvVal, IntoVal, Object, Static, Status, Symbol, TryFromVal, TryIntoVal};
 use core::fmt::Debug;
 
 extern crate static_assertions as sa;
@@ -176,6 +176,11 @@ macro_rules! declare_tryfrom {
                 } else {
                     Err(ConversionError)
                 }
+            }
+        }
+        impl<E: Env> IntoVal<E, RawVal> for $T {
+            fn into_val(self, _env: &E) -> RawVal {
+                self.into()
             }
         }
         impl<E: Env> TryFromVal<E, RawVal> for $T {

--- a/soroban-env-common/src/raw_val.rs
+++ b/soroban-env-common/src/raw_val.rs
@@ -1,6 +1,6 @@
 use stellar_xdr::{ScStatic, ScStatus, ScStatusType};
 
-use super::{BitSet, Env, EnvVal, Object, Static, Status, Symbol, TryFromVal};
+use super::{TryIntoVal, BitSet, Env, EnvVal, Object, Static, Status, Symbol, TryFromVal};
 use core::fmt::Debug;
 
 extern crate static_assertions as sa;
@@ -183,6 +183,12 @@ macro_rules! declare_tryfrom {
             #[inline(always)]
             fn try_from_val(_env: &E, val: RawVal) -> Result<Self, Self::Error> {
                 Self::try_from(val)
+            }
+        }
+        impl<E: Env> TryIntoVal<E, $T> for RawVal {
+            type Error = ConversionError;
+            fn try_into_val(self, env: &E) -> Result<$T, Self::Error> {
+                <_ as TryFromVal<E, RawVal>>::try_from_val(&env, self)
             }
         }
     };

--- a/soroban-env-common/src/raw_val.rs
+++ b/soroban-env-common/src/raw_val.rs
@@ -106,6 +106,19 @@ impl AsMut<RawVal> for RawVal {
     }
 }
 
+impl<E: Env> TryFromVal<E, RawVal> for RawVal {
+    type Error = Infallible;
+    fn try_from_val(_env: &E, val: RawVal) -> Result<Self, Self::Error> {
+        Ok(val)
+    }
+}
+
+impl<E: Env> IntoVal<E, RawVal> for RawVal {
+    fn into_val(self, _env: &E) -> RawVal {
+        self
+    }
+}
+
 // This is a 0-arg struct rather than an enum to ensure it completely compiles
 // away, the same way `()` would, while remaining a separate type to allow
 // conversion to a more-structured error code at a higher level.

--- a/soroban-env-common/src/raw_val.rs
+++ b/soroban-env-common/src/raw_val.rs
@@ -1,6 +1,6 @@
 use stellar_xdr::{ScStatic, ScStatus, ScStatusType};
 
-use super::{BitSet, Env, EnvVal, Object, Static, Status, Symbol};
+use super::{BitSet, Env, EnvVal, Object, Static, Status, Symbol, TryFromVal};
 use core::fmt::Debug;
 
 extern crate static_assertions as sa;
@@ -178,22 +178,11 @@ macro_rules! declare_tryfrom {
                 }
             }
         }
-        impl<E: Env> TryFrom<EnvVal<E, RawVal>> for $T {
+        impl<E: Env> TryFromVal<E, RawVal> for $T {
             type Error = ConversionError;
             #[inline(always)]
-            fn try_from(v: EnvVal<E, RawVal>) -> Result<Self, Self::Error> {
-                Self::try_from(v.to_raw())
-            }
-        }
-        impl<E: Env> TryFrom<EnvVal<E, RawVal>> for EnvVal<E, $T> {
-            type Error = crate::ConversionError;
-            fn try_from(ev: EnvVal<E, RawVal>) -> Result<Self, Self::Error> {
-                let val: $T = ev.to_raw().try_into().map_err(|err| {
-                    ev.clone().log_err_convert::<Self>();
-                    err
-                })?;
-                let env = ev.env;
-                Ok(Self { env, val })
+            fn try_from_val(_env: &E, val: RawVal) -> Result<Self, Self::Error> {
+                Self::try_from(val)
             }
         }
     };

--- a/soroban-env-common/src/raw_val.rs
+++ b/soroban-env-common/src/raw_val.rs
@@ -1,6 +1,6 @@
 use stellar_xdr::{ScStatic, ScStatus, ScStatusType};
 
-use super::{TryIntoVal, BitSet, Env, EnvVal, Object, Static, Status, Symbol, TryFromVal};
+use super::{BitSet, Env, EnvVal, Object, Static, Status, Symbol, TryFromVal, TryIntoVal};
 use core::fmt::Debug;
 
 extern crate static_assertions as sa;
@@ -183,6 +183,12 @@ macro_rules! declare_tryfrom {
             #[inline(always)]
             fn try_from_val(_env: &E, val: RawVal) -> Result<Self, Self::Error> {
                 Self::try_from(val)
+            }
+        }
+        impl<E: Env> TryIntoVal<E, RawVal> for $T {
+            type Error = ConversionError;
+            fn try_into_val(self, _env: &E) -> Result<RawVal, Self::Error> {
+                Ok(self.into())
             }
         }
         impl<E: Env> TryIntoVal<E, $T> for RawVal {

--- a/soroban-env-common/src/val_wrapper.rs
+++ b/soroban-env-common/src/val_wrapper.rs
@@ -19,7 +19,7 @@ macro_rules! decl_tagged_val_wrapper_methods {
                 b.0
             }
         }
-        impl crate::RawValConvertible for $tagname {
+        impl $crate::RawValConvertible for $tagname {
             #[inline(always)]
             fn is_val_type(v: RawVal) -> bool {
                 v.has_tag(Tag::$tagname)
@@ -138,11 +138,11 @@ macro_rules! impl_wrapper_from {
                 Self(x.into())
             }
         }
-        impl<E: Env> TryFrom<EnvVal<E, $tagname>> for $fromty {
-            type Error = crate::ConversionError;
+        impl<E: Env> $crate::TryFromVal<E, $tagname> for $fromty {
+            type Error = $crate::ConversionError;
             #[inline(always)]
-            fn try_from(v: EnvVal<E, $tagname>) -> Result<Self, Self::Error> {
-                Self::try_from(v.to_raw())
+            fn try_from_val(_env: &E, val: $tagname) -> Result<Self, Self::Error> {
+                Self::try_from(val.to_raw())
             }
         }
     };

--- a/soroban-env-common/tests/option.rs
+++ b/soroban-env-common/tests/option.rs
@@ -1,0 +1,30 @@
+use soroban_env_host::Host;
+
+use soroban_env_common::{IntoVal, RawVal, Static, TryIntoVal};
+use stellar_xdr::ScStatic;
+
+#[test]
+fn some() {
+    let host = Host::default();
+
+    let some = Some(1u32);
+    let val: RawVal = some.into_val(&host);
+    assert!(val.is::<u32>());
+    let u32: u32 = val.try_into_val(&host).unwrap();
+    assert_eq!(u32, 1);
+
+    assert_eq!(some, val.try_into_val(&host).unwrap());
+}
+
+#[test]
+fn none() {
+    let host = Host::default();
+
+    let none: Option<u32> = None;
+    let val: RawVal = none.into_val(&host);
+    assert!(val.is::<Static>());
+    let r#static: Static = val.try_into_val(&host).unwrap();
+    assert!(r#static.is_type(ScStatic::Void));
+
+    assert_eq!(none, val.try_into_val(&host).unwrap());
+}

--- a/soroban-env-host/src/native_contract/token/admin.rs
+++ b/soroban-env-host/src/native_contract/token/admin.rs
@@ -6,7 +6,7 @@ use crate::native_contract::token::public_types::{
 };
 use crate::native_contract::token::storage_types::DataKey;
 use core::cmp::Ordering;
-use soroban_env_common::{CheckedEnv, TryIntoVal};
+use soroban_env_common::{CheckedEnv, TryFromVal, TryIntoVal};
 
 pub fn has_administrator(e: &Host) -> Result<bool, Error> {
     let key = DataKey::Admin;
@@ -17,7 +17,7 @@ pub fn has_administrator(e: &Host) -> Result<bool, Error> {
 fn read_administrator(e: &Host) -> Result<Identifier, Error> {
     let key = DataKey::Admin;
     let rv = e.get_contract_data(key.try_into_val(e)?)?;
-    Ok(rv.in_env(e).try_into()?)
+    Ok(Identifier::try_from_val(e, rv)?)
 }
 
 pub fn to_administrator_authorization(
@@ -27,7 +27,7 @@ pub fn to_administrator_authorization(
     let admin = read_administrator(e)?;
     match (admin, auth) {
         (Identifier::Contract(admin_id), Authorization::Contract) => {
-            let invoker_id: BytesN<32> = e.get_invoking_contract()?.in_env(e).try_into()?;
+            let invoker_id: BytesN<32> = e.get_invoking_contract()?.to_raw().try_into_val(e)?;
             if admin_id.compare(&invoker_id)? != Ordering::Equal {
                 Err(Error::ContractError)
             } else {

--- a/soroban-env-host/src/native_contract/token/allowance.rs
+++ b/soroban-env-host/src/native_contract/token/allowance.rs
@@ -9,7 +9,7 @@ use soroban_env_common::{CheckedEnv, TryIntoVal};
 pub fn read_allowance(e: &Host, from: Identifier, spender: Identifier) -> Result<BigInt, Error> {
     let key = DataKey::Allowance(AllowanceDataKey { from, spender });
     if let Ok(allowance) = e.get_contract_data(key.try_into_val(e)?) {
-        Ok(allowance.in_env(e).try_into()?)
+        Ok(allowance.try_into_val(e)?)
     } else {
         Ok(BigInt::from_u64(e, 0)?)
     }

--- a/soroban-env-host/src/native_contract/token/balance.rs
+++ b/soroban-env-host/src/native_contract/token/balance.rs
@@ -9,7 +9,7 @@ use soroban_env_common::{CheckedEnv, TryIntoVal};
 pub fn read_balance(e: &Host, id: Identifier) -> Result<BigInt, Error> {
     let key = DataKey::Balance(id);
     if let Ok(balance) = e.get_contract_data(key.try_into_val(e)?) {
-        Ok(balance.in_env(e).try_into()?)
+        Ok(balance.try_into_val(e)?)
     } else {
         Ok(BigInt::from_u64(e, 0)?)
     }

--- a/soroban-env-host/src/native_contract/token/metadata.rs
+++ b/soroban-env-host/src/native_contract/token/metadata.rs
@@ -19,7 +19,7 @@ pub fn write_decimal(e: &Host, d: u8) -> Result<(), Error> {
 pub fn read_name(e: &Host) -> Result<Bytes, Error> {
     let key = DataKey::Name;
     let rv = e.get_contract_data(key.try_into_val(e)?)?;
-    Ok(rv.in_env(e).try_into()?)
+    Ok(rv.try_into_val(e)?)
 }
 
 pub fn write_name(e: &Host, d: Bytes) -> Result<(), Error> {
@@ -31,7 +31,7 @@ pub fn write_name(e: &Host, d: Bytes) -> Result<(), Error> {
 pub fn read_symbol(e: &Host) -> Result<Bytes, Error> {
     let key = DataKey::Symbol;
     let rv = e.get_contract_data(key.try_into_val(e)?)?;
-    Ok(rv.in_env(e).try_into()?)
+    Ok(rv.try_into_val(e)?)
 }
 
 pub fn write_symbol(e: &Host, d: Bytes) -> Result<(), Error> {

--- a/soroban-env-host/src/native_contract/token/nonce.rs
+++ b/soroban-env-host/src/native_contract/token/nonce.rs
@@ -8,7 +8,7 @@ use soroban_env_common::{CheckedEnv, TryIntoVal};
 pub fn read_nonce(e: &Host, id: Identifier) -> Result<BigInt, Error> {
     let key = DataKey::Nonce(id);
     if let Ok(nonce) = e.get_contract_data(key.try_into_val(e)?) {
-        Ok(nonce.in_env(e).try_into()?)
+        Ok(nonce.try_into_val(e)?)
     } else {
         Ok(BigInt::from_u64(e, 0)?)
     }

--- a/soroban-env-host/src/native_contract/token/public_types.rs
+++ b/soroban-env-host/src/native_contract/token/public_types.rs
@@ -41,7 +41,7 @@ impl KeyedAuthorization {
     pub fn get_identifier(&self, env: &Host) -> Result<Identifier, Error> {
         Ok(match self {
             KeyedAuthorization::Contract => {
-                Identifier::Contract(env.get_invoking_contract()?.in_env(env).try_into()?)
+                Identifier::Contract(env.get_invoking_contract()?.to_raw().try_into_val(env)?)
             }
             KeyedAuthorization::Ed25519(kea) => Identifier::Ed25519(kea.public_key.clone()),
             KeyedAuthorization::Account(kaa) => Identifier::Account(kaa.public_key.clone()),

--- a/soroban-env-host/src/test/basic.rs
+++ b/soroban-env-host/src/test/basic.rs
@@ -15,7 +15,7 @@ fn u64_roundtrip() -> Result<(), HostError> {
     let obj: Object = v.try_into()?;
     assert!(obj.is_obj_type(ScObjectType::U64));
     assert_eq!(obj.get_handle(), 0);
-    let j = u64::try_from(v.in_env(&host))?;
+    let j = u64::try_from_val(&host, v)?;
     assert_eq!(u, j);
 
     let u2: u64 = u64::MAX; // This will be treated as a ScVal::Object::U64
@@ -23,7 +23,7 @@ fn u64_roundtrip() -> Result<(), HostError> {
     let obj: Object = v2.try_into()?;
     assert!(obj.is_obj_type(ScObjectType::U64));
     assert_eq!(obj.get_handle(), 1);
-    let k = u64::try_from(v2.in_env(&host))?;
+    let k = u64::try_from_val(&host, v2)?;
     assert_eq!(u2, k);
     Ok(())
 }
@@ -33,7 +33,7 @@ fn i64_roundtrip() -> Result<(), HostError> {
     let host = Host::default();
     let i: i64 = 12345_i64; // Will be treated as ScVal::I64
     let v: RawVal = i.into_val(&host);
-    let j = i64::try_from(v.in_env(&host))?;
+    let j = i64::try_from_val(&host, v)?;
     assert_eq!(i, j);
 
     let i2: i64 = -13234_i64; // WIll be treated as ScVal::Object::I64
@@ -41,7 +41,7 @@ fn i64_roundtrip() -> Result<(), HostError> {
     let obj: Object = v2.try_into()?;
     assert!(obj.is_obj_type(ScObjectType::I64));
     assert_eq!(obj.get_handle(), 0);
-    let k = i64::try_from(v2.in_env(&host))?;
+    let k = i64::try_from_val(&host, v2)?;
     assert_eq!(i2, k);
     Ok(())
 }

--- a/soroban-native-sdk-macros/src/derive_fn.rs
+++ b/soroban-native-sdk-macros/src/derive_fn.rs
@@ -31,7 +31,7 @@ pub fn derive_contract_function_set<'a>(
             let func_call = quote! {
                 #discriminant_ident => {
                     if args.len() == #num_args {
-                        #(let #args: #arg_types = args.get(#arg_indices).cloned().ok_or(soroban_env_common::ConversionError)?.in_env(host).try_into()?;)*
+                        #(let #args: #arg_types = args.get(#arg_indices).cloned().ok_or(soroban_env_common::ConversionError)?.try_into_val(host)?;)*
                         Ok(Self::#ident(host, #(#args,)*)?.try_into_val(host)?)
                     } else {
                         Err(host.err_general("wrong number of args"))


### PR DESCRIPTION
### What

Replace TryFrom<EnvVal<>> with TryFromVal<>, and disconnect the link between TryFrom and TryFromVal.

### Why

Disconnecting TryFrom and TryFromVal is necessary because we otherwise can't provide an implementation for all Option<T> for conversion in. This is because the core lib has an impl of T to Option<T> for all T.

TryFromVal is more of a serialization interface than it is a type conversion interface, even though we present it as the latter. Given that our interface has unique and specific behavior for all types, even builtin types like Option<T>, I think we need to have it standalone and not utilize the builtin From/TryFrom traits.

There is an alternative, we could manually or with macros implement every Option<T> interface we need, but it feels like philosophically we shouldn't be saying TryFromVal should always be bound to TryFrom. And after making this change I gotta say it simplifies things to take away some of these blanket implementations which is really all this change is doing.

### Known limitations

[TODO or N/A]
