### PR TITLE
Bug 554 - fix stack overflow

### DIFF
--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -63,7 +63,7 @@ use self::metered_vector::MeteredVector;
 // Notes on metering: `RollbackPoint` are metered under Frame operations
 #[derive(Clone)]
 pub(crate) struct RollbackPoint {
-    storage: MeteredOrdMap<LedgerKey, Option<LedgerEntry>>,
+    storage: MeteredOrdMap<Box<LedgerKey>, Option<Box<LedgerEntry>>>,
     objects: usize,
 }
 

--- a/soroban-env-host/src/host/metered_map.rs
+++ b/soroban-env-host/src/host/metered_map.rs
@@ -43,12 +43,21 @@ impl<K, V> Default for MeteredOrdMap<K, V> {
     }
 }
 
+fn check_size_is_small<T>(name: &str) {
+    let sz = core::mem::size_of::<T>();
+    if sz > 64 {
+        panic!("type '{}' is too big: {}", name, sz);
+    }
+}
+
 impl<K, V> MeteredOrdMap<K, V>
 where
     K: Ord + Clone,
     V: Clone,
 {
     pub fn new(budget: Budget) -> Result<Self, HostError> {
+        check_size_is_small::<K>("key");
+        check_size_is_small::<V>("val");
         budget.charge(CostType::ImMapNew, 1)?;
         Ok(MeteredOrdMap {
             budget,
@@ -57,6 +66,8 @@ where
     }
 
     pub fn from_map(budget: Budget, map: OrdMap<K, V>) -> Result<Self, HostError> {
+        check_size_is_small::<K>("key");
+        check_size_is_small::<V>("val");
         budget.charge(CostType::ImMapNew, 1)?;
         Ok(MeteredOrdMap { budget, map })
     }

--- a/soroban-env-host/src/test/account.rs
+++ b/soroban-env-host/src/test/account.rs
@@ -22,7 +22,7 @@ fn check_account_exists() -> Result<(), HostError> {
     footprint.record_access(&lk1, AccessType::ReadOnly).unwrap();
 
     let mut map = im_rc::OrdMap::default();
-    map.insert(lk0, Some(le0));
+    map.insert(Box::new(lk0), Some(Box::new(le0)));
     let storage = Storage::with_enforcing_footprint_and_map(
         footprint,
         MeteredOrdMap {

--- a/soroban-env-host/src/test/bytes.rs
+++ b/soroban-env-host/src/test/bytes.rs
@@ -188,7 +188,7 @@ fn linear_memory_operations() -> Result<(), HostError> {
         }),
         ext: LedgerEntryExt::V0,
     };
-    let map = OrdMap::unit(storage_key.clone(), Some(le));
+    let map = OrdMap::unit(Box::new(storage_key.clone()), Some(Box::new(le)));
     let mut footprint = Footprint::default();
     footprint.record_access(&storage_key, AccessType::ReadOnly)?;
 

--- a/soroban-env-host/src/test/util.rs
+++ b/soroban-env-host/src/test/util.rs
@@ -89,7 +89,7 @@ impl Host {
                 }),
                 ext: LedgerEntryExt::V0,
             };
-            map.insert(storage_key.clone(), Some(le));
+            map.insert(Box::new(storage_key.clone()), Some(Box::new(le)));
             footprint
                 .record_access(&storage_key, AccessType::ReadOnly)
                 .unwrap();


### PR DESCRIPTION
First things first: this _only_ applies to debug builds. In opt builds you can build gigantic maps with no stack overflows (run the included-but-marked-as-`ignore` tests with `cargo test --release unittests -- --include-ignored`).

However, users get a _debug_ build of the host when they run contract unit tests in native local testing mode, and they can (apparently have in the wild) done things that produce large maps in those tests, and that can produce stack overflows and process aborts. Bad experience.

What goes wrong?

The insert path of `im` allocates a handful of interior B-tree nodes "by value" / as local variables held on the stack while it's rebalancing its B-tree. Interior B-tree nodes are fixed-size arrays of 64 copies of a (key,val) entry, and for maps storing `LedgerKey` and `LedgerVal` -- which the `storage` subsystem of the host does -- the entry size adds up to over 300 bytes, such that each interior B-tree node is over 20kb. Empirically, if users add a few thousand nodes, we get a few levels of B-tree splitting deep, and _debug builds_ wind up using several hundred KB with those 20KB+ stack slots _in each frame_, so the deepest frame hits the conventional 2MB thread stack limit on linux.

A more-complete solution would probably be to patch `im` to allocate fewer interior nodes, and/or to make the rust compiler and/or LLVM do more aggressive reuse of stack slots in debug builds, or .. whatever. But the _easy_ fix is just to make the key and value types in the map smaller by indirection behind `Box<...>`, which is what I'm doing here.

I checked (and left it in another of the ignored tests) that this lets debug builds get up past 16 million entries without problem. Probably much further, but it takes many minutes to run that test in a debug build, so I stopped there. I left a 64k-entry test (that finishes in a reasonable time even in debug builds).

Fixes #554 
