### PR TITLE
Add RawVal <> String conversions for tests

### DIFF
--- a/soroban-env-common/src/lib.rs
+++ b/soroban-env-common/src/lib.rs
@@ -33,6 +33,7 @@ mod raw_val;
 mod result;
 mod r#static;
 mod status;
+mod r#str;
 mod symbol;
 mod tuple;
 mod unimplemented_env;

--- a/soroban-env-common/src/str.rs
+++ b/soroban-env-common/src/str.rs
@@ -2,7 +2,9 @@
 
 use stellar_xdr::ScObjectType;
 
-use crate::{ConversionError, Env, Object, RawVal, RawValConvertible, TryFromVal, TryIntoVal};
+use crate::{
+    ConversionError, Env, IntoVal, Object, RawVal, RawValConvertible, TryFromVal, TryIntoVal,
+};
 
 impl<E: Env> TryFromVal<E, RawVal> for String {
     type Error = ConversionError;
@@ -21,43 +23,32 @@ impl<E: Env> TryFromVal<E, RawVal> for String {
     }
 }
 
-// impl<E: Env, T, F> TryIntoVal<E, Result<T, F>> for RawVal
-// where
-//     T: TryFromVal<E, RawVal, Error = ConversionError>,
-//     F: TryFromVal<E, RawVal, Error = ConversionError>,
-// {
-//     type Error = ConversionError;
+impl<E: Env> TryIntoVal<E, String> for RawVal {
+    type Error = ConversionError;
 
-//     #[inline(always)]
-//     fn try_into_val(self, env: &E) -> Result<Result<T, F>, Self::Error> {
-//         <_ as TryFromVal<E, RawVal>>::try_from_val(env, self)
-//     }
-// }
+    #[inline(always)]
+    fn try_into_val(self, env: &E) -> Result<String, Self::Error> {
+        <_ as TryFromVal<E, RawVal>>::try_from_val(env, self)
+    }
+}
 
-// impl<E: Env, T, F> IntoVal<E, RawVal> for Result<T, F>
-// where
-//     T: IntoVal<E, RawVal>,
-//     F: IntoVal<E, RawVal>,
-// {
-//     #[inline(always)]
-//     fn into_val(self, env: &E) -> RawVal {
-//         match self {
-//             Ok(t) => (SYMBOL_OK, t).into_val(env),
-//             Err(f) => (SYMBOL_ERROR, f).into_val(env),
-//         }
-//     }
-// }
+impl<E: Env> IntoVal<E, RawVal> for &str {
+    #[inline(always)]
+    fn into_val(self, env: &E) -> RawVal {
+        env.bytes_new_from_slice(self.as_bytes()).to_raw()
+    }
+}
 
-// impl<E: Env, T, F> IntoVal<E, RawVal> for &Result<T, F>
-// where
-//     for<'a> &'a T: IntoVal<E, RawVal>,
-//     for<'a> &'a F: IntoVal<E, RawVal>,
-// {
-//     #[inline(always)]
-//     fn into_val(self, env: &E) -> RawVal {
-//         match self {
-//             Ok(t) => (SYMBOL_OK, t).into_val(env),
-//             Err(f) => (SYMBOL_ERROR, f).into_val(env),
-//         }
-//     }
-// }
+impl<E: Env> IntoVal<E, RawVal> for String {
+    #[inline(always)]
+    fn into_val(self, env: &E) -> RawVal {
+        <_ as IntoVal<E, RawVal>>::into_val(&self, env)
+    }
+}
+
+impl<E: Env> IntoVal<E, RawVal> for &String {
+    #[inline(always)]
+    fn into_val(self, env: &E) -> RawVal {
+        <&str as IntoVal<E, RawVal>>::into_val(&self, env)
+    }
+}

--- a/soroban-env-common/src/str.rs
+++ b/soroban-env-common/src/str.rs
@@ -1,0 +1,63 @@
+#![cfg(feature = "std")]
+
+use stellar_xdr::ScObjectType;
+
+use crate::{ConversionError, Env, Object, RawVal, RawValConvertible, TryFromVal, TryIntoVal};
+
+impl<E: Env> TryFromVal<E, RawVal> for String {
+    type Error = ConversionError;
+
+    #[inline(always)]
+    fn try_from_val(env: &E, val: RawVal) -> Result<Self, Self::Error> {
+        let obj: Object = val.try_into_val(env)?;
+        if obj.is_obj_type(ScObjectType::Bytes) {
+            let len = unsafe { <u32 as RawValConvertible>::unchecked_from_val(env.bytes_len(obj)) };
+            let mut vec = std::vec![0; len as usize];
+            env.bytes_copy_to_slice(obj, RawVal::U32_ZERO, &mut vec);
+            String::from_utf8(vec).map_err(|_| ConversionError)
+        } else {
+            Err(ConversionError)
+        }
+    }
+}
+
+// impl<E: Env, T, F> TryIntoVal<E, Result<T, F>> for RawVal
+// where
+//     T: TryFromVal<E, RawVal, Error = ConversionError>,
+//     F: TryFromVal<E, RawVal, Error = ConversionError>,
+// {
+//     type Error = ConversionError;
+
+//     #[inline(always)]
+//     fn try_into_val(self, env: &E) -> Result<Result<T, F>, Self::Error> {
+//         <_ as TryFromVal<E, RawVal>>::try_from_val(env, self)
+//     }
+// }
+
+// impl<E: Env, T, F> IntoVal<E, RawVal> for Result<T, F>
+// where
+//     T: IntoVal<E, RawVal>,
+//     F: IntoVal<E, RawVal>,
+// {
+//     #[inline(always)]
+//     fn into_val(self, env: &E) -> RawVal {
+//         match self {
+//             Ok(t) => (SYMBOL_OK, t).into_val(env),
+//             Err(f) => (SYMBOL_ERROR, f).into_val(env),
+//         }
+//     }
+// }
+
+// impl<E: Env, T, F> IntoVal<E, RawVal> for &Result<T, F>
+// where
+//     for<'a> &'a T: IntoVal<E, RawVal>,
+//     for<'a> &'a F: IntoVal<E, RawVal>,
+// {
+//     #[inline(always)]
+//     fn into_val(self, env: &E) -> RawVal {
+//         match self {
+//             Ok(t) => (SYMBOL_OK, t).into_val(env),
+//             Err(f) => (SYMBOL_ERROR, f).into_val(env),
+//         }
+//     }
+// }

--- a/soroban-env-host/src/test.rs
+++ b/soroban-env-host/src/test.rs
@@ -6,6 +6,7 @@ mod bigint;
 mod bytes;
 mod crypto;
 mod map;
+mod str;
 mod vec;
 
 #[cfg(feature = "vm")]

--- a/soroban-env-host/src/test/str.rs
+++ b/soroban-env-host/src/test/str.rs
@@ -1,0 +1,26 @@
+use std::convert::TryInto;
+
+use soroban_env_common::{IntoVal, TryIntoVal};
+
+use crate::{CheckedEnv, Host, HostError, Object, RawVal};
+
+#[test]
+fn str_conversions() -> Result<(), HostError> {
+    let host = Host::default();
+    let mut obj = host.bytes_new()?;
+    for c in 'a'..='z' {
+        obj = host.bytes_push(obj, (c as u32).into())?;
+    }
+    let raw = obj.to_raw();
+    let s: String = raw.try_into_val(&host)?;
+    assert_eq!(s, "abcdefghijklmnopqrstuvwxyz");
+    let raw: RawVal = s.into_val(&host);
+    let obj: Object = raw.try_into_val(&host)?;
+    for (i, c) in ('a'..='z').enumerate() {
+        let c_raw = host.bytes_get(obj, (i as u32).into())?;
+        let c_u32: u32 = c_raw.try_into()?;
+        let c_char: char = char::from_u32(c_u32).unwrap();
+        assert_eq!((i, c_char), (i, c));
+    }
+    Ok(())
+}


### PR DESCRIPTION
### What
Add RawVal <> String conversions when the std feature is enabled.

### Why
For use in tests for conveniently converting strings to and from `Bytes`.

It's a little unclear on how useful this is, so I might come back and remove it, but I have one use case in some SDK testutils code where it helps simplify SDK code.