### PR TITLE
Fix branch of workplace publish dry run action

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -67,7 +67,7 @@ jobs:
     - if: matrix.sys.test
       run: cargo hack --feature-powerset test --locked --target ${{ matrix.sys.target }}
     - if: startsWith(github.head_ref, 'release/')
-      uses: stellar/actions/rust-workspace-publish-dry-run@dryrun
+      uses: stellar/actions/rust-workspace-publish-dry-run@main
       with:
         cargo-package-options: --target ${{ matrix.sys.target }}
 


### PR DESCRIPTION
### What
Change the branch of workplace publish dry run action to `main`.

### Why
I accidentally merged a PR that had the branch set to a temporary branch I was using for testing.