### PR TITLE
Fix map_keys and map_values

### DIFF
--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -1120,26 +1120,25 @@ impl CheckedEnv for Host {
     }
 
     fn map_keys(&self, m: Object) -> Result<Object, HostError> {
-        let keys = self.visit_obj(m, |hm: &HostMap| {
-            let cap = self.usize_to_u32(hm.len(), "host map too large")?;
-            Ok(hm.keys()?.cloned().collect::<Vec<_>>())
+        let vec = self.visit_obj(m, |hm: &HostMap| {
+            let mut vec = HostVec::new(self.0.budget.clone())?;
+            for k in hm.keys()?.cloned() {
+                vec.push_back(k)?;
+            }
+            Ok(vec)
         })?;
-        let mut vec = HostVec::new(self.0.budget.clone())?;
-        for k in keys {
-            vec.push_back(k)?;
-        }
         Ok(self.add_host_object(vec)?.into())
     }
 
     fn map_values(&self, m: Object) -> Result<Object, HostError> {
-        self.visit_obj(m, |hm: &HostMap| {
-            let cap = self.usize_to_u32(hm.len(), "host map too large")?;
-            let mut vec = self.vec_new(cap.into())?;
-            for k in hm.values()? {
-                vec = self.vec_push_back(vec, k.to_raw())?;
+        let vec = self.visit_obj(m, |hm: &HostMap| {
+            let mut vec = HostVec::new(self.0.budget.clone())?;
+            for k in hm.values()?.cloned() {
+                vec.push_back(k)?;
             }
             Ok(vec)
-        })
+        })?;
+        Ok(self.add_host_object(vec)?.into())
     }
 
     fn vec_new(&self, c: RawVal) -> Result<Object, HostError> {

--- a/soroban-env-host/src/test/map.rs
+++ b/soroban-env-host/src/test/map.rs
@@ -189,3 +189,35 @@ fn map_prev_and_next_heterogeneous() -> Result<(), HostError> {
 
     Ok(())
 }
+
+#[test]
+fn map_keys() -> Result<(), HostError> {
+    let host = Host::default();
+
+    let mut map = host.map_new()?;
+    map = host.map_put(map, 2u32.into(), 20u32.into())?;
+    map = host.map_put(map, 1u32.into(), 10u32.into())?;
+    let keys = host.map_keys(map)?;
+
+    let expected_keys = host.test_vec_obj::<u32>(&[1, 2])?.to_raw();
+
+    assert_eq!(host.obj_cmp(keys.to_raw(), expected_keys)?, 0);
+
+    Ok(())
+}
+
+#[test]
+fn map_values() -> Result<(), HostError> {
+    let host = Host::default();
+
+    let mut map = host.map_new()?;
+    map = host.map_put(map, 2u32.into(), 20u32.into())?;
+    map = host.map_put(map, 1u32.into(), 10u32.into())?;
+    let values = host.map_values(map)?;
+
+    let expected_values = host.test_vec_obj::<u32>(&[10, 20])?.to_raw();
+
+    assert_eq!(host.obj_cmp(values.to_raw(), expected_values)?, 0);
+
+    Ok(())
+}


### PR DESCRIPTION
### What
Associate the vec object that is created in map_keys and map_values outside of visiting the original map.

### Why
Adding an object to the host while visiting another object causes a BorrowMut error.

Close #405