### PR TITLE
Add missing conversion from Status->ScStatus for the ContractError variant

### DIFF
--- a/soroban-env-common/src/status.rs
+++ b/soroban-env-common/src/status.rs
@@ -161,6 +161,8 @@ impl TryFrom<Status> for ScStatus {
                 ScStatus::HostContextError((st.get_code() as i32).try_into()?)
             } else if st.is_type(ScStatusType::VmError) {
                 ScStatus::VmError((st.get_code() as i32).try_into()?)
+            } else if st.is_type(ScStatusType::ContractError) {
+                ScStatus::ContractError(st.get_code())
             } else {
                 return Err(stellar_xdr::Error::Invalid);
             }


### PR DESCRIPTION
### What
Add conversion from Status->ScStatus for the ContractError variant.

### Why
Contract error is a valid variant, but a Status with that value will result in an XDR invalid error because it is missing from this mapping.