### PR TITLE
Upgrade crate-git-revision to 0.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,6 +239,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "crate-git-revision"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f998aef136a4e7833b0e4f0fc0939a59c40140b28e0ffbf524ad84fb2cc568c8"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1064,7 +1075,7 @@ dependencies = [
 name = "soroban-env-common"
 version = "0.0.10"
 dependencies = [
- "crate-git-revision",
+ "crate-git-revision 0.0.4",
  "serde",
  "soroban-env-macros",
  "soroban-wasmi",
@@ -1190,7 +1201,7 @@ version = "0.0.9"
 source = "git+https://github.com/stellar/rs-stellar-xdr?rev=1309e3de#1309e3de46fcb01743f818831de3a9ac4a5b1ab6"
 dependencies = [
  "base64",
- "crate-git-revision",
+ "crate-git-revision 0.0.3",
  "hex",
  "serde",
  "serde_with",

--- a/soroban-env-common/Cargo.toml
+++ b/soroban-env-common/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 rust-version = "1.65"
 
 [build_dependencies]
-crate-git-revision = "0.0.3"
+crate-git-revision = "0.0.4"
 
 [dependencies]
 soroban-env-macros = { workspace = true }

--- a/soroban-test-wasms/wasm-workspace/Cargo.lock
+++ b/soroban-test-wasms/wasm-workspace/Cargo.lock
@@ -146,26 +146,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_format"
-version = "0.2.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7309d9b4d3d2c0641e018d449232f2e28f1b22933c137f157d3dbc14228b8c0e"
-dependencies = [
- "const_format_proc_macros",
-]
-
-[[package]]
-name = "const_format_proc_macros"
-version = "0.2.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f47bf7270cf70d370f8f98c1abb6d2d4cf60a6845d30e05bfb90c6568650"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "crate-git-revision"
-version = "0.0.2"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bf26dd21fe3d2cfed5afaedba648f944ba425e39083d1b86b6993e0d71b430"
+checksum = "78cea8a8c6f40508aa6292231db40fe5b4968f6959fefcad608e528b50657564"
 dependencies = [
  "serde",
  "serde_derive",
@@ -926,16 +906,19 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.9"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=eda2ab70#eda2ab70fbc2a9f78a12f54a211e308d1b6ac1b7"
 dependencies = [
+ "crate-git-revision",
  "soroban-env-macros",
  "soroban-wasmi",
  "static_assertions",
- "stellar-xdr 0.0.7 (git+https://github.com/stellar/rs-stellar-xdr?rev=dc7bee80)",
+ "stellar-xdr",
 ]
 
 [[package]]
 name = "soroban-env-guest"
 version = "0.0.9"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=eda2ab70#eda2ab70fbc2a9f78a12f54a211e308d1b6ac1b7"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -944,6 +927,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.9"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=eda2ab70#eda2ab70fbc2a9f78a12f54a211e308d1b6ac1b7"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -966,17 +950,19 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.9"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=eda2ab70#eda2ab70fbc2a9f78a12f54a211e308d1b6ac1b7"
 dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "stellar-xdr 0.0.7 (git+https://github.com/stellar/rs-stellar-xdr?rev=dc7bee80)",
+ "stellar-xdr",
  "syn",
 ]
 
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.9"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=eda2ab70#eda2ab70fbc2a9f78a12f54a211e308d1b6ac1b7"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1008,7 +994,7 @@ dependencies = [
  "sha2 0.10.6",
  "soroban-env-common",
  "soroban-spec",
- "stellar-xdr 0.0.7 (git+https://github.com/stellar/rs-stellar-xdr?rev=e88f9fa7)",
+ "stellar-xdr",
  "syn",
 ]
 
@@ -1026,8 +1012,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.6",
- "soroban-env-host",
- "stellar-xdr 0.0.7 (git+https://github.com/stellar/rs-stellar-xdr?rev=e88f9fa7)",
+ "stellar-xdr",
  "syn",
  "thiserror",
  "wasmparser",
@@ -1035,8 +1020,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-wasmi"
-version = "0.16.0-soroban1"
-source = "git+https://github.com/stellar/wasmi?rev=d1ec0036#d1ec0036a002a14227b0b09117f0dc6182ae19e4"
+version = "0.16.0-soroban2"
+source = "git+https://github.com/stellar/wasmi?rev=862b32f5#862b32f53f9c6223911e79e0b0fc8592fb3bb04c"
 dependencies = [
  "soroban-wasmi_core",
  "spin",
@@ -1045,8 +1030,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-wasmi_core"
-version = "0.16.0-soroban1"
-source = "git+https://github.com/stellar/wasmi?rev=d1ec0036#d1ec0036a002a14227b0b09117f0dc6182ae19e4"
+version = "0.16.0-soroban2"
+source = "git+https://github.com/stellar/wasmi?rev=862b32f5#862b32f53f9c6223911e79e0b0fc8592fb3bb04c"
 dependencies = [
  "downcast-rs",
  "libm",
@@ -1079,22 +1064,13 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "0.0.7"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=dc7bee80#dc7bee80026d409220919b1d8e92757bc9a3150f"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=2775f4b6#2775f4b6f6ce2c9fcc22af42b0709d1047fabf8f"
 dependencies = [
  "base64",
- "const_format",
  "crate-git-revision",
  "hex",
  "serde",
  "serde_with",
-]
-
-[[package]]
-name = "stellar-xdr"
-version = "0.0.7"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=e88f9fa7#e88f9fa7ab3d0f54efb5cee8499ef9080f4d41f4"
-dependencies = [
- "hex",
 ]
 
 [[package]]
@@ -1368,3 +1344,15 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[patch.unused]]
+name = "soroban-env-common"
+version = "0.0.10"
+
+[[patch.unused]]
+name = "soroban-env-guest"
+version = "0.0.10"
+
+[[patch.unused]]
+name = "soroban-env-host"
+version = "0.0.10"


### PR DESCRIPTION
### What

Upgrade crate-git-revision to 0.0.4

### Why

Per https://github.com/stellar/crate-git-revision/pull/9, when used as a git dependency, crate-git-revision 0.0.3 fails to find the correct git directory for soroban-common-env, causing the crate to always be rebuilt.
This upgrade fixes the issue, which I have verified manually.

### Known limitations

The lockfiles here end up with multiple copies of crate-git-revision.