### PR TITLE
Merge serde feature with std feature

### DIFF
--- a/soroban-env-common/Cargo.toml
+++ b/soroban-env-common/Cargo.toml
@@ -17,8 +17,7 @@ wasmi = { package = "soroban-wasmi", version = "0.11.0", optional = true }
 static_assertions = "1.1.0"
 
 [features]
-std = ["stellar-xdr/std", "stellar-xdr/base64"]
-serde = ["stellar-xdr/serde"]
+std = ["stellar-xdr/std", "stellar-xdr/base64", "stellar-xdr/serde"]
 vm = ["wasmi"]
 
 [package.metadata.docs.rs]

--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -39,7 +39,6 @@ soroban-test-wasms = { package = "soroban-test-wasms", path = "../soroban-test-w
 
 [features]
 vm = ["wasmi", "parity-wasm", "soroban-env-common/vm"]
-serde = ["soroban-env-common/serde"]
 testutils = []
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]


### PR DESCRIPTION
### What
Merge serde feature with std feature.

### Why
Additional features slow down builds, so we should add them when there's value. The stellar-xdr/serde feature doesn't need to be it's own channel of features in the env crates, it can just be enabled whenever the common crate has its std feature enabled. Everywhere we use it, it is used when the common crate is used.