### PR TITLE
Fix loan stellar-xdr 0.0.6 version stuck in the past

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,7 +1056,7 @@ dependencies = [
  "soroban-env-macros",
  "soroban-wasmi",
  "static_assertions",
- "stellar-xdr 0.0.7",
+ "stellar-xdr",
 ]
 
 [[package]]
@@ -1108,7 +1108,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "stellar-xdr 0.0.6",
+ "stellar-xdr",
  "syn",
 ]
 
@@ -1170,12 +1170,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "stellar-xdr"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc8646f7ff2122e5d1f82ea754cedd883f30996056a5a92fd9d557db0d2a3b7"
 
 [[package]]
 name = "stellar-xdr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ members = [
 
 exclude = ["soroban-test-wasms/wasm-workspace"]
 
+[workspace.dependencies]
+stellar-xdr = "0.0.7"
+wasmi = { package = "soroban-wasmi", version = "0.16.0-soroban1" }
+
 [patch.crates-io]
 soroban-env-common = { path = "soroban-env-common" }
 soroban-env-host = { path = "soroban-env-host" }

--- a/soroban-env-common/Cargo.toml
+++ b/soroban-env-common/Cargo.toml
@@ -12,8 +12,8 @@ rust-version = "1.64"
 
 [dependencies]
 soroban-env-macros = { version = "0.0.7" }
-stellar-xdr = { version = "0.0.7", default-features = false, features = [ "next" ] }
-wasmi = { package = "soroban-wasmi", version = "0.16.0-soroban1", optional = true }
+stellar-xdr = { workspace = true, default-features = false, features = [ "next" ] }
+wasmi = { workspace = true, optional = true }
 static_assertions = "1.1.0"
 
 [features]

--- a/soroban-env-macros/Cargo.toml
+++ b/soroban-env-macros/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.64"
 proc-macro = true
 
 [dependencies]
-stellar-xdr = { version = "0.0.6", features = ["next", "std"] }
+stellar-xdr = { workspace = true, features = ["next", "std"] }
 syn = {version="1.0",features=["full"]}
 quote = "1.0"
 proc-macro2 = "1.0"


### PR DESCRIPTION
### What
Change stellar-xdr that was on one package to match stellar-xdr on all other packages. Updated workspace toml to use workspace dependencies.

### Why
The use of stellar-xdr should be consistent across all these crates. Unlikely nothing bad will happen in this case, but it's good practice I think to avoid surprises. Also, the stellar-xdr crate is huge, and having to build 2x of the crate on every build is time consuming.

The use of workspace dependencies is new in Rust 1.64, and it allows us to define a version in one place for all crates. This will prevent this same problem from happening.