### PR TITLE
Make token auth match soroban-sdk-auth

### DIFF
--- a/soroban-env-host/src/native_contract/token/admin.rs
+++ b/soroban-env-host/src/native_contract/token/admin.rs
@@ -1,12 +1,10 @@
 use crate::host::Host;
 use crate::native_contract::base_types::BytesN;
 use crate::native_contract::token::error::Error;
-use crate::native_contract::token::public_types::{
-    Authorization, Identifier, KeyedAccountAuthorization, KeyedAuthorization, KeyedEd25519Signature,
-};
+use crate::native_contract::token::public_types::{Identifier, Signature};
 use crate::native_contract::token::storage_types::DataKey;
-use core::cmp::Ordering;
 use soroban_env_common::{CheckedEnv, TryFromVal, TryIntoVal};
+use std::cmp::Ordering;
 
 pub fn has_administrator(e: &Host) -> Result<bool, Error> {
     let key = DataKey::Admin;
@@ -20,38 +18,37 @@ fn read_administrator(e: &Host) -> Result<Identifier, Error> {
     Ok(Identifier::try_from_val(e, rv)?)
 }
 
-pub fn to_administrator_authorization(
-    e: &Host,
-    auth: Authorization,
-) -> Result<KeyedAuthorization, Error> {
-    let admin = read_administrator(e)?;
-    match (admin, auth) {
-        (Identifier::Contract(admin_id), Authorization::Contract) => {
-            let invoker_id: BytesN<32> = e.get_invoking_contract()?.to_raw().try_into_val(e)?;
-            if admin_id.compare(&invoker_id)? != Ordering::Equal {
-                Err(Error::ContractError)
-            } else {
-                Ok(KeyedAuthorization::Contract)
-            }
-        }
-        (Identifier::Ed25519(admin_id), Authorization::Ed25519(signature)) => {
-            Ok(KeyedAuthorization::Ed25519(KeyedEd25519Signature {
-                public_key: admin_id,
-                signature,
-            }))
-        }
-        (Identifier::Account(admin_id), Authorization::Account(signatures)) => {
-            Ok(KeyedAuthorization::Account(KeyedAccountAuthorization {
-                public_key: admin_id,
-                signatures,
-            }))
-        }
-        _ => Err(Error::ContractError),
-    }
-}
-
 pub fn write_administrator(e: &Host, id: Identifier) -> Result<(), Error> {
     let key = DataKey::Admin;
     e.put_contract_data(key.try_into_val(e)?, id.try_into_val(e)?)?;
     Ok(())
+}
+
+pub fn check_admin(e: &Host, auth: &Signature) -> Result<(), Error> {
+    let admin = read_administrator(e)?;
+    match (admin, auth) {
+        (Identifier::Contract(admin_id), Signature::Contract) => {
+            let invoker_id: BytesN<32> = e.get_invoking_contract()?.to_raw().try_into_val(e)?;
+            if admin_id.compare(&invoker_id)? != Ordering::Equal {
+                Err(Error::ContractError)
+            } else {
+                Ok(())
+            }
+        }
+        (Identifier::Ed25519(admin_id), Signature::Ed25519(signature)) => {
+            if admin_id.compare(&signature.public_key)? != Ordering::Equal {
+                Err(Error::ContractError)
+            } else {
+                Ok(())
+            }
+        }
+        (Identifier::Account(admin_id), Signature::Account(signatures)) => {
+            if admin_id.compare(&signatures.account_id)? != Ordering::Equal {
+                Err(Error::ContractError)
+            } else {
+                Ok(())
+            }
+        }
+        _ => Err(Error::ContractError),
+    }
 }

--- a/soroban-env-host/src/native_contract/token/contract.rs
+++ b/soroban-env-host/src/native_contract/token/contract.rs
@@ -1,20 +1,18 @@
 use crate::host::Host;
 use crate::native_contract::base_types::{BigInt, Bytes, Vec};
-use crate::native_contract::token::admin::{
-    has_administrator, to_administrator_authorization, write_administrator,
-};
+use crate::native_contract::token::admin::{check_admin, has_administrator, write_administrator};
 use crate::native_contract::token::allowance::{read_allowance, spend_allowance, write_allowance};
 use crate::native_contract::token::balance::{
     read_balance, read_state, receive_balance, spend_balance, write_state,
 };
-use crate::native_contract::token::cryptography::{check_auth, Domain};
+use crate::native_contract::token::cryptography::check_auth;
 use crate::native_contract::token::error::Error;
 use crate::native_contract::token::metadata::{
     read_decimal, read_name, read_symbol, write_decimal, write_name, write_symbol,
 };
 use crate::native_contract::token::nonce::read_nonce;
-use crate::native_contract::token::public_types::{Authorization, Identifier, KeyedAuthorization};
-use soroban_env_common::TryIntoVal;
+use crate::native_contract::token::public_types::{Identifier, Signature};
+use soroban_env_common::{Symbol, TryIntoVal};
 use soroban_native_sdk_macros::contractimpl;
 
 pub trait TokenTrait {
@@ -32,7 +30,8 @@ pub trait TokenTrait {
 
     fn approve(
         e: &Host,
-        from: KeyedAuthorization,
+        from: Signature,
+        nonce: BigInt,
         spender: Identifier,
         amount: BigInt,
     ) -> Result<(), Error>;
@@ -43,28 +42,47 @@ pub trait TokenTrait {
 
     fn xfer(
         e: &Host,
-        from: KeyedAuthorization,
+        from: Signature,
+        nonce: BigInt,
         to: Identifier,
         amount: BigInt,
     ) -> Result<(), Error>;
 
     fn xfer_from(
         e: &Host,
-        spender: KeyedAuthorization,
+        spender: Signature,
+        nonce: BigInt,
         from: Identifier,
         to: Identifier,
         amount: BigInt,
     ) -> Result<(), Error>;
 
-    fn burn(e: &Host, admin: Authorization, from: Identifier, amount: BigInt) -> Result<(), Error>;
+    fn burn(
+        e: &Host,
+        admin: Signature,
+        nonce: BigInt,
+        from: Identifier,
+        amount: BigInt,
+    ) -> Result<(), Error>;
 
-    fn freeze(e: &Host, admin: Authorization, id: Identifier) -> Result<(), Error>;
+    fn freeze(e: &Host, admin: Signature, nonce: BigInt, id: Identifier) -> Result<(), Error>;
 
-    fn mint(e: &Host, admin: Authorization, to: Identifier, amount: BigInt) -> Result<(), Error>;
+    fn mint(
+        e: &Host,
+        admin: Signature,
+        nonce: BigInt,
+        to: Identifier,
+        amount: BigInt,
+    ) -> Result<(), Error>;
 
-    fn set_admin(e: &Host, admin: Authorization, new_admin: Identifier) -> Result<(), Error>;
+    fn set_admin(
+        e: &Host,
+        admin: Signature,
+        nonce: BigInt,
+        new_admin: Identifier,
+    ) -> Result<(), Error>;
 
-    fn unfreeze(e: &Host, admin: Authorization, id: Identifier) -> Result<(), Error>;
+    fn unfreeze(e: &Host, admin: Signature, nonce: BigInt, id: Identifier) -> Result<(), Error>;
 
     fn decimals(e: &Host) -> Result<u32, Error>;
 
@@ -105,15 +123,18 @@ impl TokenTrait for Token {
 
     fn approve(
         e: &Host,
-        from: KeyedAuthorization,
+        from: Signature,
+        nonce: BigInt,
         spender: Identifier,
         amount: BigInt,
     ) -> Result<(), Error> {
         let from_id = from.get_identifier(&e)?;
         let mut args = Vec::new(e)?;
+        args.push(from.get_identifier(&e)?)?;
+        args.push(nonce.clone())?;
         args.push(spender.clone())?;
         args.push(amount.clone())?;
-        check_auth(&e, from, Domain::Approve, args)?;
+        check_auth(&e, from, nonce, Symbol::from_str("approve"), args)?;
         write_allowance(&e, from_id, spender, amount)?;
         Ok(())
     }
@@ -128,15 +149,18 @@ impl TokenTrait for Token {
 
     fn xfer(
         e: &Host,
-        from: KeyedAuthorization,
+        from: Signature,
+        nonce: BigInt,
         to: Identifier,
         amount: BigInt,
     ) -> Result<(), Error> {
         let from_id = from.get_identifier(&e)?;
         let mut args = Vec::new(e)?;
+        args.push(from.get_identifier(&e)?)?;
+        args.push(nonce.clone())?;
         args.push(to.clone())?;
         args.push(amount.clone())?;
-        check_auth(&e, from, Domain::Transfer, args)?;
+        check_auth(&e, from, nonce, Symbol::from_str("xfer"), args)?;
         spend_balance(&e, from_id, amount.clone())?;
         receive_balance(&e, to, amount)?;
         Ok(())
@@ -144,66 +168,96 @@ impl TokenTrait for Token {
 
     fn xfer_from(
         e: &Host,
-        spender: KeyedAuthorization,
+        spender: Signature,
+        nonce: BigInt,
         from: Identifier,
         to: Identifier,
         amount: BigInt,
     ) -> Result<(), Error> {
         let spender_id = spender.get_identifier(&e)?;
         let mut args = Vec::new(e)?;
+        args.push(spender.get_identifier(&e)?)?;
+        args.push(nonce.clone())?;
         args.push(from.clone())?;
         args.push(to.clone())?;
         args.push(amount.clone())?;
-        check_auth(&e, spender, Domain::TransferFrom, args)?;
+        check_auth(&e, spender, nonce, Symbol::from_str("xfer_from"), args)?;
         spend_allowance(&e, from.clone(), spender_id, amount.clone())?;
         spend_balance(&e, from, amount.clone())?;
         receive_balance(&e, to, amount)?;
         Ok(())
     }
 
-    fn burn(e: &Host, admin: Authorization, from: Identifier, amount: BigInt) -> Result<(), Error> {
-        let auth = to_administrator_authorization(&e, admin)?;
+    fn burn(
+        e: &Host,
+        admin: Signature,
+        nonce: BigInt,
+        from: Identifier,
+        amount: BigInt,
+    ) -> Result<(), Error> {
+        check_admin(&e, &admin)?;
         let mut args = Vec::new(e)?;
+        args.push(admin.get_identifier(&e)?)?;
+        args.push(nonce.clone())?;
         args.push(from.clone())?;
         args.push(amount.clone())?;
-        check_auth(&e, auth, Domain::Burn, args)?;
+        check_auth(&e, admin, nonce, Symbol::from_str("burn"), args)?;
         spend_balance(&e, from, amount)?;
         Ok(())
     }
 
-    fn freeze(e: &Host, admin: Authorization, id: Identifier) -> Result<(), Error> {
-        let auth = to_administrator_authorization(&e, admin)?;
+    fn freeze(e: &Host, admin: Signature, nonce: BigInt, id: Identifier) -> Result<(), Error> {
+        check_admin(&e, &admin)?;
         let mut args = Vec::new(e)?;
+        args.push(admin.get_identifier(&e)?)?;
+        args.push(nonce.clone())?;
         args.push(id.clone())?;
-        check_auth(&e, auth, Domain::Freeze, args)?;
+        check_auth(&e, admin, nonce, Symbol::from_str("freeze"), args)?;
         write_state(&e, id, true)?;
         Ok(())
     }
 
-    fn mint(e: &Host, admin: Authorization, to: Identifier, amount: BigInt) -> Result<(), Error> {
-        let auth = to_administrator_authorization(&e, admin)?;
+    fn mint(
+        e: &Host,
+        admin: Signature,
+        nonce: BigInt,
+        to: Identifier,
+        amount: BigInt,
+    ) -> Result<(), Error> {
+        check_admin(&e, &admin)?;
         let mut args = Vec::new(e)?;
+        args.push(admin.get_identifier(&e)?)?;
+        args.push(nonce.clone())?;
         args.push(to.clone())?;
         args.push(amount.clone())?;
-        check_auth(&e, auth, Domain::Mint, args)?;
+        check_auth(&e, admin, nonce, Symbol::from_str("mint"), args)?;
         receive_balance(&e, to, amount)?;
         Ok(())
     }
 
-    fn set_admin(e: &Host, admin: Authorization, new_admin: Identifier) -> Result<(), Error> {
-        let auth = to_administrator_authorization(&e, admin)?;
+    fn set_admin(
+        e: &Host,
+        admin: Signature,
+        nonce: BigInt,
+        new_admin: Identifier,
+    ) -> Result<(), Error> {
+        check_admin(&e, &admin)?;
         let mut args = Vec::new(e)?;
+        args.push(admin.get_identifier(&e)?)?;
+        args.push(nonce.clone())?;
         args.push(new_admin.clone())?;
-        check_auth(&e, auth, Domain::SetAdministrator, args)?;
+        check_auth(&e, admin, nonce, Symbol::from_str("set_admin"), args)?;
         write_administrator(&e, new_admin)?;
         Ok(())
     }
 
-    fn unfreeze(e: &Host, admin: Authorization, id: Identifier) -> Result<(), Error> {
-        let auth = to_administrator_authorization(&e, admin)?;
+    fn unfreeze(e: &Host, admin: Signature, nonce: BigInt, id: Identifier) -> Result<(), Error> {
+        check_admin(&e, &admin)?;
         let mut args = Vec::new(e)?;
+        args.push(admin.get_identifier(&e)?)?;
+        args.push(nonce.clone())?;
         args.push(id.clone())?;
-        check_auth(&e, auth, Domain::Unfreeze, args)?;
+        check_auth(&e, admin, nonce, Symbol::from_str("unfreeze"), args)?;
         write_state(&e, id, false)?;
         Ok(())
     }


### PR DESCRIPTION
### What

Make token auth match soroban-sdk-auth.

### Why

It was completely impossible to use the native token without this because the necessary types weren't exported anywhere.

### Known limitations

Lightly tested.