### PR TITLE
Change the encoding of Result to only support Status as errpr

### DIFF
--- a/soroban-env-common/src/result.rs
+++ b/soroban-env-common/src/result.rs
@@ -1,56 +1,65 @@
 use crate::{ConversionError, Env, IntoVal, RawVal, Status, TryFromVal, TryIntoVal};
 
-impl<E: Env, T> TryFromVal<E, RawVal> for Result<T, Status>
+impl<E: Env, T, R> TryFromVal<E, RawVal> for Result<T, R>
 where
     T: TryFromVal<E, RawVal, Error = ConversionError>,
+    R: TryFrom<Status>,
 {
     type Error = ConversionError;
 
     #[inline(always)]
     fn try_from_val(env: &E, val: RawVal) -> Result<Self, Self::Error> {
         if let Ok(status) = Status::try_from_val(env, val) {
-            Ok(Err(status))
+            Ok(Err(status.try_into().map_err(|_| ConversionError)?))
         } else {
             Ok(Ok(T::try_from_val(env, val)?))
         }
     }
 }
 
-impl<E: Env, T> TryIntoVal<E, Result<T, Status>> for RawVal
+impl<E: Env, T, R> TryIntoVal<E, Result<T, R>> for RawVal
 where
     T: TryFromVal<E, RawVal, Error = ConversionError>,
+    R: TryFrom<Status>,
 {
     type Error = ConversionError;
 
     #[inline(always)]
-    fn try_into_val(self, env: &E) -> Result<Result<T, Status>, Self::Error> {
+    fn try_into_val(self, env: &E) -> Result<Result<T, R>, Self::Error> {
         <_ as TryFromVal<E, RawVal>>::try_from_val(env, self)
     }
 }
 
-impl<E: Env, T> IntoVal<E, RawVal> for Result<T, Status>
+impl<E: Env, T, R> IntoVal<E, RawVal> for Result<T, R>
 where
     T: IntoVal<E, RawVal>,
+    R: Into<Status>,
 {
     #[inline(always)]
     fn into_val(self, env: &E) -> RawVal {
         match self {
             Ok(t) => t.into_val(env),
-            Err(status) => status.into_val(env),
+            Err(r) => {
+                let status: Status = r.into();
+                status.into_val(env)
+            }
         }
     }
 }
 
-impl<E: Env, T, F> IntoVal<E, RawVal> for &Result<T, F>
+impl<E: Env, T, R> IntoVal<E, RawVal> for &Result<T, R>
 where
     for<'a> &'a T: IntoVal<E, RawVal>,
-    for<'a> &'a F: IntoVal<E, RawVal>,
+    for<'a> &'a R: Into<Status>,
 {
     #[inline(always)]
     fn into_val(self, env: &E) -> RawVal {
         match self {
             Ok(t) => t.into_val(env),
-            Err(status) => status.into_val(env),
+            Err(r) => {
+                let status: Status = r.into();
+                status.into_val(env)
+            }
         }
     }
 }

--- a/soroban-env-common/src/result.rs
+++ b/soroban-env-common/src/result.rs
@@ -1,52 +1,42 @@
-use crate::{ConversionError, Env, IntoVal, RawVal, Symbol, TryFromVal, TryIntoVal};
+use crate::{ConversionError, Env, IntoVal, RawVal, Status, TryFromVal, TryIntoVal};
 
-const SYMBOL_OK: Symbol = Symbol::from_str("Ok");
-const SYMBOL_OK_PAYLOAD: u64 = SYMBOL_OK.to_raw().get_payload();
-
-const SYMBOL_ERROR: Symbol = Symbol::from_str("Err");
-const SYMBOL_ERROR_PAYLOAD: u64 = SYMBOL_ERROR.to_raw().get_payload();
-
-impl<E: Env, T, F> TryFromVal<E, RawVal> for Result<T, F>
+impl<E: Env, T> TryFromVal<E, RawVal> for Result<T, Status>
 where
     T: TryFromVal<E, RawVal, Error = ConversionError>,
-    F: TryFromVal<E, RawVal, Error = ConversionError>,
 {
     type Error = ConversionError;
 
     #[inline(always)]
     fn try_from_val(env: &E, val: RawVal) -> Result<Self, Self::Error> {
-        let (discriminant, value): (RawVal, RawVal) = val.try_into_val(env)?;
-        match discriminant.get_payload() {
-            SYMBOL_OK_PAYLOAD => Ok(Ok(T::try_from_val(env, value)?)),
-            SYMBOL_ERROR_PAYLOAD => Ok(Err(F::try_from_val(env, value)?)),
-            _ => Err(ConversionError),
+        if let Ok(status) = Status::try_from_val(env, val) {
+            Ok(Err(status))
+        } else {
+            Ok(Ok(T::try_from_val(env, val)?))
         }
     }
 }
 
-impl<E: Env, T, F> TryIntoVal<E, Result<T, F>> for RawVal
+impl<E: Env, T> TryIntoVal<E, Result<T, Status>> for RawVal
 where
     T: TryFromVal<E, RawVal, Error = ConversionError>,
-    F: TryFromVal<E, RawVal, Error = ConversionError>,
 {
     type Error = ConversionError;
 
     #[inline(always)]
-    fn try_into_val(self, env: &E) -> Result<Result<T, F>, Self::Error> {
+    fn try_into_val(self, env: &E) -> Result<Result<T, Status>, Self::Error> {
         <_ as TryFromVal<E, RawVal>>::try_from_val(env, self)
     }
 }
 
-impl<E: Env, T, F> IntoVal<E, RawVal> for Result<T, F>
+impl<E: Env, T> IntoVal<E, RawVal> for Result<T, Status>
 where
     T: IntoVal<E, RawVal>,
-    F: IntoVal<E, RawVal>,
 {
     #[inline(always)]
     fn into_val(self, env: &E) -> RawVal {
         match self {
-            Ok(t) => (SYMBOL_OK, t).into_val(env),
-            Err(f) => (SYMBOL_ERROR, f).into_val(env),
+            Ok(t) => t.into_val(env),
+            Err(status) => status.into_val(env),
         }
     }
 }
@@ -59,8 +49,8 @@ where
     #[inline(always)]
     fn into_val(self, env: &E) -> RawVal {
         match self {
-            Ok(t) => (SYMBOL_OK, t).into_val(env),
-            Err(f) => (SYMBOL_ERROR, f).into_val(env),
+            Ok(t) => t.into_val(env),
+            Err(status) => status.into_val(env),
         }
     }
 }

--- a/soroban-env-common/src/status.rs
+++ b/soroban-env-common/src/status.rs
@@ -269,6 +269,11 @@ impl Status {
     }
 
     #[inline(always)]
+    pub const fn from_contract_error(code: u32) -> Status {
+        Self::from_type_and_code(ScStatusType::ContractError, code)
+    }
+
+    #[inline(always)]
     pub const fn from_type_and_code(ty: ScStatusType, code: u32) -> Status {
         // Unfortunately we can't use from_major_minor here because
         // it's not const, and making it const requires nightly.

--- a/soroban-env-common/src/status.rs
+++ b/soroban-env-common/src/status.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use core::{
     cmp::Ordering,
+    convert::TryFrom,
     fmt::Debug,
     hash::{Hash, Hasher},
 };


### PR DESCRIPTION
### What
Change the encoding of `Result` to only support conversion to `RawVal` when the error value is `Into<Status>`.

### Why
Errors are distinct values that always map to `Status`.

@graydon has plans in the works where when `Status` values are returned from functions it will cause a revert/rollback. So it's important that we only use `Status` or values that convert into `Status` as errors, otherwise it will be confusing if some errors rollback and some do not.

Close https://github.com/stellar/rs-soroban-sdk/issues/631