### PR TITLE
Add Host::with_artificial_test_contract_frame

### DIFF
--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -438,6 +438,25 @@ impl Host {
         res
     }
 
+    /// Pushes an artificial [`Frame`], runs a closure, and then pops the frame, rolling back
+    /// if the closure returned an error. Returns the result that the closure
+    /// returned (or any error caused during the frame push/pop).
+    // Notes on metering: `GuardFrame` charges on the work done on protecting the `context`.
+    /// It does not cover the cost of the actual closure call. The closure needs to be
+    /// metered separately.
+    #[cfg(any(test, feature = "testutils"))]
+    pub fn with_artificial_test_contract_frame<F>(
+        &self,
+        id: Hash,
+        func: Symbol,
+        f: F,
+    ) -> Result<RawVal, HostError>
+    where
+        F: FnOnce() -> Result<RawVal, HostError>,
+    {
+        self.with_frame(Frame::TestContract(TestContractFrame::new(id, func)), f)
+    }
+
     /// Returns [`Hash`] contract ID from the VM frame at the top of the context
     /// stack, or a [`HostError`] if the context stack is empty or has a non-VM
     /// frame at its top.

--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -438,7 +438,7 @@ impl Host {
         res
     }
 
-    /// Pushes an test contract [`Frame`], runs a closure, and then pops the
+    /// Pushes a test contract [`Frame`], runs a closure, and then pops the
     /// frame, rolling back if the closure returned an error. Returns the result
     /// that the closure returned (or any error caused during the frame
     /// push/pop). Used for testing.

--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -438,12 +438,12 @@ impl Host {
         res
     }
 
-    /// Pushes an artificial [`Frame`], runs a closure, and then pops the frame,
-    /// rolling back if the closure returned an error. Returns the result that
-    /// the closure returned (or any error caused during the frame push/pop).
-    /// Used for testing.
+    /// Pushes an test contract [`Frame`], runs a closure, and then pops the
+    /// frame, rolling back if the closure returned an error. Returns the result
+    /// that the closure returned (or any error caused during the frame
+    /// push/pop). Used for testing.
     #[cfg(any(test, feature = "testutils"))]
-    pub fn with_artificial_test_contract_frame<F>(
+    pub fn with_test_contract_frame<F>(
         &self,
         id: Hash,
         func: Symbol,

--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -438,12 +438,10 @@ impl Host {
         res
     }
 
-    /// Pushes an artificial [`Frame`], runs a closure, and then pops the frame, rolling back
-    /// if the closure returned an error. Returns the result that the closure
-    /// returned (or any error caused during the frame push/pop).
-    // Notes on metering: `GuardFrame` charges on the work done on protecting the `context`.
-    /// It does not cover the cost of the actual closure call. The closure needs to be
-    /// metered separately.
+    /// Pushes an artificial [`Frame`], runs a closure, and then pops the frame,
+    /// rolling back if the closure returned an error. Returns the result that
+    /// the closure returned (or any error caused during the frame push/pop).
+    /// Used for testing.
     #[cfg(any(test, feature = "testutils"))]
     pub fn with_artificial_test_contract_frame<F>(
         &self,


### PR DESCRIPTION
### What
Add Host::with_artificial_test_contract_frame that executes a function inside a test frame artificially created that may not reference a contract that is actually deployed.

### Why
To support the SDK providing functionality where logic is executed as a contract, without the contract having to provide that logic itself. This is helpful in testing.

For https://github.com/stellar/rs-soroban-sdk/pull/761
Close https://github.com/stellar/rs-soroban-sdk/issues/739