### PR TITLE
Dry run publish release/ branches

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -67,7 +67,7 @@ jobs:
     - if: matrix.sys.test
       run: cargo hack --feature-powerset test --locked --target ${{ matrix.sys.target }}
     - if: startsWith(github.ref_name, 'release/v')
-      run: make publish
+      uses: stellar/actions/rust-workspace-publish-dry-run@workspacedryrunpublish
 
   publish:
     if: github.event_name == 'release'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,6 +68,8 @@ jobs:
       run: cargo hack --feature-powerset test --locked --target ${{ matrix.sys.target }}
     - if: startsWith(github.head_ref, 'release/')
       uses: stellar/actions/rust-workspace-publish-dry-run@dryrun
+      with:
+        cargo-package-options: --target ${{ matrix.sys.target }}
 
   publish:
     if: github.event_name == 'release'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,8 +66,8 @@ jobs:
     - run: cargo hack --feature-powerset check --locked --target ${{ matrix.sys.target }}
     - if: matrix.sys.test
       run: cargo hack --feature-powerset test --locked --target ${{ matrix.sys.target }}
-    - if: startsWith(github.ref_name, 'release/')
-      uses: stellar/actions/rust-workspace-publish-dry-run@main
+    - if: startsWith(github.head_ref, 'release/')
+      uses: stellar/actions/rust-workspace-publish-dry-run@dryrun
 
   publish:
     if: github.event_name == 'release'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,8 +66,8 @@ jobs:
     - run: cargo hack --feature-powerset check --locked --target ${{ matrix.sys.target }}
     - if: matrix.sys.test
       run: cargo hack --feature-powerset test --locked --target ${{ matrix.sys.target }}
-    - if: startsWith(github.ref_name, 'release/v')
-      uses: stellar/actions/rust-workspace-publish-dry-run@workspacedryrunpublish
+    - if: startsWith(github.ref_name, 'release/')
+      uses: stellar/actions/rust-workspace-publish-dry-run@main
 
   publish:
     if: github.event_name == 'release'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: Rust
 
 on:
   push:
-    branches: [main, "release/**"]
+    branches: [main]
   pull_request:
   release:
     types: [published]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,6 +66,8 @@ jobs:
     - run: cargo hack --feature-powerset check --locked --target ${{ matrix.sys.target }}
     - if: matrix.sys.test
       run: cargo hack --feature-powerset test --locked --target ${{ matrix.sys.target }}
+    - if: startsWith(github.ref_name, 'release/v')
+      run: make publish
 
   publish:
     if: github.event_name == 'release'

--- a/Makefile
+++ b/Makefile
@@ -20,12 +20,5 @@ clean:
 regenerate-test-wasms:
 	make -C soroban-test-wasms regenerate-test-wasms
 
-publish-verify:
-	sed -i.bak -r '/git ?=/d' Cargo.toml
-	cargo vendor --versioned-dirs
-	cargo hack --ignore-private package --no-verify
-	for crate in target/package/*.crate; do cargo vendor-add --crate "$crate" --vendor-path vendor; done
-	cargo hack --ignore-private --config "source.crates-io.replace-with = 'vendored-sources'" --config "source.vendored-sources.directory = 'vendor'" package
-
 publish:
 	cargo workspaces publish --all --force '*' --from-git --yes

--- a/Makefile
+++ b/Makefile
@@ -20,5 +20,12 @@ clean:
 regenerate-test-wasms:
 	make -C soroban-test-wasms regenerate-test-wasms
 
+publish-verify:
+	sed -i.bak -r '/git ?=/d' Cargo.toml
+	cargo vendor --versioned-dirs
+	cargo hack --ignore-private package --no-verify
+	for crate in target/package/*.crate; do cargo vendor-add --crate "$crate" --vendor-path vendor; done
+	cargo hack --ignore-private --config "source.crates-io.replace-with = 'vendored-sources'" --config "source.vendored-sources.directory = 'vendor'" package
+
 publish:
 	cargo workspaces publish --all --force '*' --from-git --yes


### PR DESCRIPTION
### What

Add a dry run publish step to branches that start with `release/`.

### Why

The bump version workflow creates a branch that starts with `release/`. (Ref: https://github.com/stellar/actions/blob/2eaba3e378ef8fd4e1af5e22cc17b72371c89c9a/.github/workflows/rust-bump-version.yml#L26)

We should prevent merging the release branch to main if the release would not publish successfully. That way we don't merge the bump version and then attempt the release, have it fail, and then have to undo tagging and redo it.

### Known limitations

[TODO or N/A]
