### PR TITLE
Add FromVal

### DIFF
--- a/soroban-env-common/src/env_val.rs
+++ b/soroban-env-common/src/env_val.rs
@@ -95,6 +95,10 @@ pub trait TryIntoVal<E: Env, V>: Sized {
     }
 }
 
+pub trait FromVal<E: Env, V>: Sized {
+    fn from_val(env: &E, v: V) -> Self;
+}
+
 pub trait TryFromVal<E: Env, V>: Sized {
     type Error;
     fn try_from_val(env: &E, v: V) -> Result<Self, Self::Error>;

--- a/soroban-env-common/src/lib.rs
+++ b/soroban-env-common/src/lib.rs
@@ -48,7 +48,7 @@ pub use val::Val;
 pub use checked_env::CheckedEnv;
 pub use convert::TryConvert;
 pub use env::{Env, EnvBase};
-pub use env_val::{EnvVal, IntoVal, TryFromVal, TryIntoVal};
+pub use env_val::{EnvVal, FromVal, IntoVal, TryFromVal, TryIntoVal};
 pub use unimplemented_env::UnimplementedEnv;
 
 // BitSet, Status and Symbol wrap RawVals.

--- a/soroban-env-common/src/raw_val.rs
+++ b/soroban-env-common/src/raw_val.rs
@@ -1,6 +1,8 @@
 use stellar_xdr::{ScStatic, ScStatus, ScStatusType};
 
-use super::{BitSet, Env, EnvVal, IntoVal, Object, Static, Status, Symbol, TryFromVal, TryIntoVal};
+use super::{
+    BitSet, Env, EnvVal, FromVal, IntoVal, Object, Static, Status, Symbol, TryFromVal, TryIntoVal,
+};
 use core::{convert::Infallible, fmt::Debug};
 
 extern crate static_assertions as sa;
@@ -103,6 +105,12 @@ impl AsRef<RawVal> for RawVal {
 impl AsMut<RawVal> for RawVal {
     fn as_mut(&mut self) -> &mut RawVal {
         self
+    }
+}
+
+impl<E: Env> FromVal<E, RawVal> for RawVal {
+    fn from_val(_env: &E, val: RawVal) -> Self {
+        val
     }
 }
 


### PR DESCRIPTION
### What
Add FromVal.

### Why
There are some conversions in the SDK that won't fail but need an Env. We have previously just implemented them with infallible TryFromVal, which forces unnecessary error checking.