### PR TITLE
Set the target-dir for cargo installs

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -5,7 +5,6 @@ on:
     inputs:
       version:
         description: 'Version to bump to'
-        type: 'string'
         required: true
 
 jobs:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -75,7 +75,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: stellar/actions/rust-cache@main
     - run: rustup update
-    - run: cargo install --locked --version 0.2.35 cargo-workspaces
+    - run: cargo install --locked --version 0.2.35 cargo-workspaces --target-dir ~/.cargo/target
     - run: make publish
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
### What
Set the target-dir for cargo installs.

### Why
If target-dir isn't set for cargo installs the target dir will be a temporary directory and blown away, which breaks cashing of bin installs.