### PR TITLE
Remove legacy placeholder-free "format strings" on debug events that mask arguments

### DIFF
--- a/soroban-env-host/src/events.rs
+++ b/soroban-env-host/src/events.rs
@@ -144,7 +144,7 @@ impl DebugError {
     {
         let status: Status = status.into();
         Self {
-            event: DebugEvent::new().msg("status").arg::<RawVal>(status.into()),
+            event: DebugEvent::new().arg::<RawVal>(status.into()),
             status,
         }
     }

--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -1048,7 +1048,7 @@ impl VmCallerCheckedEnv for Host {
 
     // Notes on metering: covered by the components
     fn log_value(&self, _vmcaller: &mut VmCaller<Host>, v: RawVal) -> Result<RawVal, HostError> {
-        self.record_debug_event(DebugEvent::new().msg("log").arg(v))?;
+        self.record_debug_event(DebugEvent::new().arg(v))?;
         Ok(RawVal::from_void())
     }
 
@@ -1686,7 +1686,7 @@ impl VmCallerCheckedEnv for Host {
         let res = self.call_n(contract, func, args.as_slice());
         if let Err(e) = &res {
             let evt = DebugEvent::new()
-                .msg("contract call invocation resulted in error")
+                .msg("contract call invocation resulted in error {}")
                 .arg::<RawVal>(e.status.into());
             self.record_debug_event(evt)?;
         }

--- a/soroban-env-host/src/test/invocation.rs
+++ b/soroban-env-host/src/test/invocation.rs
@@ -76,7 +76,10 @@ fn invoke_cross_contract_with_err() -> Result<(), HostError> {
     let last_event = events.0.last();
     match last_event {
         Some(HostEvent::Debug(de)) => {
-            assert_eq!(de.msg, Some("contract call invocation resulted in error"));
+            assert_eq!(
+                de.msg,
+                Some("contract call invocation resulted in error {}")
+            );
             assert_eq!(de.args.len(), 1);
             if let DebugArg::Val(rv) = de.args[0] {
                 let status: Status = rv.try_into()?;
@@ -105,7 +108,10 @@ fn invoke_cross_contract_with_err() -> Result<(), HostError> {
     let last_event = events.0.last();
     match last_event {
         Some(HostEvent::Debug(de)) => {
-            assert_eq!(de.msg, Some("contract call invocation resulted in error"));
+            assert_eq!(
+                de.msg,
+                Some("contract call invocation resulted in error {}")
+            );
             assert_eq!(de.args.len(), 1);
             if let DebugArg::Val(rv) = de.args[0] {
                 let status: Status = rv.try_into()?;
@@ -181,7 +187,10 @@ fn invoke_cross_contract_indirect_err() -> Result<(), HostError> {
     let last_event = events.0.last();
     match last_event {
         Some(HostEvent::Debug(de)) => {
-            assert_eq!(de.msg, Some("contract call invocation resulted in error"));
+            assert_eq!(
+                de.msg,
+                Some("contract call invocation resulted in error {}")
+            );
             assert_eq!(de.args.len(), 1);
             if let DebugArg::Val(rv) = de.args[0] {
                 let status: Status = rv.try_into()?;
@@ -210,7 +219,10 @@ fn invoke_cross_contract_indirect_err() -> Result<(), HostError> {
     let last_event = events.0.last();
     match last_event {
         Some(HostEvent::Debug(de)) => {
-            assert_eq!(de.msg, Some("contract call invocation resulted in error"));
+            assert_eq!(
+                de.msg,
+                Some("contract call invocation resulted in error {}")
+            );
             assert_eq!(de.args.len(), 1);
             if let DebugArg::Val(rv) = de.args[0] {
                 let status: Status = rv.try_into()?;


### PR DESCRIPTION
When we transitioned to having format strings in debug events, we didn't purge (or fix to have format-string placeholders) all cases where we were passing a combination of static strings and rawval args. This meant (among other things) that `log_value` always just logs the word `log` -- not exactly useful.