### PR TITLE
Add conversions from ref types to RawVal

### DIFF
--- a/soroban-env-common/src/raw_val.rs
+++ b/soroban-env-common/src/raw_val.rs
@@ -202,6 +202,11 @@ macro_rules! declare_tryfrom {
                 self.into()
             }
         }
+        impl<E: Env> IntoVal<E, RawVal> for &$T {
+            fn into_val(self, _env: &E) -> RawVal {
+                (*self).into()
+            }
+        }
         impl<E: Env> TryFromVal<E, RawVal> for $T {
             type Error = ConversionError;
             #[inline(always)]

--- a/soroban-env-common/src/tuple.rs
+++ b/soroban-env-common/src/tuple.rs
@@ -44,6 +44,18 @@ macro_rules! impl_for_tuple {
             }
         }
 
+        impl<E: Env, $($typ),*> IntoVal<E, RawVal> for &($($typ,)*)
+        where
+            $(for<'a> &'a $typ: IntoVal<E, RawVal>),*
+        {
+            fn into_val(self, env: &E) -> RawVal {
+                let env = env.clone();
+                let vec = env.vec_new($count.into());
+                $(let vec = env.vec_push(vec, (&self.$idx).into_val(&env));)*
+                vec.to_raw()
+            }
+        }
+
         impl<E: Env, $($typ),*> IntoVal<E, EnvVal<E, RawVal>> for ($($typ,)*)
         where
             $($typ: IntoVal<E, RawVal>),*


### PR DESCRIPTION
### What
Add conversions from ref types to RawVal.

### Why
So that we can convert from values like &T to a RawVal and not just from T to RawVal. Conversions to RawVal never need to own the type being converted from, so their ref conversions should always be supportable.

Clos_e https://github.com/stellar/rs-soroban-sdk/issues/507