### PR TITLE
Add RawVal conversions for Result<>

### DIFF
--- a/soroban-env-common/src/lib.rs
+++ b/soroban-env-common/src/lib.rs
@@ -30,6 +30,7 @@ pub mod meta;
 mod object;
 mod option;
 mod raw_val;
+mod result;
 mod r#static;
 mod status;
 mod symbol;
@@ -37,7 +38,6 @@ mod tuple;
 mod unimplemented_env;
 mod val;
 mod vmcaller_checked_env;
-mod result;
 
 // Re-export the XDR definitions
 pub use stellar_xdr as xdr;

--- a/soroban-env-common/src/lib.rs
+++ b/soroban-env-common/src/lib.rs
@@ -37,6 +37,7 @@ mod tuple;
 mod unimplemented_env;
 mod val;
 mod vmcaller_checked_env;
+mod result;
 
 // Re-export the XDR definitions
 pub use stellar_xdr as xdr;

--- a/soroban-env-common/src/result.rs
+++ b/soroban-env-common/src/result.rs
@@ -1,0 +1,63 @@
+use crate::{ConversionError, Env, IntoVal, RawVal, Symbol, TryFromVal, TryIntoVal};
+
+const SYMBOL_OK: Symbol = Symbol::from_str("OK");
+const SYMBOL_OK_PAYLOAD: u64 = SYMBOL_OK.to_raw().get_payload();
+
+const SYMBOL_ERROR: Symbol = Symbol::from_str("ERROR");
+const SYMBOL_ERROR_PAYLOAD: u64 = SYMBOL_ERROR.to_raw().get_payload();
+
+impl<E: Env, T, F> TryFromVal<E, RawVal> for Result<T, F>
+where
+    T: TryFromVal<E, RawVal, Error = ConversionError>,
+    F: TryFromVal<E, RawVal, Error = ConversionError>,
+{
+    type Error = ConversionError;
+
+    fn try_from_val(env: &E, val: RawVal) -> Result<Self, Self::Error> {
+        let (discriminant, value): (RawVal, RawVal) = val.try_into_val(env)?;
+        match discriminant.get_payload() {
+            SYMBOL_OK_PAYLOAD => Ok(Ok(T::try_from_val(env, value)?)),
+            SYMBOL_ERROR_PAYLOAD => Ok(Err(F::try_from_val(env, value)?)),
+            _ => Err(ConversionError),
+        }
+    }
+}
+
+impl<E: Env, T, F> TryIntoVal<E, Result<T, F>> for RawVal
+where
+    T: TryFromVal<E, RawVal, Error = ConversionError>,
+    F: TryFromVal<E, RawVal, Error = ConversionError>,
+{
+    type Error = ConversionError;
+
+    #[inline(always)]
+    fn try_into_val(self, env: &E) -> Result<Result<T, F>, Self::Error> {
+        <_ as TryFromVal<E, RawVal>>::try_from_val(env, self)
+    }
+}
+
+impl<E: Env, T, F> IntoVal<E, RawVal> for Result<T, F>
+where
+    T: IntoVal<E, RawVal>,
+    F: IntoVal<E, RawVal>,
+{
+    fn into_val(self, env: &E) -> RawVal {
+        match self {
+            Ok(t) => (SYMBOL_OK, t).into_val(env),
+            Err(f) => (SYMBOL_ERROR, f).into_val(env),
+        }
+    }
+}
+
+impl<E: Env, T, F> IntoVal<E, RawVal> for &Result<T, F>
+where
+    for<'a> &'a T: IntoVal<E, RawVal>,
+    for<'a> &'a F: IntoVal<E, RawVal>,
+{
+    fn into_val(self, env: &E) -> RawVal {
+        match self {
+            Ok(t) => (SYMBOL_OK, t).into_val(env),
+            Err(f) => (SYMBOL_ERROR, f).into_val(env),
+        }
+    }
+}

--- a/soroban-env-common/src/result.rs
+++ b/soroban-env-common/src/result.rs
@@ -13,6 +13,7 @@ where
 {
     type Error = ConversionError;
 
+    #[inline(always)]
     fn try_from_val(env: &E, val: RawVal) -> Result<Self, Self::Error> {
         let (discriminant, value): (RawVal, RawVal) = val.try_into_val(env)?;
         match discriminant.get_payload() {
@@ -41,6 +42,7 @@ where
     T: IntoVal<E, RawVal>,
     F: IntoVal<E, RawVal>,
 {
+    #[inline(always)]
     fn into_val(self, env: &E) -> RawVal {
         match self {
             Ok(t) => (SYMBOL_OK, t).into_val(env),
@@ -54,6 +56,7 @@ where
     for<'a> &'a T: IntoVal<E, RawVal>,
     for<'a> &'a F: IntoVal<E, RawVal>,
 {
+    #[inline(always)]
     fn into_val(self, env: &E) -> RawVal {
         match self {
             Ok(t) => (SYMBOL_OK, t).into_val(env),


### PR DESCRIPTION
### What
Add RawVal conversions for Result<>

### Why
For use in contracts that want to return a result or an error that can be handled. Similar to Ethereum contracts where developers return enums for error conditions.

Note that there are no tests in this PR, because it is much easier and more meaningful to test this logic in the SDK. This logic would probably live in the SDK if not for the limitations on where Rust trait implementations are allowed to live.