### PR TITLE
Add support for auth_required in the token contract

### DIFF
--- a/soroban-env-host/src/native_contract/token/balance.rs
+++ b/soroban-env-host/src/native_contract/token/balance.rs
@@ -83,7 +83,10 @@ pub fn receive_balance(e: &Host, id: Identifier, amount: BigInt) -> Result<(), H
         if balance.authorized {
             write_balance_and_auth(e, id, (balance.amount + amount)?, true)
         } else {
-            Err(e.err_status_msg(ContractError::BalanceFrozenError, "balance is frozen"))
+            Err(e.err_status_msg(
+                ContractError::BalanceDeauthorizedError,
+                "balance is deauthorized",
+            ))
         }
     } else if is_asset_auth_required(e)? {
         // Balance does not exist, so now we need to enforce auth_required IF this is a wrapped token
@@ -117,7 +120,10 @@ pub fn spend_balance(e: &Host, id: Identifier, amount: BigInt) -> Result<(), Hos
                 write_balance_and_auth(e, id, (balance.amount - amount)?, true)
             }
         } else {
-            Err(e.err_status_msg(ContractError::BalanceFrozenError, "balance is frozen"))
+            Err(e.err_status_msg(
+                ContractError::BalanceDeauthorizedError,
+                "balance is deauthorized",
+            ))
         }
     } else {
         Err(e.err_status_msg(ContractError::BalanceError, "balance does not exist"))

--- a/soroban-env-host/src/native_contract/token/balance.rs
+++ b/soroban-env-host/src/native_contract/token/balance.rs
@@ -14,17 +14,6 @@ use soroban_env_common::{CheckedEnv, TryIntoVal};
 use super::error::ContractError;
 use super::storage_types::BalanceValue;
 
-// Metering: *mostly* covered by components. Not sure about `try_into_val`.
-pub fn read_balance(e: &Host, id: Identifier) -> Result<BigInt, HostError> {
-    let key = DataKey::Balance(id);
-    if let Ok(balance) = e.get_contract_data(key.try_into_val(e)?) {
-        let balance: BalanceValue = balance.try_into_val(e)?;
-        Ok(balance.amount)
-    } else {
-        Ok(BigInt::from_u64(e, 0)?)
-    }
-}
-
 fn is_issuer_auth_required(e: &Host, issuer_id: AccountId) -> Result<bool, HostError> {
     let lk = e.to_account_key(issuer_id);
     e.with_mut_storage(|storage| {
@@ -61,73 +50,85 @@ fn is_asset_auth_required(e: &Host) -> Result<bool, HostError> {
     }
 }
 
-// Metering: *mostly* covered by components. Not sure about `try_into_val`.
-fn write_balance(e: &Host, id: Identifier, amount: BigInt) -> Result<(), HostError> {
-    let raw_key = DataKey::Balance(id).try_into_val(e)?;
-
-    if let Ok(raw_balance) = e.get_contract_data(raw_key) {
-        let mut balance: BalanceValue = raw_balance.try_into_val(e)?;
-        balance.amount = amount;
-        e.put_contract_data(raw_key, balance.try_into_val(e)?)?;
-    } else {
-        // Balance does not exist, so now we need to enforce auth_required IF this is a wrapped token
-        // with an auth_required issuer.
-        if is_asset_auth_required(e)? {
-            return Err(e.err_status_msg(
-                ContractError::IssuerAuthRequiredError,
-                "Issuer is auth required",
-            ));
-        } else {
-            e.put_contract_data(
-                raw_key,
-                BalanceValue {
-                    amount,
-                    authorized: true,
-                }
-                .try_into_val(e)?,
-            )?;
-        }
-    }
+fn write_balance_and_auth(
+    e: &Host,
+    id: Identifier,
+    amount: BigInt,
+    authorized: bool,
+) -> Result<(), HostError> {
+    let key = DataKey::Balance(id);
+    e.put_contract_data(
+        key.try_into_val(e)?,
+        BalanceValue { amount, authorized }.try_into_val(e)?,
+    )?;
     Ok(())
+}
+
+// Metering: *mostly* covered by components. Not sure about `try_into_val`.
+pub fn read_balance(e: &Host, id: Identifier) -> Result<BigInt, HostError> {
+    let key = DataKey::Balance(id);
+    if let Ok(balance) = e.get_contract_data(key.try_into_val(e)?) {
+        let balance: BalanceValue = balance.try_into_val(e)?;
+        Ok(balance.amount)
+    } else {
+        Ok(BigInt::from_u64(e, 0)?)
+    }
 }
 
 // Metering: covered by components.
 pub fn receive_balance(e: &Host, id: Identifier, amount: BigInt) -> Result<(), HostError> {
-    let balance = read_balance(e, id.clone())?;
-    let is_authorized = read_authorization(e, id.clone())?;
-    if is_authorized {
-        write_balance(e, id, (balance + amount)?)
+    let key = DataKey::Balance(id.clone());
+    if let Ok(balance) = e.get_contract_data(key.try_into_val(e)?) {
+        let balance: BalanceValue = balance.try_into_val(e)?;
+        if balance.authorized {
+            write_balance_and_auth(e, id, (balance.amount + amount)?, true)
+        } else {
+            Err(e.err_status_msg(ContractError::BalanceFrozenError, "balance is frozen"))
+        }
+    } else if is_asset_auth_required(e)? {
+        // Balance does not exist, so now we need to enforce auth_required IF this is a wrapped token
+        // with an auth_required issuer.
+        Err(e.err_status_msg(
+            ContractError::IssuerAuthRequiredError,
+            "issuer is auth required",
+        ))
     } else {
-        Err(e.err_status_msg(ContractError::BalanceFrozenError, "balance is frozen"))
+        // Write a new authorized balance
+        write_balance_and_auth(e, id, amount, true)
     }
 }
 
 // Metering: covered by components.
 pub fn spend_balance(e: &Host, id: Identifier, amount: BigInt) -> Result<(), HostError> {
-    let balance = read_balance(e, id.clone())?;
-    let is_authorized = read_authorization(e, id.clone())?;
-    if is_authorized {
-        if balance.compare(&amount)? == Ordering::Less {
-            Err(err!(
-                e,
-                ContractError::BalanceError,
-                "balance is not sufficient to spend: {} < {}",
-                balance,
-                amount
-            ))
+    let key = DataKey::Balance(id.clone());
+    if let Ok(balance) = e.get_contract_data(key.try_into_val(e)?) {
+        let balance: BalanceValue = balance.try_into_val(e)?;
+        if balance.authorized {
+            if balance.amount.compare(&amount)? == Ordering::Less {
+                Err(err!(
+                    e,
+                    ContractError::BalanceError,
+                    "balance is not sufficient to spend: {} < {}",
+                    balance,
+                    amount
+                ))
+            } else {
+                // Write if balance exists, is authorized, and has sufficient funds
+                write_balance_and_auth(e, id, (balance.amount - amount)?, true)
+            }
         } else {
-            write_balance(e, id, (balance - amount)?)
+            Err(e.err_status_msg(ContractError::BalanceFrozenError, "balance is frozen"))
         }
     } else {
-        Err(e.err_status_msg(ContractError::BalanceFrozenError, "balance is frozen"))
+        Err(e.err_status_msg(ContractError::BalanceError, "balance does not exist"))
     }
 }
 
 // Metering: *mostly* covered by components. Not sure about `try_into_val`.
 pub fn read_authorization(e: &Host, id: Identifier) -> Result<bool, HostError> {
     let key = DataKey::Balance(id);
-    if let Ok(balance) = e.get_contract_data(key.try_into_val(e)?) {
-        let balance: BalanceValue = balance.try_into_val(e)?;
+    if let Ok(raw_balance) = e.get_contract_data(key.try_into_val(e)?) {
+        let balance: BalanceValue = raw_balance.try_into_val(e)?;
         Ok(balance.authorized)
     } else {
         Ok(!is_asset_auth_required(e)?)
@@ -136,26 +137,15 @@ pub fn read_authorization(e: &Host, id: Identifier) -> Result<bool, HostError> {
 
 // Metering: *mostly* covered by components. Not sure about `try_into_val`.
 pub fn write_authorization(e: &Host, id: Identifier, authorized: bool) -> Result<(), HostError> {
-    let raw_key = DataKey::Balance(id).try_into_val(e)?;
-
-    if let Ok(raw_balance) = e.get_contract_data(raw_key) {
-        let mut balance: BalanceValue = raw_balance.try_into_val(e)?;
-        balance.authorized = authorized;
-        e.put_contract_data(raw_key, balance.try_into_val(e)?)?;
+    let key = DataKey::Balance(id.clone());
+    if let Ok(raw_balance) = e.get_contract_data(key.try_into_val(e)?) {
+        let balance: BalanceValue = raw_balance.try_into_val(e)?;
+        write_balance_and_auth(e, id, balance.amount, authorized)
     } else {
         // Balance does not exist, so write a 0 amount along with the authorization flag.
         // No need to check auth_required because this function can only be called by the admin.
-        e.put_contract_data(
-            raw_key,
-            BalanceValue {
-                amount: BigInt::from_u64(&e, 0)?,
-                authorized,
-            }
-            .try_into_val(e)?,
-        )?;
+        write_balance_and_auth(e, id, BigInt::from_u64(&e, 0)?, authorized)
     }
-
-    Ok(())
 }
 
 // Metering: covered by components

--- a/soroban-env-host/src/native_contract/token/error.rs
+++ b/soroban-env-host/src/native_contract/token/error.rs
@@ -17,6 +17,7 @@ pub enum ContractError {
     AllowanceError = 10,
     BalanceError = 11,
     BalanceFrozenError = 12,
+    IssuerAuthRequiredError = 13,
 }
 
 impl From<ContractError> for Status {

--- a/soroban-env-host/src/native_contract/token/error.rs
+++ b/soroban-env-host/src/native_contract/token/error.rs
@@ -16,7 +16,7 @@ pub enum ContractError {
     NegativeAmountError = 9,
     AllowanceError = 10,
     BalanceError = 11,
-    BalanceFrozenError = 12,
+    BalanceDeauthorizedError = 12,
     IssuerAuthRequiredError = 13,
 }
 

--- a/soroban-env-host/src/native_contract/token/event.rs
+++ b/soroban-env-host/src/native_contract/token/event.rs
@@ -60,17 +60,17 @@ pub(crate) fn burn(
     Ok(())
 }
 
-pub(crate) fn freeze(e: &Host, admin: Identifier, id: Identifier) -> Result<(), HostError> {
+pub(crate) fn de_auth(e: &Host, admin: Identifier, id: Identifier) -> Result<(), HostError> {
     let mut topics = Vec::new(e)?;
-    topics.push(Symbol::from_str("freeze"))?;
+    topics.push(Symbol::from_str("de_auth"))?;
     topics.push(admin)?;
     e.contract_event(topics.into(), id.try_into_val(e)?)?;
     Ok(())
 }
 
-pub(crate) fn unfreeze(e: &Host, admin: Identifier, id: Identifier) -> Result<(), HostError> {
+pub(crate) fn authorize(e: &Host, admin: Identifier, id: Identifier) -> Result<(), HostError> {
     let mut topics = Vec::new(e)?;
-    topics.push(Symbol::from_str("unfreeze"))?;
+    topics.push(Symbol::from_str("authorize"))?;
     topics.push(admin)?;
     e.contract_event(topics.into(), id.try_into_val(e)?)?;
     Ok(())

--- a/soroban-env-host/src/native_contract/token/storage_types.rs
+++ b/soroban-env-host/src/native_contract/token/storage_types.rs
@@ -1,4 +1,4 @@
-use crate::native_contract::base_types::Map;
+use crate::native_contract::base_types::{BigInt, Map};
 use crate::native_contract::token::public_types::Identifier;
 use soroban_env_common::TryIntoVal;
 use soroban_native_sdk_macros::contracttype;
@@ -14,7 +14,12 @@ pub enum DataKey {
     Allowance(AllowanceDataKey),
     Balance(Identifier),
     Nonce(Identifier),
-    State(Identifier),
     Admin,
     Metadata,
+}
+
+#[contracttype]
+pub struct BalanceValue {
+    pub amount: BigInt,
+    pub authorized: bool,
 }

--- a/soroban-env-host/src/native_contract/token/test_token.rs
+++ b/soroban-env-host/src/native_contract/token/test_token.rs
@@ -187,7 +187,7 @@ impl<'a> TestToken<'a> {
             .try_into()?)
     }
 
-    pub(crate) fn freeze(
+    pub(crate) fn de_auth(
         &self,
         admin: &TestSigner,
         nonce: BigInt,
@@ -196,7 +196,7 @@ impl<'a> TestToken<'a> {
         let signature = sign_args(
             self.host,
             admin,
-            "freeze",
+            "de_auth",
             &self.id,
             host_vec![
                 self.host,
@@ -210,13 +210,13 @@ impl<'a> TestToken<'a> {
             .host
             .call(
                 self.id.clone().into(),
-                Symbol::from_str("freeze").into(),
+                Symbol::from_str("de_auth").into(),
                 host_vec![self.host, signature, nonce, id].into(),
             )?
             .try_into()?)
     }
 
-    pub(crate) fn unfreeze(
+    pub(crate) fn authorize(
         &self,
         admin: &TestSigner,
         nonce: BigInt,
@@ -225,7 +225,7 @@ impl<'a> TestToken<'a> {
         let signature = sign_args(
             self.host,
             admin,
-            "unfreeze",
+            "authorize",
             &self.id,
             host_vec![
                 self.host,
@@ -239,18 +239,18 @@ impl<'a> TestToken<'a> {
             .host
             .call(
                 self.id.clone().into(),
-                Symbol::from_str("unfreeze").into(),
+                Symbol::from_str("authorize").into(),
                 host_vec![self.host, signature, nonce, id].into(),
             )?
             .try_into()?)
     }
 
-    pub(crate) fn is_frozen(&self, id: Identifier) -> Result<bool, HostError> {
+    pub(crate) fn is_deauth(&self, id: Identifier) -> Result<bool, HostError> {
         Ok(self
             .host
             .call(
                 self.id.clone().into(),
-                Symbol::from_str("is_frozen").into(),
+                Symbol::from_str("is_deauth").into(),
                 host_vec![self.host, id].into(),
             )?
             .try_into_val(self.host)?)

--- a/soroban-env-host/src/test/token.rs
+++ b/soroban-env-host/src/test/token.rs
@@ -1052,7 +1052,7 @@ fn test_transfer_with_allowance() {
 }
 
 #[test]
-fn test_freeze_and_unfreeze() {
+fn test_deauth_and_authorize() {
     let test = TokenTest::setup();
     let admin = TestSigner::Ed25519(&test.admin_key);
     let token = test.default_smart_token(&admin);
@@ -1076,18 +1076,18 @@ fn test_freeze_and_unfreeze() {
         )
         .unwrap();
 
-    assert!(!token.is_frozen(user.get_identifier(&test.host)).unwrap());
+    assert!(!token.is_deauth(user.get_identifier(&test.host)).unwrap());
 
-    // Freeze the balance of `user`.
+    // Deauthorize the balance of `user`.
     token
-        .freeze(
+        .de_auth(
             &admin,
             token.nonce(admin.get_identifier(&test.host)).unwrap(),
             user.get_identifier(&test.host),
         )
         .unwrap();
 
-    assert!(token.is_frozen(user.get_identifier(&test.host)).unwrap());
+    assert!(token.is_deauth(user.get_identifier(&test.host)).unwrap());
     // Make sure neither outgoing nor incoming balance transfers are possible.
     assert_eq!(
         to_contract_err(
@@ -1118,16 +1118,16 @@ fn test_freeze_and_unfreeze() {
         ContractError::BalanceFrozenError
     );
 
-    // Unfreeze the balance of `user`.
+    // Authorize the balance of `user`.
     token
-        .unfreeze(
+        .authorize(
             &admin,
             token.nonce(admin.get_identifier(&test.host)).unwrap(),
             user.get_identifier(&test.host),
         )
         .unwrap();
 
-    assert!(!token.is_frozen(user.get_identifier(&test.host)).unwrap());
+    assert!(!token.is_deauth(user.get_identifier(&test.host)).unwrap());
     // Make sure balance transfers are possible now.
     token
         .xfer(
@@ -1283,7 +1283,7 @@ fn test_set_admin() {
     assert_eq!(
         to_contract_err(
             token
-                .freeze(
+                .de_auth(
                     &admin,
                     token.nonce(admin.get_identifier(&test.host)).unwrap(),
                     new_admin.get_identifier(&test.host),
@@ -1296,7 +1296,7 @@ fn test_set_admin() {
     assert_eq!(
         to_contract_err(
             token
-                .unfreeze(
+                .authorize(
                     &admin,
                     token.nonce(admin.get_identifier(&test.host)).unwrap(),
                     new_admin.get_identifier(&test.host),
@@ -1325,14 +1325,14 @@ fn test_set_admin() {
         )
         .unwrap();
     token
-        .freeze(
+        .de_auth(
             &new_admin,
             token.nonce(new_admin.get_identifier(&test.host)).unwrap(),
             admin.get_identifier(&test.host),
         )
         .unwrap();
     token
-        .unfreeze(
+        .authorize(
             &new_admin,
             token.nonce(new_admin.get_identifier(&test.host)).unwrap(),
             admin.get_identifier(&test.host),

--- a/soroban-env-host/src/test/token.rs
+++ b/soroban-env-host/src/test/token.rs
@@ -1101,7 +1101,7 @@ fn test_deauth_and_authorize() {
                 .err()
                 .unwrap()
         ),
-        ContractError::BalanceFrozenError
+        ContractError::BalanceDeauthorizedError
     );
     assert_eq!(
         to_contract_err(
@@ -1115,7 +1115,7 @@ fn test_deauth_and_authorize() {
                 .err()
                 .unwrap()
         ),
-        ContractError::BalanceFrozenError
+        ContractError::BalanceDeauthorizedError
     );
 
     // Authorize the balance of `user`.


### PR DESCRIPTION
### What

This is a prototype for auth_required support in the built-in token contract. When new balances are written, the contract will check if auth_required is set on the issuer, and if so, fail with an error. One significant change here is that the is_frozen flag was removed (stored in `DataKey::State`) and replaced with an authorized boolean that exists in the same `ContractDataEntry` as the balance.

There are still some TODO's to address, tests to write, and naming issues to resolve (like freeze vs deauthorize) but I wanted to see if anyone had an issue with this change at a high level.
