### PR TITLE
Use stellar/binaries for binary installs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,7 +60,10 @@ jobs:
     - uses: stellar/actions/rust-cache@main
     - run: rustup update
     - run: rustup target add ${{ matrix.sys.target }}
-    - run: cargo install --target-dir ~/.cargo/target --locked --version 0.5.16 cargo-hack
+    - uses: stellar/binaries@v12
+      with:
+        name: cargo-hack
+        version: 0.5.16
     - run: cargo hack --feature-powerset check --locked --target ${{ matrix.sys.target }}
     - if: matrix.sys.test
       run: cargo hack --feature-powerset test --locked --target ${{ matrix.sys.target }}


### PR DESCRIPTION
### What
Use stellar/binaries for binary installs.

### Why
To avoid rebuilding tools.