### PR TITLE
interpret status-return as an error and roll back frame, fix #453

### DIFF
--- a/soroban-env-host/src/test/contract_event.rs
+++ b/soroban-env-host/src/test/contract_event.rs
@@ -4,7 +4,7 @@ use crate::{
         ContractEvent, ContractEventBody, ContractEventType, ContractEventV0, ExtensionPoint, Hash,
         ScMap, ScMapEntry, ScObject::Map, ScVal,
     },
-    ContractFunctionSet, Env, EnvBase, Host, HostError, RawVal, Status, Symbol,
+    ContractFunctionSet, Env, EnvBase, Host, HostError, RawVal, Symbol,
 };
 use std::rc::Rc;
 
@@ -34,7 +34,7 @@ fn contract_event() -> Result<(), HostError> {
     host.register_test_contract(id, test_contract)?;
     assert_eq!(
         host.call(id, sym.into(), args.into()).get_payload(),
-        Status::OK.to_raw().get_payload()
+        RawVal::from_void().get_payload()
     );
 
     let event_ref = ContractEvent {

--- a/soroban-env-host/src/test/lifecycle.rs
+++ b/soroban-env-host/src/test/lifecycle.rs
@@ -7,7 +7,7 @@ use crate::{
         self, LedgerEntryData, LedgerKey, LedgerKeyContractData, ScContractCode, ScHostFnErrorCode,
         ScObject, ScStatic, ScVal, ScVec,
     },
-    CheckedEnv, Host, HostError, Symbol,
+    CheckedEnv, Host, HostError, RawVal, Symbol,
 };
 use hex::FromHex;
 use soroban_test_wasms::CREATE_CONTRACT;
@@ -166,8 +166,9 @@ fn create_contract_test() -> Result<(), HostError> {
         let del_res = host.del_contract_data(host.to_host_val(&key)?.to_raw());
         let code = ScHostFnErrorCode::InputArgsInvalid;
         assert!(HostError::result_matches_err_status(del_res, code));
-        Ok(())
-    })
+        Ok(RawVal::from_void())
+    })?;
+    Ok(())
 }
 
 /// VM tests


### PR DESCRIPTION
Promote a status return to an error when returning from a frame'd function, thereby causing rollback.