### PR TITLE
Correct / tidy up / comment calibration code.

### DIFF
--- a/soroban-env-host/benches/common/cost_types/bigint_div_rem.rs
+++ b/soroban-env-host/benches/common/cost_types/bigint_div_rem.rs
@@ -10,6 +10,10 @@ pub(crate) struct BigIntDivRemRun {
     input: u64,
 }
 
+// This measures the costs of doing div_rem on the bigint type. The input value
+// is the number of bits. The underlying code is variable-time in the bit size,
+// but we expect that by bounding the bit size we can make a reasonably tight
+// constant or linear-function upper bound. Examine the table and histogram.
 impl HostCostMeasurement for BigIntDivRemRun {
     const COST_TYPE: CostType = CostType::BigIntDivRem;
     const RUN_ITERATIONS: u64 = 100;
@@ -28,6 +32,8 @@ impl HostCostMeasurement for BigIntDivRemRun {
             let one: BigInt = 1.into();
             a + one
         }
+        // TODO: unclear if this really represents "worst case", it's
+        // just a guess.
         let a: BigInt = repeating_byte_bigint(0xf7, input);
         let b: BigInt = repeating_byte_bigint(0xf6, 1 + (input / 2));
         Self { a, b, input }

--- a/soroban-env-host/benches/common/cost_types/compute_ed25519_pubkey.rs
+++ b/soroban-env-host/benches/common/cost_types/compute_ed25519_pubkey.rs
@@ -3,31 +3,28 @@ use ed25519_dalek::{PublicKey, SecretKey};
 use rand::rngs::StdRng;
 use soroban_env_host::{budget::CostType, Host};
 
+// This measures the costs to turn one byte buffer into an Ed25519
+// pubkey, which should be constant time. The input value is ignored.
 pub(crate) struct ComputeEd25519PubKeyRun {
-    keys: Vec<Vec<u8>>,
+    key: Vec<u8>,
 }
 
 impl HostCostMeasurement for ComputeEd25519PubKeyRun {
     const COST_TYPE: CostType = CostType::ComputeEd25519PubKey;
+    const RUN_ITERATIONS: u64 = 100;
 
-    fn new_random_case(_host: &Host, rng: &mut StdRng, input: u64) -> Self {
-        let keys = (0..input)
-            .map(|_| {
-                let secret = SecretKey::generate(rng);
-                let public: PublicKey = (&secret).into();
-                public.as_bytes().as_slice().into()
-            })
-            .collect();
-        Self { keys }
+    fn new_random_case(_host: &Host, rng: &mut StdRng, _input: u64) -> Self {
+        let secret = SecretKey::generate(rng);
+        let public: PublicKey = (&secret).into();
+        let key = public.as_bytes().as_slice().into();
+        Self { key }
     }
 
     fn get_input(&self, _host: &Host) -> u64 {
-        self.keys.len() as u64
+        1
     }
 
     fn run(&mut self, _iter: u64, _host: &Host) {
-        for i in self.keys.iter() {
-            ed25519_dalek::PublicKey::from_bytes(i.as_slice()).expect("publickey");
-        }
+        ed25519_dalek::PublicKey::from_bytes(self.key.as_slice()).expect("publickey");
     }
 }

--- a/soroban-env-host/benches/common/cost_types/compute_sha256_hash.rs
+++ b/soroban-env-host/benches/common/cost_types/compute_sha256_hash.rs
@@ -3,6 +3,9 @@ use rand::rngs::StdRng;
 use sha2::{Digest, Sha256};
 use soroban_env_host::{budget::CostType, Host};
 
+// This measures the costs of performing a sha256 hash on a variable-sized
+// byte buffer. The input value is the size of the buffer. It should be
+// linear time.
 pub(crate) struct ComputeSha256HashRun {
     buf: Vec<u8>,
 }

--- a/soroban-env-host/benches/common/cost_types/ed25519_scalar_mul.rs
+++ b/soroban-env-host/benches/common/cost_types/ed25519_scalar_mul.rs
@@ -3,6 +3,11 @@ use curve25519_dalek::{constants, edwards, scalar};
 use rand::{rngs::StdRng, Rng, RngCore};
 use soroban_env_host::{budget::CostType, Host};
 
+// This measures the costs of doing an Ed25519 scalar multiply, which is a
+// component of signature verification and is the only part advertised as
+// variable time. The input value is ignored. The underlying operation is
+// nonlinear and the point of this measurement is to investigate how wide the
+// variation is in the histogram.
 #[allow(non_snake_case)]
 pub(crate) struct EdwardsPointCurve25519ScalarMulRun {
     a: scalar::Scalar,

--- a/soroban-env-host/benches/common/cost_types/host_obj_alloc_slot.rs
+++ b/soroban-env-host/benches/common/cost_types/host_obj_alloc_slot.rs
@@ -6,24 +6,34 @@ use soroban_env_host::{
     Host,
 };
 
+// This measures the cost of allocating a slot in the host object array,
+// which is pretty much just the cost of doing a vector-grow operation in
+// rust. It should be _amortized_ constant-time. The input value is the
+// new object handle number, which is the size of the existing object array.
 pub(crate) struct HostObjAllocSlotRun {
-    count: u64,
     val: ScVal,
 }
 
-/// Measures the costs of allocating large numbers of simple objects.
 impl HostCostMeasurement for HostObjAllocSlotRun {
     const COST_TYPE: CostType = CostType::HostObjAllocSlot;
 
-    fn new_random_case(_host: &Host, _rng: &mut StdRng, input: u64) -> Self {
+    // We iterate a bunch of times so that we cross a reallocation boundary.
+    const RUN_ITERATIONS: u64 = 100;
+
+    fn new_random_case(host: &Host, _rng: &mut StdRng, input: u64) -> Self {
+        // During setup we inject a bunch of copies of the object to make
+        // the host object array large.
         let size = input * 100;
         let val = ScVal::Object(Some(ScObject::I64(0)));
-        Self { count: size, val }
+        for _ in 0..size {
+            host.inject_val(&val).unwrap();
+        }
+        Self { val }
     }
 
     fn run(&mut self, _iter: u64, host: &Host) {
-        for _ in 0..self.count {
-            host.inject_val(&self.val).unwrap();
-        }
+        // When measuring, we just inject a single copy to see what
+        // the cost of "one more" is at the given size.
+        host.inject_val(&self.val).unwrap();
     }
 }

--- a/soroban-env-host/benches/common/cost_types/im_map_immut_entry.rs
+++ b/soroban-env-host/benches/common/cost_types/im_map_immut_entry.rs
@@ -1,39 +1,49 @@
 use crate::common::HostCostMeasurement;
-use rand::rngs::StdRng;
+use rand::{rngs::StdRng, seq::SliceRandom};
 use soroban_env_host::{budget::CostType, EnvVal, Host, RawVal};
 
+use super::util;
+
 pub(crate) struct ImMapImmutEntryRun {
-    map: im_rc::OrdMap<EnvVal<Host, RawVal>, EnvVal<Host, RawVal>>,
-    input: u64,
+    pub(crate) map: im_rc::OrdMap<EnvVal<Host, RawVal>, EnvVal<Host, RawVal>>,
+    pub(crate) keys: Vec<EnvVal<Host, RawVal>>,
 }
 
-/// Measures the costs of accessing maps of varying sizes.
+// Measures the costs of accessing maps of varying sizes. It should have zero
+// memory cost and logarithmic cpu cost, which we will approximate as constant
+// with an upper bound on map size. The input value is the size of the map.
 impl HostCostMeasurement for ImMapImmutEntryRun {
+    const RUN_ITERATIONS: u64 = 100;
     const COST_TYPE: CostType = CostType::ImMapImmutEntry;
 
-    fn new_random_case(host: &Host, _rng: &mut StdRng, input: u64) -> Self {
-        let size = input * 100;
-        let map: im_rc::OrdMap<EnvVal<Host, RawVal>, EnvVal<Host, RawVal>> = (0..size)
-            .map(|k| {
-                let ev = EnvVal {
-                    env: host.clone(),
-                    val: RawVal::from_u32(k as u32),
-                };
-                (ev.clone(), ev)
-            })
-            .collect();
-        Self { map, input }
+    fn new_random_case(host: &Host, rng: &mut StdRng, input: u64) -> Self {
+        let input = input * 100;
+        let mut keys: Vec<_> = util::to_envval_u32(host, 0..(input as u32)).collect();
+        keys.shuffle(rng);
+        let map = keys.iter().cloned().zip(keys.iter().cloned()).collect();
+        keys.shuffle(rng);
+        Self { map, keys }
     }
 
-    fn run(&mut self, _iter: u64, host: &Host) {
-        let ev = EnvVal {
-            env: host.clone(),
-            val: RawVal::from_u32((self.input / 2) as u32),
-        };
-        let _ = self.map.get(&ev);
+    fn new_worst_case(host: &Host, _rng: &mut StdRng, input: u64) -> Self {
+        let input = input * 100;
+        let keys: Vec<_> = util::to_envval_u32(host, 0..(input as u32)).collect();
+        let map = keys.iter().cloned().zip(keys.iter().cloned()).collect();
+        let keys = util::to_envval_u32(host, [0, u32::MAX].iter().cloned()).collect();
+        Self { map, keys }
+    }
+
+    fn new_best_case(host: &Host, _rng: &mut StdRng) -> Self {
+        let keys: Vec<_> = util::to_envval_u32(host, [0].iter().cloned()).collect();
+        let map = keys.iter().cloned().zip(keys.iter().cloned()).collect();
+        Self { map, keys }
+    }
+
+    fn run(&mut self, iter: u64, _host: &Host) {
+        let _ = self.map.get(&self.keys[iter as usize % self.keys.len()]);
     }
 
     fn get_input(&self, _host: &Host) -> u64 {
-        self.input
+        self.map.len() as u64
     }
 }

--- a/soroban-env-host/benches/common/cost_types/im_vec_immut_entry.rs
+++ b/soroban-env-host/benches/common/cost_types/im_vec_immut_entry.rs
@@ -1,28 +1,38 @@
 use crate::common::HostCostMeasurement;
-use rand::rngs::StdRng;
+use rand::{rngs::StdRng, seq::SliceRandom};
 use soroban_env_host::{budget::CostType, EnvVal, Host, RawVal};
 
+use super::util;
+
 pub(crate) struct ImVecImmutEntryRun {
-    vec: im_rc::Vector<EnvVal<Host, RawVal>>,
+    pub(crate) vec: im_rc::Vector<EnvVal<Host, RawVal>>,
+    pub(crate) idxs: Vec<usize>,
 }
 
+// Measures the costs of accessing vectors of various sizes. It should have zero
+// memory cost and logarithmic cpu cost, which we will approximate with an upper
+// bound on vector size.
 impl HostCostMeasurement for ImVecImmutEntryRun {
     const COST_TYPE: CostType = CostType::ImVecImmutEntry;
     const RUN_ITERATIONS: u64 = 100;
 
-    fn new_random_case(host: &Host, _rng: &mut StdRng, input: u64) -> Self {
-        let size = 1 + (input * 100);
-        let vec: im_rc::Vector<EnvVal<Host, RawVal>> = (0..size)
-            .map(|k| EnvVal {
-                env: host.clone(),
-                val: RawVal::from_u32(k as u32),
-            })
-            .collect();
-        Self { vec }
+    fn new_best_case(host: &Host, _rng: &mut StdRng) -> Self {
+        let vec = util::to_envval_u32(host, 0..1).collect();
+        let idxs = [0].to_vec();
+        Self { vec, idxs }
+    }
+
+    // Random case is worst case.
+    fn new_random_case(host: &Host, rng: &mut StdRng, input: u64) -> Self {
+        let input = 1 + (input * 10000);
+        let vec = util::to_envval_u32(host, 0..(input as u32)).collect();
+        let mut idxs: Vec<usize> = (0..input as usize).collect();
+        idxs.shuffle(rng);
+        Self { vec, idxs }
     }
 
     fn run(&mut self, iter: u64, _host: &Host) {
-        let _ = self.vec.get(iter as usize % self.vec.len());
+        let _ = self.vec.get(self.idxs[iter as usize % self.idxs.len()]);
     }
 
     fn get_input(&self, _host: &Host) -> u64 {

--- a/soroban-env-host/benches/common/cost_types/im_vec_mut_entry.rs
+++ b/soroban-env-host/benches/common/cost_types/im_vec_mut_entry.rs
@@ -2,30 +2,41 @@ use crate::common::HostCostMeasurement;
 use rand::rngs::StdRng;
 use soroban_env_host::{budget::CostType, EnvVal, Host, RawVal};
 
+use super::im_vec_immut_entry::ImVecImmutEntryRun;
+
 pub(crate) struct ImVecMutEntryRun {
-    vec: im_rc::Vector<EnvVal<Host, RawVal>>,
+    im: ImVecImmutEntryRun,
+    second_vec_ref: im_rc::Vector<EnvVal<Host, RawVal>>,
 }
 
+// This is just a variant of ImVecImmutEntryRun that calls the get_mut method on
+// a multiply-referenced vec, causing a copy-on-write of some nodes. It should
+// cost a nearly-constant (perhaps very-slow-log) amount of memory and CPU.
 impl HostCostMeasurement for ImVecMutEntryRun {
     const COST_TYPE: CostType = CostType::ImVecMutEntry;
-    const RUN_ITERATIONS: u64 = 100;
+    const RUN_ITERATIONS: u64 = ImVecImmutEntryRun::RUN_ITERATIONS;
 
-    fn new_random_case(host: &Host, _rng: &mut StdRng, input: u64) -> Self {
-        let size = 1 + (input * 100);
-        let vec: im_rc::Vector<EnvVal<Host, RawVal>> = (0..size)
-            .map(|k| EnvVal {
-                env: host.clone(),
-                val: RawVal::from_u32(k as u32),
-            })
-            .collect();
-        Self { vec }
+    fn new_best_case(host: &Host, rng: &mut StdRng) -> Self {
+        let im = ImVecImmutEntryRun::new_best_case(host, rng);
+        let second_vec_ref = im.vec.clone();
+        Self { im, second_vec_ref }
+    }
+
+    // Random case is worst case.
+    fn new_random_case(host: &Host, rng: &mut StdRng, input: u64) -> Self {
+        let im = ImVecImmutEntryRun::new_random_case(host, rng, input);
+        let second_vec_ref = im.vec.clone();
+        Self { im, second_vec_ref }
     }
 
     fn run(&mut self, iter: u64, _host: &Host) {
-        let _ = self.vec.get_mut(iter as usize % self.vec.len());
+        let _ = self
+            .im
+            .vec
+            .get_mut(self.im.idxs[iter as usize % self.im.idxs.len()]);
     }
 
-    fn get_input(&self, _host: &Host) -> u64 {
-        self.vec.len() as u64
+    fn get_input(&self, host: &Host) -> u64 {
+        self.im.get_input(host)
     }
 }

--- a/soroban-env-host/benches/common/cost_types/im_vec_new.rs
+++ b/soroban-env-host/benches/common/cost_types/im_vec_new.rs
@@ -15,6 +15,7 @@ impl HostCostMeasurement for ImVecNewRun {
     const COST_TYPE: CostType = CostType::ImVecNew;
     const RUN_ITERATIONS: u64 = 1000;
 
+    // All cases are the random case, which is a constant-effort operation.
     fn new_random_case(_host: &Host, _rng: &mut StdRng, _input: u64) -> Self {
         let scvec: ScVec = ScVec(vec![].try_into().unwrap());
         let val = ScVal::Object(Some(ScObject::Vec(scvec)));

--- a/soroban-env-host/benches/common/cost_types/mod.rs
+++ b/soroban-env-host/benches/common/cost_types/mod.rs
@@ -14,6 +14,8 @@ mod verify_ed25519_sig;
 mod vm_instantiation;
 mod wasm_insn_exec;
 
+mod util;
+
 use std::collections::BTreeSet;
 
 use soroban_env_host::budget::CostType;
@@ -24,17 +26,40 @@ pub trait Benchmark {
     fn bench<HCM: HostCostMeasurement>() -> std::io::Result<()>;
 }
 
+fn get_explicit_bench_names() -> Option<Vec<String>> {
+    let bare_args: Vec<_> = std::env::args().filter(|x| !x.starts_with("-")).collect();
+    match bare_args.len() {
+        0 | 1 => None,
+        _ => Some(bare_args[1..].into()),
+    }
+}
+
+fn should_run<HCM: HostCostMeasurement>() -> bool {
+    if let Some(bench_names) = get_explicit_bench_names() {
+        let name = format!("{:?}", HCM::COST_TYPE)
+            .split("::")
+            .last()
+            .unwrap()
+            .to_string();
+        bench_names.into_iter().find(|arg| *arg == name).is_some()
+    } else {
+        true
+    }
+}
+
 fn call_bench<B: Benchmark, HCM: HostCostMeasurement>(
     costs: &mut BTreeSet<CostType>,
 ) -> std::io::Result<()> {
-    B::bench::<HCM>()?;
-    costs.insert(HCM::COST_TYPE);
+    if should_run::<HCM>() {
+        B::bench::<HCM>()?;
+        costs.insert(HCM::COST_TYPE);
+    }
     Ok(())
 }
 
 pub fn for_each_host_cost_measurement<B: Benchmark>() -> std::io::Result<()> {
     let mut costs: BTreeSet<CostType> = BTreeSet::new();
-    call_bench::<B, wasm_insn_exec::WasmInsnExecRun>(&mut costs)?;
+
     call_bench::<B, bigint_div_rem::BigIntDivRemRun>(&mut costs)?;
     call_bench::<B, compute_ed25519_pubkey::ComputeEd25519PubKeyRun>(&mut costs)?;
     call_bench::<B, compute_sha256_hash::ComputeSha256HashRun>(&mut costs)?;
@@ -46,12 +71,16 @@ pub fn for_each_host_cost_measurement<B: Benchmark>() -> std::io::Result<()> {
     call_bench::<B, im_vec_mut_entry::ImVecMutEntryRun>(&mut costs)?;
     call_bench::<B, im_vec_new::ImVecNewRun>(&mut costs)?;
     call_bench::<B, scmap_to_host_map::ScMapToHostMapRun>(&mut costs)?;
+    call_bench::<B, scvec_to_host_vec::ScVecToHostVecRun>(&mut costs)?;
     call_bench::<B, verify_ed25519_sig::VerifyEd25519SigRun>(&mut costs)?;
     call_bench::<B, vm_instantiation::VmInstantiationRun>(&mut costs)?;
+    call_bench::<B, wasm_insn_exec::WasmInsnExecRun>(&mut costs)?;
 
-    for cost in CostType::variants() {
-        if !costs.contains(cost) {
-            eprintln!("warning: missing cost measurement for {:?}", cost);
+    if get_explicit_bench_names().is_none() {
+        for cost in CostType::variants() {
+            if !costs.contains(cost) {
+                eprintln!("warning: missing cost measurement for {:?}", cost);
+            }
         }
     }
     Ok(())

--- a/soroban-env-host/benches/common/cost_types/scmap_to_host_map.rs
+++ b/soroban-env-host/benches/common/cost_types/scmap_to_host_map.rs
@@ -14,10 +14,12 @@ pub(crate) struct ScMapToHostMapRun {
     input: u64,
 }
 
-/// Measures the costs of allocating maps of varying sizes.
+// This measures the costs of converting maps of varying sizes
+// from XDR to host format. The input is the size of the map,
+// the costs should be linear.
 impl HostCostMeasurement for ScMapToHostMapRun {
     const COST_TYPE: CostType = CostType::ScMapToHostMap;
-    const RUN_ITERATIONS: u64 = 100;
+    const RUN_ITERATIONS: u64 = 5;
 
     fn new_random_case(_host: &Host, rng: &mut StdRng, input: u64) -> Self {
         let input = input * 100;

--- a/soroban-env-host/benches/common/cost_types/scvec_to_host_vec.rs
+++ b/soroban-env-host/benches/common/cost_types/scvec_to_host_vec.rs
@@ -12,9 +12,11 @@ pub(crate) struct ScVecToHostVecRun {
     val: ScVal,
 }
 
-/// Measures the costs of allocating vectors of varying sizes.
+// This measures the costs of converting vectors of varying sizes from XDR to
+// host format. The input is the size of the map, the costs should be linear.
 impl HostCostMeasurement for ScVecToHostVecRun {
     const COST_TYPE: CostType = CostType::ScVecToHostVec;
+    const RUN_ITERATIONS: u64 = 5;
 
     fn new_random_case(_host: &Host, _rng: &mut StdRng, input: u64) -> Self {
         let input = input * 100;

--- a/soroban-env-host/benches/common/cost_types/util.rs
+++ b/soroban-env-host/benches/common/cost_types/util.rs
@@ -1,0 +1,12 @@
+use soroban_env_host::{EnvVal, Host, RawVal};
+
+pub(crate) fn to_envval_u32<I: Iterator<Item = u32>>(
+    host: &Host,
+    vals: I,
+) -> impl Iterator<Item = EnvVal<Host, RawVal>> {
+    let host = host.clone();
+    vals.map(move |v| EnvVal {
+        env: host.clone(),
+        val: RawVal::from_u32(v),
+    })
+}

--- a/soroban-env-host/benches/common/cost_types/verify_ed25519_sig.rs
+++ b/soroban-env-host/benches/common/cost_types/verify_ed25519_sig.rs
@@ -9,11 +9,15 @@ pub(crate) struct VerifyEd25519SigRun {
     sig: Signature,
 }
 
+// This measures the cost of verifying an Ed25519 signature of varying-length
+// messages. The input value is the length of the signed message. It should cost
+// linear CPU (for hashing) and zero heap memory.
 impl HostCostMeasurement for VerifyEd25519SigRun {
     const COST_TYPE: CostType = CostType::VerifyEd25519Sig;
+    const RUN_ITERATIONS: u64 = 3;
 
     fn new_random_case(_host: &Host, rng: &mut StdRng, input: u64) -> Self {
-        let size = input * 100;
+        let size = input * 10000;
         let keypair: Keypair = Keypair::generate(rng);
         let key: PublicKey = keypair.public.clone();
         let msg: Vec<u8> = (0..size).map(|x| x as u8).collect();

--- a/soroban-env-host/benches/common/cost_types/vm_instantiation.rs
+++ b/soroban-env-host/benches/common/cost_types/vm_instantiation.rs
@@ -7,6 +7,10 @@ pub(crate) struct VmInstantiationRun {
     wasm: Vec<u8>,
 }
 
+// This measures the cost of instantiating a host::Vm on a variety of possible
+// wasm modules, of different sizes. The input value should be the size of the
+// module, though for now we're just selecting modules from the fixed example
+// repertoire. Costs should be linear.
 impl HostCostMeasurement for VmInstantiationRun {
     const COST_TYPE: CostType = CostType::VmInstantiation;
     const RUN_ITERATIONS: u64 = 10;

--- a/soroban-env-host/benches/common/cost_types/wasm_insn_exec.rs
+++ b/soroban-env-host/benches/common/cost_types/wasm_insn_exec.rs
@@ -50,6 +50,9 @@ pub(crate) struct WasmInsnExecRun {
     vm: Rc<Vm>,
 }
 
+// This measures the cost of executing a block of WASM instructions. The
+// input value is the length of the instruction block. The CPU cost should
+// be linear in the length and the memory should be zero.
 impl HostCostMeasurement for WasmInsnExecRun {
     const COST_TYPE: CostType = CostType::WasmInsnExec;
 

--- a/soroban-env-host/benches/common/measure.rs
+++ b/soroban-env-host/benches/common/measure.rs
@@ -303,6 +303,7 @@ where
         let start = Instant::now();
         mem_tracker.0.store(0, Ordering::SeqCst);
         let alloc_guard = alloc_group_token.enter();
+        host.with_budget(|budget| budget.reset_inputs());
         cpu_insn_counter.begin();
         for iter in 0..HCM::RUN_ITERATIONS {
             m.run(iter, &host);
@@ -310,7 +311,7 @@ where
         let cpu_insns = cpu_insn_counter.end_and_count() / HCM::RUN_ITERATIONS;
         drop(alloc_guard);
         let stop = Instant::now();
-        let input = m.get_input(&host);
+        let input = m.get_input(&host) / HCM::RUN_ITERATIONS;
         let mem_bytes = mem_tracker.0.load(Ordering::SeqCst) / HCM::RUN_ITERATIONS;
         let time_nsecs = stop.duration_since(start).as_nanos() as u64 / HCM::RUN_ITERATIONS;
         ret.push(Measurement {

--- a/soroban-env-host/src/budget.rs
+++ b/soroban-env-host/src/budget.rs
@@ -533,7 +533,7 @@ impl Default for BudgetImpl {
                 }
                 CostType::ValXdrConv | CostType::ValSer | CostType::ValDeser => cpu.lin_param = 10,
                 CostType::CloneEvents => cpu.lin_param = 10,
-                CostType::HostObjAllocSlot => cpu.lin_param = 1000,
+                CostType::HostObjAllocSlot => cpu.const_param = 1000,
                 CostType::HostVecAllocCell => cpu.lin_param = 300,
                 CostType::HostMapAllocCell => {
                     cpu.const_param = 2000;

--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -634,9 +634,10 @@ impl Host {
 
     pub(crate) fn charge_for_new_host_object(
         &self,
+        prev_len: usize,
         ho: HostObject,
     ) -> Result<HostObject, HostError> {
-        self.charge_budget(CostType::HostObjAllocSlot, 1)?;
+        self.charge_budget(CostType::HostObjAllocSlot, prev_len as u64)?;
         match &ho {
             HostObject::Vec(v) => {
                 self.charge_budget(CostType::HostVecAllocCell, v.len() as u64)?;
@@ -678,16 +679,17 @@ impl Host {
         &self,
         hot: HOT,
     ) -> Result<HostObj, HostError> {
-        let handle = self.0.objects.borrow().len();
-        if handle > u32::MAX as usize {
+        let prev_len = self.0.objects.borrow().len();
+        if prev_len > u32::MAX as usize {
             return Err(self.err_status(ScHostObjErrorCode::ObjectCountExceedsU32Max));
         }
         self.0
             .objects
             .borrow_mut()
-            .push(self.charge_for_new_host_object(HOT::inject(hot))?);
+            .push(self.charge_for_new_host_object(prev_len, HOT::inject(hot))?);
         let env = WeakHost(Rc::downgrade(&self.0));
-        let v = Object::from_type_and_handle(HOT::get_type(), handle as u32);
+        let handle = prev_len as u32;
+        let v = Object::from_type_and_handle(HOT::get_type(), handle);
         Ok(EnvVal { env, val: v })
     }
 


### PR DESCRIPTION
This does a bit of refactoring, commenting and correcting calibration routines. It also adds the ability to run a single calibration benchmark by name by passing it on the command line.