### PR TITLE
Migrate to wasmi_v1 API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,6 +277,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap-nostd"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
+
+[[package]]
 name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,34 +694,31 @@ version = "0.0.5"
 
 [[package]]
 name = "soroban-wasmi"
-version = "0.11.0"
-source = "git+https://github.com/stellar/wasmi?rev=7b1f2355#7b1f2355ba26d09daf0241f953eb16f7afe16057"
+version = "0.16.0"
+source = "git+https://github.com/stellar/wasmi?rev=a61b6df#a61b6dffa0a13aca70b046fc11e379a3fde31147"
 dependencies = [
- "parity-wasm",
- "soroban-wasmi-validation",
  "soroban-wasmi_core",
-]
-
-[[package]]
-name = "soroban-wasmi-validation"
-version = "0.4.1"
-source = "git+https://github.com/stellar/wasmi?rev=7b1f2355#7b1f2355ba26d09daf0241f953eb16f7afe16057"
-dependencies = [
- "parity-wasm",
+ "spin",
+ "wasmparser-nostd",
 ]
 
 [[package]]
 name = "soroban-wasmi_core"
-version = "0.1.0"
-source = "git+https://github.com/stellar/wasmi?rev=7b1f2355#7b1f2355ba26d09daf0241f953eb16f7afe16057"
+version = "0.2.0"
+source = "git+https://github.com/stellar/wasmi?rev=a61b6df#a61b6dffa0a13aca70b046fc11e379a3fde31147"
 dependencies = [
  "downcast-rs",
  "libm",
  "memory_units",
  "num-rational",
  "num-traits",
- "parity-wasm",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
 
 [[package]]
 name = "static_assertions"
@@ -874,6 +877,15 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasmparser-nostd"
+version = "0.90.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92a94fbf4c521b038f41382df2056cf47099d3b7a0faa5a6e46f7771fd7c84a6"
+dependencies = [
+ "indexmap-nostd",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ soroban-env-host = { path = "soroban-env-host" }
 soroban-env-macros = { path = "soroban-env-macros" }
 soroban-native-sdk-macros = { path = "soroban-native-sdk-macros" }
 stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "fee9a436" }
-wasmi = { package = "soroban-wasmi", git = "https://github.com/stellar/wasmi", rev = "7b1f2355" }
+wasmi = { package = "soroban-wasmi", git = "https://github.com/stellar/wasmi", rev = "a61b6df" }

--- a/soroban-env-common/Cargo.toml
+++ b/soroban-env-common/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.63"
 [dependencies]
 soroban-env-macros = { version = "0.0.5" }
 stellar-xdr = { version = "0.0.2", default-features = false, features = [ "next" ] }
-wasmi = { package = "soroban-wasmi", version = "0.11.0", optional = true }
+wasmi = { package = "soroban-wasmi", version = "0.16.0", optional = true }
 static_assertions = "1.1.0"
 
 [features]

--- a/soroban-env-common/src/lib.rs
+++ b/soroban-env-common/src/lib.rs
@@ -36,6 +36,7 @@ mod symbol;
 mod tuple;
 mod unimplemented_env;
 mod val;
+mod vmcaller_checked_env;
 
 // Re-export the XDR definitions
 pub use stellar_xdr as xdr;
@@ -50,6 +51,7 @@ pub use convert::TryConvert;
 pub use env::{Env, EnvBase};
 pub use env_val::{EnvVal, FromVal, IntoVal, TryFromVal, TryIntoVal};
 pub use unimplemented_env::UnimplementedEnv;
+pub use vmcaller_checked_env::{VmCaller, VmCallerCheckedEnv};
 
 // BitSet, Status and Symbol wrap RawVals.
 // TODO: maybe these should wrap EnvVals?

--- a/soroban-env-common/src/raw_val.rs
+++ b/soroban-env-common/src/raw_val.rs
@@ -248,17 +248,20 @@ declare_tryfrom!(Static);
 declare_tryfrom!(Object);
 
 #[cfg(feature = "vm")]
-impl wasmi::FromValue for RawVal {
-    fn from_value(val: wasmi::RuntimeValue) -> Option<Self> {
-        let maybe: Option<u64> = val.try_into();
-        maybe.map(RawVal::from_payload)
+impl wasmi::core::FromValue for RawVal {
+    fn from_value(val: wasmi::core::Value) -> Option<Self> {
+        if let wasmi::core::Value::I64(i) = val {
+            Some(RawVal::from_payload(i as u64))
+        } else {
+            None
+        }
     }
 }
 
 #[cfg(feature = "vm")]
-impl From<RawVal> for wasmi::RuntimeValue {
+impl From<RawVal> for wasmi::core::Value {
     fn from(v: RawVal) -> Self {
-        wasmi::RuntimeValue::I64(v.get_payload() as i64)
+        wasmi::core::Value::I64(v.get_payload() as i64)
     }
 }
 

--- a/soroban-env-common/src/val_wrapper.rs
+++ b/soroban-env-common/src/val_wrapper.rs
@@ -70,9 +70,9 @@ macro_rules! decl_tagged_val_wrapper_methods {
 
         // wasmi / VM argument support
         #[cfg(feature = "vm")]
-        impl wasmi::FromValue for $tagname {
-            fn from_value(val: wasmi::RuntimeValue) -> Option<Self> {
-                let maybe: Option<u64> = val.try_into();
+        impl wasmi::core::FromValue for $tagname {
+            fn from_value(val: wasmi::core::Value) -> Option<Self> {
+                let maybe: Option<u64> = <u64 as wasmi::core::FromValue>::from_value(val);
                 match maybe {
                     Some(u) => {
                         let raw = RawVal::from_payload(u);
@@ -89,9 +89,9 @@ macro_rules! decl_tagged_val_wrapper_methods {
             }
         }
         #[cfg(feature = "vm")]
-        impl From<$tagname> for wasmi::RuntimeValue {
+        impl From<$tagname> for wasmi::core::Value {
             fn from(v: $tagname) -> Self {
-                wasmi::RuntimeValue::I64(v.as_raw().get_payload() as i64)
+                wasmi::core::Value::I64(v.as_raw().get_payload() as i64)
             }
         }
 

--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.63"
 [dependencies]
 soroban-native-sdk-macros = { version = "0.0.5" }
 soroban-env-common = { version = "0.0.5", features = [ "std" ] }
-wasmi = { package = "soroban-wasmi", version = "0.11.0", optional = true }
+wasmi = { package = "soroban-wasmi", version = "0.16.0", optional = true }
 static_assertions = "1.1.0"
 im-rc = "15.0.0"
 num-bigint = "0.4"

--- a/soroban-env-host/src/test/budget_metering.rs
+++ b/soroban-env-host/src/test/budget_metering.rs
@@ -45,17 +45,17 @@ fn vm_hostfn_invocation() -> Result<(), HostError> {
         .enable_model(CostType::HostFunction);
 
     let obj = host.test_bin_obj(&dummy_id)?;
-    // `vec_err` is a test contract function which calls `vec_new` (1 param)
-    // and `vec_put` (3 params) so total 4 inputs to the budget from `CostType::HostFunction`.
+    // `vec_err` is a test contract function which calls `vec_new` (1 call)
+    // and `vec_put` (1 call) so total input of 2 to the budget from `CostType::HostFunction`.
     let sym = Symbol::from_str("vec_err");
     let args = host.test_vec_obj::<u32>(&[1])?;
 
     // try_call
     host.try_call(obj.to_object(), sym.into(), args.clone().into())?;
     host.get_budget(|budget| {
-        assert_eq!(budget.get_input(CostType::HostFunction), 4);
-        assert_eq!(budget.get_cpu_insns_count(), 40);
-        assert_eq!(budget.get_mem_bytes_count(), 4);
+        assert_eq!(budget.get_input(CostType::HostFunction), 2);
+        assert_eq!(budget.get_cpu_insns_count(), 20);
+        assert_eq!(budget.get_mem_bytes_count(), 2);
     });
 
     Ok(())

--- a/soroban-env-host/src/test/bytes.rs
+++ b/soroban-env-host/src/test/bytes.rs
@@ -166,7 +166,7 @@ fn bytes_xdr_roundtrip() -> Result<(), HostError> {
 
 #[cfg(feature = "vm")]
 #[test]
-fn invoke_memcpy() -> Result<(), HostError> {
+fn linear_memory_operations() -> Result<(), HostError> {
     use crate::xdr::ScContractCode;
     use crate::{budget::Budget, host::metered_map::MeteredOrdMap};
 

--- a/soroban-env-host/src/vm/dispatch.rs
+++ b/soroban-env-host/src/vm/dispatch.rs
@@ -1,75 +1,10 @@
-use crate::{budget::CostType, CheckedEnv, Host, Object, RawVal, Symbol};
+use crate::{budget::CostType, Host, Object, RawVal, Symbol, VmCaller, VmCallerCheckedEnv};
 use soroban_env_common::call_macro_with_all_host_functions;
-use wasmi::{RuntimeArgs, RuntimeValue};
+use wasmi::core::{FromValue, Trap, TrapCode::UnexpectedSignature, Value};
 
 ///////////////////////////////////////////////////////////////////////////////
 /// X-macro use: dispatch functions
 ///////////////////////////////////////////////////////////////////////////////
-
-// This is a helper macro used only by generate_dispatch_functions below. It
-// consumes a token-tree of the form:
-//
-//  {$host:expr, $vmargs:expr, fn $fn_id:ident $args:tt }
-//
-// in each of 6 valid forms (with 0, 1, ... 6 possible arguments) and produces a
-// function-call expression that extracts and converts the correct number of
-// arguments from the $vmargs argument (a wasmi::RuntimeArgs structure) and
-// forwards them to the corresponding $host.$fn_id function (a method on Host).
-macro_rules! dispatch_function_helper {
-
-    {$host:expr, $vmargs:expr, fn $fn_id:ident()} =>
-    {$host.$fn_id()};
-
-    {$host:expr, $vmargs:expr, fn $fn_id:ident($a0:ident:$t0:ty)} =>
-    {$host.$fn_id($vmargs.nth_checked::<$t0>(0)?)};
-
-    {$host:expr, $vmargs:expr, fn $fn_id:ident($a0:ident:$t0:ty,
-                                                 $a1:ident:$t1:ty)} =>
-    {$host.$fn_id($vmargs.nth_checked::<$t0>(0)?,
-                  $vmargs.nth_checked::<$t1>(1)?)};
-
-    {$host:expr, $vmargs:expr, fn $fn_id:ident($a0:ident:$t0:ty,
-                                                 $a1:ident:$t1:ty,
-                                                 $a2:ident:$t2:ty)} =>
-    {$host.$fn_id($vmargs.nth_checked::<$t0>(0)?,
-                  $vmargs.nth_checked::<$t1>(1)?,
-                  $vmargs.nth_checked::<$t2>(2)?)};
-
-
-    {$host:expr, $vmargs:expr, fn $fn_id:ident($a0:ident:$t0:ty,
-                                                 $a1:ident:$t1:ty,
-                                                 $a2:ident:$t2:ty,
-                                                 $a3:ident:$t3:ty)} =>
-    {$host.$fn_id($vmargs.nth_checked::<$t0>(0)?,
-                  $vmargs.nth_checked::<$t1>(1)?,
-                  $vmargs.nth_checked::<$t2>(2)?,
-                  $vmargs.nth_checked::<$t3>(3)?)};
-
-    {$host:expr, $vmargs:expr, fn $fn_id:ident($a0:ident:$t0:ty,
-                                                 $a1:ident:$t1:ty,
-                                                 $a2:ident:$t2:ty,
-                                                 $a3:ident:$t3:ty,
-                                                 $a4:ident:$t4:ty)} =>
-    {$host.$fn_id($vmargs.nth_checked::<$t0>(0)?,
-                  $vmargs.nth_checked::<$t1>(1)?,
-                  $vmargs.nth_checked::<$t2>(2)?,
-                  $vmargs.nth_checked::<$t3>(3)?,
-                  $vmargs.nth_checked::<$t4>(4)?)};
-
-
-    {$host:expr, $vmargs:expr, fn $fn_id:ident($a0:ident:$t0:ty,
-                                                 $a1:ident:$t1:ty,
-                                                 $a2:ident:$t2:ty,
-                                                 $a3:ident:$t3:ty,
-                                                 $a4:ident:$t4:ty,
-                                                 $a5:ident:$t5:ty)} =>
-    {$host.$fn_id($vmargs.nth_checked::<$t0>(0)?,
-                  $vmargs.nth_checked::<$t1>(1)?,
-                  $vmargs.nth_checked::<$t2>(2)?,
-                  $vmargs.nth_checked::<$t3>(3)?,
-                  $vmargs.nth_checked::<$t4>(4)?,
-                  $vmargs.nth_checked::<$t5>(5)?)};
-}
 
 // This is a callback macro that pattern-matches the token-tree passed by the
 // x-macro (call_macro_with_all_host_functions) and produces a suite of
@@ -91,7 +26,7 @@ macro_rules! generate_dispatch_functions {
                     // pattern-repetition matcher so that it will match all such
                     // descriptions.
                     $(#[$fn_attr:meta])*
-                    { $fn_str:literal, fn $fn_id:ident $args:tt -> $ret:ty }
+                    { $fn_str:literal, fn $fn_id:ident ($($arg:ident:$type:ty),*) -> $ret:ty }
                 )*
             }
         )*
@@ -105,28 +40,47 @@ macro_rules! generate_dispatch_functions {
         // to forward calls to the host.
         $(
             $(
-                // This defines a function containing a body that includes the
-                // expansion of a macro call to the dispatch_function_helper!
-                // macro above, called with some expressions from the enclosing
-                // function (host and vmargs) as well as the relevant parts of
-                // the token-tree function declaration matched by the inner
-                // pattern above. It is embedded in two nested `$()*`
-                // pattern-repetition expanders that correspond to the
-                // pattern-repetition matchers in the match section, but we
-                // ignore the structure of the 'mod' block repetition-level from
-                // the outer pattern in the expansion, flattening all functions
-                // from all 'mod' blocks into a set of functions.
+                // This defines a "dispatch function" that does several things:
+                //
+                //  1. charges the budget for the call, failing if over budget.
+                //  2. attempts to convert incoming wasmi i64 args to RawVals or
+                //     RawVal-wrappers expected by host functions, failing if
+                //     any conversions fail.
+                //  3. calls the host function
+                //  4. checks the result is Ok, or traps the VM on Err
+                //  5. converts the result back to an i64 for wasmi
+                //
+                // It is embedded in two nested `$()*` pattern-repetition
+                // expanders that correspond to the pattern-repetition matchers
+                // in the match section, but we ignore the structure of the
+                // 'mod' block repetition-level from the outer pattern in the
+                // expansion, flattening all functions from all 'mod' blocks
+                // into a set of functions.
                 $(#[$fn_attr])*
-                pub(crate) fn $fn_id(host: &mut Host, _vmargs: RuntimeArgs) ->
-                    Result<RuntimeValue, wasmi::Trap>
+                pub(crate) fn $fn_id(caller: wasmi::Caller<Host>, $($arg:i64),*) ->
+                    Result<(i64,), Trap>
                 {
                     // Notes on metering: a flat charge per host function invocation.
                     // This does not account for the actual work being done in those functions,
                     // which are accounted for individually at the operation level.
-                    // This is analogous to a flat toll charge for getting on the highway,
-                    // whereas the actual work are the tickets to the attractions.
-                    host.charge_budget(CostType::HostFunction, _vmargs.len() as u64)?;
-                    Ok(dispatch_function_helper!{host, _vmargs, fn $fn_id $args }?.into())
+                    let host = caller.host_data().clone();
+                    host.charge_budget(CostType::HostFunction, 1)?;
+                    let mut vmcaller = VmCaller(Some(caller));
+                    // The odd / seemingly-redundant use of `wasmi::Value` here
+                    // as intermediates -- rather than just passing RawVals --
+                    // has to do with the fact that some host functions are
+                    // typed as receiving or returning plain _non-Rawval_ i64 or
+                    // u64 values. So the call here has to be able to massage
+                    // both types into and out of i64, and `wasmi::Value`
+                    // happens to be a natural switching point for that: we have
+                    // conversions to and from both RawVal and i64 / u64 for
+                    // wasmi::Value.
+                    let res: Value = host.$fn_id(&mut vmcaller, $(<$type as FromValue>::from_value(Value::I64($arg)).ok_or(UnexpectedSignature)?),*)?.into();
+                    if let Value::I64(v) = res {
+                        Ok((v,))
+                    } else {
+                        Err(UnexpectedSignature.into())
+                    }
                 }
             )*
         )*

--- a/soroban-test-wasms/wasm-workspace/Cargo.toml
+++ b/soroban-test-wasms/wasm-workspace/Cargo.toml
@@ -38,7 +38,7 @@ stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "fee9a4
 
 # You should actually be able to set this to be any existing version of wasmi because we are
 # not building the SDK in host mode, so the "vm" feature is off.
-wasmi = { package = "soroban-wasmi", git = "https://github.com/stellar/wasmi", rev = "7b1f2355" }
+wasmi = { package = "soroban-wasmi", git = "https://github.com/stellar/wasmi", rev = "3bda8032" }
 
 # The following SDK patch lines must denote an SDK version that is _compatible_
 # with the current version of soroban-env-guest and soroban-env-common, as found


### PR DESCRIPTION
This upgrades the env crates to use the new wasmi_v1 API that arrives with [the upgrade to wasmi 0.16.0](https://github.com/stellar/wasmi/pull/2).

Unfortunately it's quite invasive: every host function signature changes inside the host. The fallout _should_ be limited to the host (and people who embed and invoke it). Most of the changes have to do with the fact that wasmi now requires us to thread a `&mut Store` through to the host function if we want to use anything stored _in_ its store (such as linear memory). We can't dynamically acquire mutable access to it elsewhere, as it's already mutably borrowed during execution.

Everything else is mostly just "same task, different API" sort of stuff. Module parsing and dispatch functions actually got a little simpler.