### PR TITLE
Bump version to v0.0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1062,7 +1062,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "crate-git-revision",
  "serde",
@@ -1074,7 +1074,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -1082,7 +1082,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "backtrace",
  "bytes-lit",
@@ -1116,7 +1116,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-native-sdk-macros"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1137,7 +1137,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-synth-wasm"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "expect-test",
  "soroban-env-common",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-test-wasms"
-version = "0.0.9"
+version = "0.0.10"
 
 [[package]]
 name = "soroban-wasmi"
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "test_no_std"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "soroban-env-common",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,14 +15,14 @@ members = [
 exclude = ["soroban-test-wasms/wasm-workspace"]
 
 [workspace.package]
-version = "0.0.9"
+version = "0.0.10"
 
 [workspace.dependencies]
-soroban-env-common = { version = "0.0.9", path = "soroban-env-common" }
-soroban-env-guest = { version = "0.0.9", path = "soroban-env-guest" }
-soroban-env-host = { version = "0.0.9", path = "soroban-env-host" }
-soroban-env-macros = { version = "0.0.9", path = "soroban-env-macros" }
-soroban-native-sdk-macros = { version = "0.0.9", path = "soroban-native-sdk-macros" }
+soroban-env-common = { version = "0.0.10", path = "soroban-env-common" }
+soroban-env-guest = { version = "0.0.10", path = "soroban-env-guest" }
+soroban-env-host = { version = "0.0.10", path = "soroban-env-host" }
+soroban-env-macros = { version = "0.0.10", path = "soroban-env-macros" }
+soroban-native-sdk-macros = { version = "0.0.10", path = "soroban-native-sdk-macros" }
 
 [workspace.dependencies.stellar-xdr]
 version = "0.0.9"


### PR DESCRIPTION
### What
Bump version to v0.0.10.

### Why
Doing this manually because cargo-workspaces is broken.