### PR TITLE
Flesh out support for ContractCode, Hash and PublicKey.

### DIFF
--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -478,8 +478,9 @@ impl Host {
                             Ok(ScObject::Bytes(self.map_err(b.clone().try_into())?))
                         }
                         HostObject::BigInt(bi) => self.scobj_from_bigint(bi),
-                        HostObject::Hash(_) => todo!(),
-                        HostObject::PublicKey(_) => todo!(),
+                        HostObject::Hash(h) => Ok(ScObject::Hash(h.clone())),
+                        HostObject::PublicKey(pk) => Ok(ScObject::PublicKey(pk.clone())),
+                        HostObject::ContractCode(cc) => Ok(ScObject::ContractCode(cc.clone())),
                     },
                 }
             })
@@ -516,9 +517,9 @@ impl Host {
                 };
                 self.add_host_object(bi)
             }
-            ScObject::Hash(_) => todo!(),
-            ScObject::PublicKey(_) => todo!(),
-            ScObject::ContractCode(_) => todo!(),
+            ScObject::Hash(h) => self.add_host_object(h.clone()),
+            ScObject::PublicKey(pk) => self.add_host_object(pk.clone()),
+            ScObject::ContractCode(cc) => self.add_host_object(cc.clone()),
         }
     }
 
@@ -541,6 +542,7 @@ impl Host {
             HostObject::BigInt(_) => {}
             HostObject::Hash(_) => {}
             HostObject::PublicKey(_) => {}
+            HostObject::ContractCode(_) => {}
         }
         Ok(ho)
     }

--- a/soroban-env-host/src/host/conversion.rs
+++ b/soroban-env-host/src/host/conversion.rs
@@ -186,11 +186,9 @@ impl Host {
                                 None => Err(self.err_status(ScHostObjErrorCode::UnknownReference)),
                                 Some(ho) => match ho {
                                     // TODO: use more event-specific error codes than `UnexpectedType`
-                                    HostObject::Vec(_) => {
-                                        Err(self.err_status(ScHostObjErrorCode::UnexpectedType))
-                                    }
-                                    // TODO: use more event-specific error codes than `UnexpectedType`
-                                    HostObject::Map(_) => {
+                                    HostObject::Vec(_)
+                                    | HostObject::Map(_)
+                                    | HostObject::ContractCode(_) => {
                                         Err(self.err_status(ScHostObjErrorCode::UnexpectedType))
                                     }
                                     HostObject::Bin(b) => {
@@ -206,8 +204,10 @@ impl Host {
                                     HostObject::U64(u) => Ok(ScObject::U64(*u)),
                                     HostObject::I64(i) => Ok(ScObject::I64(*i)),
                                     HostObject::BigInt(bi) => self.scobj_from_bigint(bi),
-                                    HostObject::Hash(_) => todo!(),
-                                    HostObject::PublicKey(_) => todo!(),
+                                    HostObject::Hash(h) => Ok(ScObject::Hash(h.clone())),
+                                    HostObject::PublicKey(pk) => {
+                                        Ok(ScObject::PublicKey(pk.clone()))
+                                    }
                                 },
                             }?;
                             Ok(ScVal::Object(Some(sco)))

--- a/soroban-env-host/src/host_object.rs
+++ b/soroban-env-host/src/host_object.rs
@@ -1,4 +1,8 @@
-use super::{weak_host::WeakHost, xdr::ScObjectType, EnvVal, Object, RawVal};
+use super::{
+    weak_host::WeakHost,
+    xdr::{self, ScObjectType},
+    EnvVal, Object, RawVal,
+};
 
 use im_rc::{OrdMap, Vector};
 use num_bigint::BigInt;
@@ -9,12 +13,6 @@ pub(crate) type HostMap = OrdMap<HostVal, HostVal>;
 pub(crate) type HostVec = Vector<HostVal>;
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) struct Sha256Hash([u8; 32]);
-
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) struct Ed25519PK([u8; 32]);
-
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum HostObject {
     Vec(HostVec),
     Map(HostMap),
@@ -22,8 +20,9 @@ pub(crate) enum HostObject {
     I64(i64),
     Bin(Vec<u8>),
     BigInt(BigInt),
-    Hash(Sha256Hash),
-    PublicKey(Ed25519PK),
+    Hash(xdr::ScHash),
+    PublicKey(xdr::PublicKey),
+    ContractCode(xdr::ScContractCode),
 }
 
 pub(crate) trait HostObjectType: Sized {
@@ -60,5 +59,6 @@ declare_host_object_type!(u64, U64, U64);
 declare_host_object_type!(i64, I64, I64);
 declare_host_object_type!(Vec<u8>, Bytes, Bin);
 declare_host_object_type!(BigInt, BigInt, BigInt);
-declare_host_object_type!(Sha256Hash, Hash, Hash);
-declare_host_object_type!(Ed25519PK, PublicKey, PublicKey);
+declare_host_object_type!(xdr::ScHash, Hash, Hash);
+declare_host_object_type!(xdr::PublicKey, PublicKey, PublicKey);
+declare_host_object_type!(xdr::ScContractCode, ContractCode, ContractCode);


### PR DESCRIPTION
While we're still discussing what to do with Hash, PublicKey and ContractCode, we've actually started _using_ them in some code paths -- the recent native contract stuff in particular -- and therefore we need to be able to interconvert for basic tests to continue to function (eg. the contract_data unit test in core, which forms a ContractCode LE).