### PR TITLE
Update test-wasms dependencies

### DIFF
--- a/soroban-test-wasms/wasm-workspace/Cargo.lock
+++ b/soroban-test-wasms/wasm-workspace/Cargo.lock
@@ -78,6 +78,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "bytes-lit"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75651e281e98fa84907ea7704dde00b1970f611d803caeb0ee5619d4a1afc3cb"
+dependencies = [
+ "num-bigint",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +355,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+
+[[package]]
 name = "libc"
 version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,10 +552,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
+name = "ryu"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+
+[[package]]
 name = "serde"
 version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.143"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "sha2"
@@ -643,8 +692,9 @@ dependencies = [
 [[package]]
 name = "soroban-sdk"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=44f6711a#44f6711ad9349abda8850a7c93942107946a9229"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=0cf5257#0cf5257b75bf5487804dbda445c7afc52f193ee3"
 dependencies = [
+ "bytes-lit",
  "ed25519-dalek",
  "soroban-env-guest",
  "soroban-env-host",
@@ -654,7 +704,7 @@ dependencies = [
 [[package]]
 name = "soroban-sdk-macros"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=44f6711a#44f6711ad9349abda8850a7c93942107946a9229"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=0cf5257#0cf5257b75bf5487804dbda445c7afc52f193ee3"
 dependencies = [
  "darling",
  "itertools",
@@ -670,14 +720,18 @@ dependencies = [
 [[package]]
 name = "soroban-spec"
 version = "0.0.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=44f6711a#44f6711ad9349abda8850a7c93942107946a9229"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=0cf5257#0cf5257b75bf5487804dbda445c7afc52f193ee3"
 dependencies = [
  "base64",
  "darling",
  "itertools",
  "proc-macro2",
  "quote",
+ "serde",
+ "serde_derive",
+ "serde_json",
  "sha2 0.10.2",
+ "soroban-env-host",
  "stellar-xdr",
  "syn",
  "thiserror",
@@ -724,9 +778,10 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "stellar-xdr"
 version = "0.0.1"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=f4fe3091#f4fe309136070c3d932bfcb8019ded953b842e5c"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=8c8d334#8c8d334d284424c9ca722b496d7cb9b0660419d3"
 dependencies = [
  "base64",
+ "serde",
 ]
 
 [[package]]

--- a/soroban-test-wasms/wasm-workspace/Cargo.toml
+++ b/soroban-test-wasms/wasm-workspace/Cargo.toml
@@ -34,7 +34,7 @@ soroban-native-sdk-macros = { path = "../../soroban-native-sdk-macros" }
 
 # You should update this rev to the XDR rev used by the outer workspace
 # anytime you're going to recompile this workspace.
-stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "f4fe3091" }
+stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "8c8d334" }
 
 # You should actually be able to set this to be any existing version of wasmi because we are
 # not building the SDK in host mode, so the "vm" feature is off.
@@ -93,8 +93,8 @@ wasmi = { package = "soroban-wasmi", git = "https://github.com/stellar/wasmi", r
 # when you change the Env trait itself, and whatever change you make to Env may
 # well cause recompilation to fail. Again, you will know if it doesn't compile!
 
-soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "44f6711a" }
-soroban-sdk-macros = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "44f6711a" }
+soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "0cf5257" }
+soroban-sdk-macros = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "0cf5257" }
 
 [profile.release]
 opt-level = "z"


### PR DESCRIPTION
### What

Update "soroban-test-wasms" dependencies so that the wasm files would build (without local checkouts). 
This is the last step in the cycle of the compatibility-breaking `env` update process. 

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
