### PR TITLE
Update stellar-xdr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,7 +730,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "stellar-xdr"
 version = "0.0.2"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=54bf5e00#54bf5e006852356af9e68231116aca1d705afb80"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=fb78a6b8#fb78a6b84c807fd2641cf257818060e1d7d26c62"
 dependencies = [
  "base64",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ soroban-env-common = { path = "soroban-env-common" }
 soroban-env-host = { path = "soroban-env-host" }
 soroban-env-macros = { path = "soroban-env-macros" }
 soroban-native-sdk-macros = { path = "soroban-native-sdk-macros" }
-stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "54bf5e00" }
+stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "fb78a6b8" }
 wasmi = { package = "soroban-wasmi", git = "https://github.com/stellar/wasmi", rev = "a61b6df" }


### PR DESCRIPTION
### What
Update stellar-xdr.

### Why
To get the changes to the contract spec that add the enum error UDT type.