### PR TITLE
Organize with_mut_storage, with_ledger_info

### DIFF
--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -204,7 +204,7 @@ impl Host {
         *self.0.ledger.borrow_mut() = Some(info)
     }
 
-    fn with_ledger_info<F, T>(&self, f: F) -> Result<T, HostError>
+    pub fn with_ledger_info<F, T>(&self, f: F) -> Result<T, HostError>
     where
         F: FnOnce(&LedgerInfo) -> Result<T, HostError>,
     {
@@ -214,7 +214,6 @@ impl Host {
         }
     }
 
-    #[cfg(feature = "testutils")]
     pub fn with_mut_ledger_info<F>(&self, mut f: F) -> Result<(), HostError>
     where
         F: FnMut(&mut LedgerInfo),
@@ -289,7 +288,14 @@ impl Host {
         self.charge_budget(CostType::HostEventContract, 1)
     }
 
-    pub(crate) fn visit_storage<F, U>(&self, f: F) -> Result<U, HostError>
+    pub fn with_storage<F, U>(&self, f: F) -> Result<U, HostError>
+    where
+        F: FnOnce(&Storage) -> Result<U, HostError>,
+    {
+        f(&*self.0.storage.borrow())
+    }
+
+    pub fn with_mut_storage<F, U>(&self, f: F) -> Result<U, HostError>
     where
         F: FnOnce(&mut Storage) -> Result<U, HostError>,
     {
@@ -917,7 +923,7 @@ impl Host {
             account_id: self.to_account_id(account)?,
         });
 
-        self.visit_storage(|storage| {
+        self.with_mut_storage(|storage| {
             let mut le = storage.get(&lk)?;
             let ae = match &mut le.data {
                 LedgerEntryData::Account(ae) => Ok(ae),
@@ -976,7 +982,7 @@ impl Host {
         })?;
 
         let lk = self.to_trustline_key(account, asset_code, issuer)?;
-        self.visit_storage(|storage| {
+        self.with_mut_storage(|storage| {
             let mut le = storage.get(&lk)?;
             let tl = match &mut le.data {
                 LedgerEntryData::Trustline(tl) => Ok(tl),

--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -288,13 +288,6 @@ impl Host {
         self.charge_budget(CostType::HostEventContract, 1)
     }
 
-    pub fn with_storage<F, U>(&self, f: F) -> Result<U, HostError>
-    where
-        F: FnOnce(&Storage) -> Result<U, HostError>,
-    {
-        f(&*self.0.storage.borrow())
-    }
-
     pub fn with_mut_storage<F, U>(&self, f: F) -> Result<U, HostError>
     where
         F: FnOnce(&mut Storage) -> Result<U, HostError>,

--- a/soroban-env-host/src/host/data_helper.rs
+++ b/soroban-env-host/src/host/data_helper.rs
@@ -135,7 +135,7 @@ impl Host {
             account_id: self
                 .visit_obj(a, |id: &AccountId| Ok(id.metered_clone(&self.0.budget)?))?,
         });
-        self.visit_storage(|storage| match storage.get(&acc)?.data {
+        self.with_mut_storage(|storage| match storage.get(&acc)?.data {
             LedgerEntryData::Account(ae) => Ok(ae),
             _ => Err(self.err_general("not account")),
         })
@@ -147,7 +147,7 @@ impl Host {
             account_id: self
                 .visit_obj(a, |id: &AccountId| Ok(id.metered_clone(&self.0.budget)?))?,
         });
-        self.visit_storage(|storage| storage.has(&acc))
+        self.with_mut_storage(|storage| storage.has(&acc))
     }
 
     pub fn to_trustline_key(

--- a/soroban-env-host/src/test/lifecycle.rs
+++ b/soroban-env-host/src/test/lifecycle.rs
@@ -16,7 +16,7 @@ use im_rc::OrdMap;
 use sha2::{Digest, Sha256};
 
 pub(crate) fn check_new_code(host: &Host, storage_key: LedgerKey, code: ScVal) {
-    host.visit_storage(|s: &mut Storage| {
+    host.with_mut_storage(|s: &mut Storage| {
         assert!(s.has(&storage_key)?);
 
         match s.get(&storage_key)?.data {
@@ -136,7 +136,7 @@ fn create_contract_using_parent_id_test() {
         key: ScVal::Static(ScStatic::LedgerKeyContractCode),
     });
 
-    host.visit_storage(|s: &mut Storage| {
+    host.with_mut_storage(|s: &mut Storage| {
         s.footprint
             .record_access(&child_storage_key, AccessType::ReadWrite)
             .unwrap();


### PR DESCRIPTION
### What
Rename `Host::visit_storage` to `Host::with_mut_storage`. Add `Host::with_storage`. Make these functions and `Host::with_mut_ledger_info` pub.

### Why
The broad reason for this change is so that these functions are consistently named, and accessible to the SDK for building out test utilities in the SDK.

We have a mix of `visit_` and `with_` functions, but they're behavior is the same. I asked @graydon what the most idiomatic would be, and he said `with_` was more common in Rust so I went with that.

The storage function provides a mutable value, and in the ledger info we have a mutable variant, so I named it to match.

All these functions have been made public so the SDK can access them, and because there's little reason for them to be private. For example, the `with_mut_ledger_info` was private and marked as testutils, but there is little reason to do that because the `set_ledger_info` function is public and not scoped to testutils.