### PR TITLE
Add base64 feature to xdr import

### DIFF
--- a/soroban-env-common/Cargo.toml
+++ b/soroban-env-common/Cargo.toml
@@ -12,12 +12,12 @@ rust-version = "1.63"
 
 [dependencies]
 soroban-env-macros = { version = "0.0.3" }
-stellar-xdr = { version = "0.0.1", default-features = false, features = [ "next", "base64" ] }
+stellar-xdr = { version = "0.0.1", default-features = false, features = [ "next" ] }
 wasmi = { package = "soroban-wasmi", version = "0.11.0", optional = true }
 static_assertions = "1.1.0"
 
 [features]
-std = ["stellar-xdr/std"]
+std = ["stellar-xdr/std", "stellar-xdr/base64"]
 serde = ["stellar-xdr/serde"]
 vm = ["wasmi"]
 

--- a/soroban-env-common/Cargo.toml
+++ b/soroban-env-common/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.63"
 
 [dependencies]
 soroban-env-macros = { version = "0.0.3" }
-stellar-xdr = { version = "0.0.1", default-features = false, features = [ "next" ] }
+stellar-xdr = { version = "0.0.1", default-features = false, features = [ "next", "base64" ] }
 wasmi = { package = "soroban-wasmi", version = "0.11.0", optional = true }
 static_assertions = "1.1.0"
 


### PR DESCRIPTION
### What

Add `base64` feature to xdr import.

### Why

So we can save a few characters when encoding/decoding to base64.
