### PR TITLE
Remove `EnvVal`

### DIFF
--- a/soroban-env-common/src/bitset.rs
+++ b/soroban-env-common/src/bitset.rs
@@ -1,4 +1,4 @@
-use crate::{decl_tagged_val_wrapper_methods, ConversionError, Env, EnvVal, RawVal, Tag};
+use crate::{impl_wrapper_common, ConversionError, RawVal, Tag};
 use core::cmp::Ordering;
 use core::fmt::Debug;
 use core::hash::{Hash, Hasher};
@@ -8,7 +8,7 @@ use core::hash::{Hash, Hasher};
 #[derive(Copy, Clone)]
 pub struct BitSet(RawVal);
 
-decl_tagged_val_wrapper_methods!(BitSet);
+impl_wrapper_common!(BitSet);
 
 /// Errors related to operations on the [BitSet] type.
 #[derive(Debug)]

--- a/soroban-env-common/src/env_val.rs
+++ b/soroban-env-common/src/env_val.rs
@@ -3,96 +3,22 @@ use stellar_xdr::ScObjectType;
 #[cfg(feature = "std")]
 use stellar_xdr::{ScObject, ScStatic, ScVal};
 
+use crate::{raw_val::ConversionError, Object};
 #[cfg(feature = "std")]
-use crate::Static;
-use crate::{raw_val::ConversionError, BitSet, Object, Status, Symbol, Tag, Val};
+use crate::{BitSet, Static, Status, Symbol, Tag};
 
 use super::{
     raw_val::{RawVal, RawValConvertible},
     Env,
 };
-use core::{cmp::Ordering, convert::Infallible, fmt::Debug};
-
-/// Some type of value coupled to a specific instance of [Env], which some of
-/// the value's methods may call into to support some conversion and comparison
-/// functions.
-///
-/// The value and `Env` instance used in an `EnvVal` will vary by context:
-///
-///   - In contract code compiled for WASM, the `Env` is a zero-sized `Guest`
-///     struct
-///   - In contract code compiled natively for local testing, the `Env` is a
-///     reference-counted `Host`
-///   - Inside the `Host`, the `Env` is either a `Host` or a weak reference to a
-///     `Host`
-///
-/// The value will typically either be [RawVal] or one of its tag-specific
-/// wrapper types.
-#[derive(Clone)]
-pub struct EnvVal<E: Env, V> {
-    /// The environment to call into for comparison and conversion assistance.
-    pub env: E,
-    /// The value that will call into the environment as needed.
-    pub val: V,
-}
-
-impl<E: Env, V: Val> EnvVal<E, V> {
-    pub fn env(&self) -> &E {
-        &self.env
-    }
-}
-
-impl<E: Env> EnvVal<E, RawVal> {
-    pub fn as_raw(&self) -> &RawVal {
-        self.val.as_ref()
-    }
-    pub fn to_raw(&self) -> RawVal {
-        self.val
-    }
-}
-
-impl<E: Env> EnvVal<E, Object> {
-    pub fn as_object(&self) -> &Object {
-        &self.val
-    }
-    pub fn to_object(&self) -> Object {
-        self.val
-    }
-}
-
-impl<E: Env, V: Val> AsRef<RawVal> for EnvVal<E, V> {
-    fn as_ref(&self) -> &RawVal {
-        self.val.as_ref()
-    }
-}
-
-impl<E: Env, V: Val> AsMut<RawVal> for EnvVal<E, V> {
-    fn as_mut(&mut self) -> &mut RawVal {
-        self.val.as_mut()
-    }
-}
 
 pub trait IntoVal<E: Env, V>: Sized {
     fn into_val(self, env: &E) -> V;
-
-    fn into_env_val(self, env: &E) -> EnvVal<E, V> {
-        EnvVal {
-            env: env.clone(),
-            val: self.into_val(env),
-        }
-    }
 }
 
 pub trait TryIntoVal<E: Env, V>: Sized {
     type Error;
     fn try_into_val(self, env: &E) -> Result<V, Self::Error>;
-
-    fn try_into_env_val(self, env: &E) -> Result<EnvVal<E, V>, Self::Error> {
-        Ok(EnvVal {
-            env: env.clone(),
-            val: self.try_into_val(env)?,
-        })
-    }
 }
 
 pub trait FromVal<E: Env, V>: Sized {
@@ -102,28 +28,6 @@ pub trait FromVal<E: Env, V>: Sized {
 pub trait TryFromVal<E: Env, V>: Sized {
     type Error;
     fn try_from_val(env: &E, v: V) -> Result<Self, Self::Error>;
-}
-
-impl<E: Env> From<EnvVal<E, RawVal>> for RawVal {
-    fn from(ev: EnvVal<E, RawVal>) -> Self {
-        ev.val
-    }
-}
-
-impl<E: Env, V> IntoVal<E, V> for EnvVal<E, V> {
-    fn into_val(self, _env: &E) -> V {
-        self.val
-    }
-}
-
-impl<E: Env, V> TryFromVal<E, V> for EnvVal<E, V> {
-    type Error = Infallible;
-    fn try_from_val(env: &E, val: V) -> Result<Self, Self::Error> {
-        Ok(EnvVal {
-            env: env.clone(),
-            val,
-        })
-    }
 }
 
 pub(crate) fn log_err_convert<T>(env: &impl Env, val: &impl AsRef<RawVal>) {
@@ -450,122 +354,5 @@ where
     type Error = ConversionError;
     fn try_into_val(self, env: &E) -> Result<RawVal, Self::Error> {
         (&self).try_into_val(env)
-    }
-}
-
-impl<E: Env + Debug, V> Debug for EnvVal<E, V> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("EnvVal")
-            .field("env", &self.env)
-            .field("val", &self)
-            .finish()
-    }
-}
-
-impl<E: Env, V: Val> Eq for EnvVal<E, V> {}
-
-impl<E: Env, V: Val> PartialEq for EnvVal<E, V> {
-    fn eq(&self, other: &Self) -> bool {
-        self.env.check_same_env(&other.env);
-        if self.as_ref().get_payload() == other.as_ref().get_payload() {
-            // Fast path: bit-identical vals.
-            true
-        } else if self.as_ref().get_tag() != Tag::Object || other.as_ref().get_tag() != Tag::Object
-        {
-            // Other fast path: non-identical non-objects, must be non-equal.
-            false
-        } else {
-            // Slow path: deep object comparison via the environment.
-            let v = self.env.obj_cmp(*self.as_ref(), *other.as_ref());
-            v == 0
-        }
-    }
-}
-
-impl<E: Env, V: Val> PartialOrd for EnvVal<E, V> {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl<E: Env, V: Val> Ord for EnvVal<E, V> {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.env.check_same_env(&other.env);
-        let self_tag = self.as_ref().get_tag();
-        let other_tag = other.as_ref().get_tag();
-        if self_tag < other_tag {
-            Ordering::Less
-        } else if self_tag > other_tag {
-            Ordering::Greater
-        } else {
-            // Tags are equal so we only have to switch on one.
-            match self_tag {
-                Tag::U32 => {
-                    let a = unsafe {
-                        <u32 as RawValConvertible>::unchecked_from_val(*self.val.as_ref())
-                    };
-                    let b = unsafe {
-                        <u32 as RawValConvertible>::unchecked_from_val(*other.val.as_ref())
-                    };
-                    a.cmp(&b)
-                }
-                Tag::I32 => {
-                    let a = unsafe {
-                        <i32 as RawValConvertible>::unchecked_from_val(*self.val.as_ref())
-                    };
-                    let b = unsafe {
-                        <i32 as RawValConvertible>::unchecked_from_val(*other.val.as_ref())
-                    };
-                    a.cmp(&b)
-                }
-                Tag::Static => self
-                    .val
-                    .as_ref()
-                    .get_body()
-                    .cmp(&other.val.as_ref().get_body()),
-                Tag::Object => {
-                    let v = self.env.obj_cmp(*self.val.as_ref(), *other.val.as_ref());
-                    if v == 0 {
-                        Ordering::Equal
-                    } else if v < 0 {
-                        Ordering::Less
-                    } else {
-                        Ordering::Greater
-                    }
-                }
-                Tag::Symbol => {
-                    let a = unsafe {
-                        <Symbol as RawValConvertible>::unchecked_from_val(*self.val.as_ref())
-                    };
-                    let b = unsafe {
-                        <Symbol as RawValConvertible>::unchecked_from_val(*other.val.as_ref())
-                    };
-                    a.cmp(&b)
-                }
-                Tag::BitSet => {
-                    let a = unsafe {
-                        <BitSet as RawValConvertible>::unchecked_from_val(*self.val.as_ref())
-                    };
-                    let b = unsafe {
-                        <BitSet as RawValConvertible>::unchecked_from_val(*other.val.as_ref())
-                    };
-                    a.cmp(&b)
-                }
-                Tag::Status => {
-                    let a = unsafe {
-                        <Status as RawValConvertible>::unchecked_from_val(*self.val.as_ref())
-                    };
-                    let b = unsafe {
-                        <Status as RawValConvertible>::unchecked_from_val(*other.val.as_ref())
-                    };
-                    a.cmp(&b)
-                }
-                Tag::Reserved => self
-                    .val
-                    .as_ref()
-                    .get_payload()
-                    .cmp(&other.val.as_ref().get_payload()),
-            }
-        }
     }
 }

--- a/soroban-env-common/src/lib.rs
+++ b/soroban-env-common/src/lib.rs
@@ -70,7 +70,7 @@ pub use checked_env::CheckedEnv;
 pub use compare::Compare;
 pub use convert::Convert;
 pub use env::{Env, EnvBase};
-pub use env_val::{EnvVal, FromVal, IntoVal, TryFromVal, TryIntoVal};
+pub use env_val::{FromVal, IntoVal, TryFromVal, TryIntoVal};
 pub use unimplemented_env::UnimplementedEnv;
 pub use vmcaller_checked_env::{VmCaller, VmCallerCheckedEnv};
 

--- a/soroban-env-common/src/object.rs
+++ b/soroban-env-common/src/object.rs
@@ -1,6 +1,5 @@
 use crate::{
-    decl_tagged_val_wrapper_methods, xdr::ScObjectType, Convert, Env, EnvVal, RawVal, Tag,
-    TryFromVal, TryIntoVal,
+    impl_wrapper_common, xdr::ScObjectType, Convert, Env, RawVal, Tag, TryFromVal, TryIntoVal,
 };
 use core::fmt::Debug;
 use stellar_xdr::{ScObject, ScVal};
@@ -13,7 +12,7 @@ use stellar_xdr::{ScObject, ScVal};
 #[derive(Copy, Clone)]
 pub struct Object(RawVal);
 
-decl_tagged_val_wrapper_methods!(Object);
+impl_wrapper_common!(Object);
 
 impl Debug for Object {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {

--- a/soroban-env-common/src/raw_val.rs
+++ b/soroban-env-common/src/raw_val.rs
@@ -1,7 +1,7 @@
 use stellar_xdr::{ScStatic, ScStatus, ScStatusType};
 
 use super::{
-    BitSet, Env, EnvVal, FromVal, IntoVal, Object, Static, Status, Symbol, TryFromVal, TryIntoVal,
+    BitSet, Env, FromVal, IntoVal, Object, Static, Status, Symbol, TryFromVal, TryIntoVal,
 };
 use core::{convert::Infallible, fmt::Debug};
 
@@ -453,13 +453,6 @@ impl From<&ScStatus> for RawVal {
 }
 
 impl RawVal {
-    pub fn in_env<E: Env>(self, env: &E) -> EnvVal<E, RawVal> {
-        EnvVal {
-            env: env.clone(),
-            val: self,
-        }
-    }
-
     #[inline(always)]
     pub const fn get_payload(self) -> u64 {
         self.0

--- a/soroban-env-common/src/static.rs
+++ b/soroban-env-common/src/static.rs
@@ -1,6 +1,6 @@
+use crate::{impl_wrapper_common, impl_wrapper_from, Env, RawVal, Tag};
+use core::cmp::{Eq, Ord, PartialEq, PartialOrd};
 use stellar_xdr::ScStatic;
-
-use crate::{decl_tagged_val_wrapper_methods, impl_wrapper_from, Env, EnvVal, RawVal, Tag};
 
 /// Wrapper for a [RawVal] that is tagged with [Tag::Static], interpreting the
 /// [RawVal]'s body as a 32-bit value from a reserved set of "static" values
@@ -8,10 +8,31 @@ use crate::{decl_tagged_val_wrapper_methods, impl_wrapper_from, Env, EnvVal, Raw
 #[derive(Copy, Clone)]
 pub struct Static(RawVal);
 
-decl_tagged_val_wrapper_methods!(Static);
+impl_wrapper_common!(Static);
 
 impl_wrapper_from!((), Static);
 impl_wrapper_from!(bool, Static);
+
+impl Eq for Static {}
+
+impl PartialEq for Static {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_raw().get_payload() == other.as_raw().get_payload()
+    }
+}
+
+impl Ord for Static {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.as_raw()
+            .get_payload()
+            .cmp(&other.as_raw().get_payload())
+    }
+}
+impl PartialOrd for Static {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
 
 impl Static {
     // NB: we don't provide a "get_type" to avoid casting a bad bit-pattern into

--- a/soroban-env-common/src/status.rs
+++ b/soroban-env-common/src/status.rs
@@ -1,7 +1,4 @@
-use crate::{
-    decl_tagged_val_wrapper_methods, BitSetError, ConversionError, Env, EnvVal, RawVal,
-    SymbolError, Tag,
-};
+use crate::{impl_wrapper_common, BitSetError, ConversionError, RawVal, SymbolError, Tag};
 use core::{
     cmp::Ordering,
     convert::TryFrom,
@@ -21,7 +18,7 @@ use stellar_xdr::{
 #[derive(Copy, Clone)]
 pub struct Status(RawVal);
 
-decl_tagged_val_wrapper_methods!(Status);
+impl_wrapper_common!(Status);
 
 impl Status {
     pub const UNKNOWN_ERROR: Status =

--- a/soroban-env-common/src/symbol.rs
+++ b/soroban-env-common/src/symbol.rs
@@ -1,4 +1,4 @@
-use crate::{decl_tagged_val_wrapper_methods, require, ConversionError, Env, EnvVal, RawVal, Tag};
+use crate::{impl_wrapper_common, require, ConversionError, RawVal, Tag};
 use core::{
     cmp::Ordering,
     fmt::Debug,
@@ -58,7 +58,7 @@ sa::const_assert!(CODE_BITS * MAX_CHARS == BODY_BITS);
 #[derive(Copy, Clone)]
 pub struct Symbol(RawVal);
 
-decl_tagged_val_wrapper_methods!(Symbol);
+impl_wrapper_common!(Symbol);
 
 impl Hash for Symbol {
     fn hash<H: Hasher>(&self, state: &mut H) {

--- a/soroban-env-common/src/tuple.rs
+++ b/soroban-env-common/src/tuple.rs
@@ -1,8 +1,7 @@
 use stellar_xdr::ScObjectType;
 
 use crate::{
-    ConversionError, Env, EnvVal, IntoVal, Object, RawVal, RawValConvertible, TryFromVal,
-    TryIntoVal,
+    ConversionError, Env, IntoVal, Object, RawVal, RawValConvertible, TryFromVal, TryIntoVal,
 };
 
 macro_rules! impl_for_tuple {
@@ -67,19 +66,6 @@ macro_rules! impl_for_tuple {
                 let vec = env.vec_new($count.into());
                 $(let vec = env.vec_push_back(vec, (&self.$idx).into_val(&env));)*
                 vec.to_raw()
-            }
-        }
-
-        impl<E: Env, $($typ),*> IntoVal<E, EnvVal<E, RawVal>> for ($($typ,)*)
-        where
-            $($typ: IntoVal<E, RawVal>),*
-        {
-            fn into_val(self, env: &E) -> EnvVal<E, RawVal> {
-                let rv: RawVal = self.into_val(env);
-                EnvVal{
-                    env: env.clone(),
-                    val: rv,
-                }
             }
         }
 

--- a/soroban-env-common/src/val_wrapper.rs
+++ b/soroban-env-common/src/val_wrapper.rs
@@ -1,6 +1,6 @@
 #[doc(hidden)]
 #[macro_export]
-macro_rules! decl_tagged_val_wrapper_methods {
+macro_rules! impl_wrapper_common {
     ($tagname:ident) => {
         // AsRef / AsMut to RawVal.
         impl AsRef<RawVal> for $tagname {
@@ -27,44 +27,6 @@ macro_rules! decl_tagged_val_wrapper_methods {
             #[inline(always)]
             unsafe fn unchecked_from_val(v: RawVal) -> Self {
                 $tagname(v)
-            }
-        }
-
-        // EnvVal ref/mut/from support
-        impl<E: Env> AsRef<$tagname> for EnvVal<E, $tagname> {
-            fn as_ref(&self) -> &$tagname {
-                &self.val
-            }
-        }
-        impl<E: Env> AsMut<$tagname> for EnvVal<E, $tagname> {
-            fn as_mut(&mut self) -> &mut $tagname {
-                &mut self.val
-            }
-        }
-        impl<E: Env> From<EnvVal<E, $tagname>> for EnvVal<E, RawVal> {
-            fn from(ev: EnvVal<E, $tagname>) -> Self {
-                EnvVal {
-                    env: ev.env,
-                    val: ev.val.to_raw(),
-                }
-            }
-        }
-        impl<E: Env> From<EnvVal<E, $tagname>> for RawVal {
-            fn from(ev: EnvVal<E, $tagname>) -> Self {
-                ev.val.0
-            }
-        }
-        impl<E: Env> From<EnvVal<E, $tagname>> for $tagname {
-            fn from(ev: EnvVal<E, $tagname>) -> Self {
-                ev.val
-            }
-        }
-        impl<E: Env> EnvVal<E, $tagname> {
-            pub fn as_raw(&self) -> &RawVal {
-                self.val.as_ref()
-            }
-            pub fn to_raw(&self) -> RawVal {
-                self.val.to_raw()
             }
         }
 
@@ -105,13 +67,6 @@ macro_rules! decl_tagged_val_wrapper_methods {
 
             pub const fn to_raw(&self) -> RawVal {
                 self.0
-            }
-
-            pub fn in_env<E: Env>(self, env: &E) -> EnvVal<E, Self> {
-                EnvVal {
-                    env: env.clone(),
-                    val: self,
-                }
             }
 
             #[inline(always)]

--- a/soroban-env-host/benches/common/cost_types/im_map_ops.rs
+++ b/soroban-env-host/benches/common/cost_types/im_map_ops.rs
@@ -24,7 +24,7 @@ impl HostCostMeasurement for ImMapImmutEntryMeasure {
 
     fn new_random_case(host: &Host, rng: &mut StdRng, input: u64) -> ImMapImmutEntrySample {
         let input = input * 100;
-        let mut keys: Vec<_> = util::to_rawval_u32(host, 0..(input as u32)).collect();
+        let mut keys: Vec<_> = util::to_rawval_u32(0..(input as u32)).collect();
         keys.shuffle(rng);
         let om = keys.iter().cloned().zip(keys.iter().cloned()).collect();
         let map: MeteredOrdMap<_, _, _> = MeteredOrdMap::from_map(om, host).unwrap();
@@ -34,15 +34,15 @@ impl HostCostMeasurement for ImMapImmutEntryMeasure {
 
     fn new_worst_case(host: &Host, _rng: &mut StdRng, input: u64) -> ImMapImmutEntrySample {
         let input = input * 100;
-        let keys: Vec<_> = util::to_rawval_u32(host, 0..(input as u32)).collect();
+        let keys: Vec<_> = util::to_rawval_u32(0..(input as u32)).collect();
         let om = keys.iter().cloned().zip(keys.iter().cloned()).collect();
         let map: MeteredOrdMap<_, _, _> = MeteredOrdMap::from_map(om, host).unwrap();
-        let keys = util::to_rawval_u32(host, [0, u32::MAX].iter().cloned()).collect();
+        let keys = util::to_rawval_u32([0, u32::MAX].iter().cloned()).collect();
         ImMapImmutEntrySample { map, keys }
     }
 
     fn new_best_case(host: &Host, _rng: &mut StdRng) -> ImMapImmutEntrySample {
-        let keys: Vec<_> = util::to_rawval_u32(host, [0].iter().cloned()).collect();
+        let keys: Vec<_> = util::to_rawval_u32([0].iter().cloned()).collect();
         let om = keys.iter().cloned().zip(keys.iter().cloned()).collect();
         let map: MeteredOrdMap<_, _, _> = MeteredOrdMap::from_map(om, host).unwrap();
         ImMapImmutEntrySample { map, keys }

--- a/soroban-env-host/benches/common/cost_types/im_vec_ops.rs
+++ b/soroban-env-host/benches/common/cost_types/im_vec_ops.rs
@@ -22,17 +22,17 @@ pub(crate) struct ImVecImmutEntryMeasure;
 impl HostCostMeasurement for ImVecImmutEntryMeasure {
     type Runner = ImVecImmutEntryRun;
 
-    fn new_best_case(host: &Host, _rng: &mut StdRng) -> ImVecImmutEntrySample {
-        let ov = util::to_rawval_u32(host, 0..1).collect();
+    fn new_best_case(_host: &Host, _rng: &mut StdRng) -> ImVecImmutEntrySample {
+        let ov = util::to_rawval_u32(0..1).collect();
         let vec: MeteredVector<_> = MeteredVector::from_vec(ov).unwrap();
         let idxs = [0].to_vec();
         ImVecImmutEntrySample { vec, idxs }
     }
 
     // Random case is worst case.
-    fn new_random_case(host: &Host, rng: &mut StdRng, input: u64) -> ImVecImmutEntrySample {
+    fn new_random_case(_host: &Host, rng: &mut StdRng, input: u64) -> ImVecImmutEntrySample {
         let input = 1 + (input * 100);
-        let ov = util::to_rawval_u32(host, 0..(input as u32)).collect();
+        let ov = util::to_rawval_u32(0..(input as u32)).collect();
         let vec: MeteredVector<_> = MeteredVector::from_vec(ov).unwrap();
         let mut idxs: Vec<usize> = (0..input as usize).collect();
         idxs.shuffle(rng);

--- a/soroban-env-host/benches/common/cost_types/record_debug_event.rs
+++ b/soroban-env-host/benches/common/cost_types/record_debug_event.rs
@@ -10,11 +10,11 @@ impl HostCostMeasurement for CreateRecordDebugEventMeasure {
     type Runner = CreateRecordDebugEventRun;
 
     fn new_random_case(
-        host: &Host,
+        _host: &Host,
         _rng: &mut rand::prelude::StdRng,
         input: u64,
     ) -> CreateRecordDebugEventSample {
-        let args = util::to_rawval_u32(host, 0..(input as u32)).collect();
+        let args = util::to_rawval_u32(0..(input as u32)).collect();
         CreateRecordDebugEventSample {
             msg: "this is a debug msg",
             args,

--- a/soroban-env-host/benches/common/cost_types/scmap_to_host_map.rs
+++ b/soroban-env-host/benches/common/cost_types/scmap_to_host_map.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
 use crate::common::HostCostMeasurement;
 use rand::{rngs::StdRng, Rng};
@@ -18,7 +18,7 @@ impl HostCostMeasurement for ScMapToHostMapMeasure {
 
     fn new_random_case(_host: &Host, rng: &mut StdRng, input: u64) -> ScVal {
         let input = input * 100;
-        let mut hs: HashSet<u32> = HashSet::new();
+        let mut hs: BTreeSet<u32> = BTreeSet::new();
         while hs.len() < (input as usize) {
             hs.insert(rng.gen());
         }

--- a/soroban-env-host/benches/common/cost_types/wasm_insn_exec.rs
+++ b/soroban-env-host/benches/common/cost_types/wasm_insn_exec.rs
@@ -5,7 +5,7 @@ use soroban_env_host::{
     xdr::{Hash, ScVal, ScVec},
     Host, Symbol, Vm,
 };
-use soroban_synth_wasm::{Arity, GlobalRef, LocalRef, ModEmitter, Operand};
+use soroban_synth_wasm::{Arity, GlobalRef, ModEmitter, Operand};
 
 const INSNS_OVERHEAD_CONST: u64 = 21; // measured by `push_const`
 const INSNS_OVERHEAD_DROP: u64 = 17; // measured by `drop`

--- a/soroban-env-host/benches/common/util.rs
+++ b/soroban-env-host/benches/common/util.rs
@@ -1,14 +1,5 @@
-use soroban_env_host::{EnvVal, Host, RawVal};
+use soroban_env_host::RawVal;
 
-type HostVal = EnvVal<Host, RawVal>;
-
-pub(crate) fn to_rawval_u32<I: Iterator<Item = u32>>(
-    host: &Host,
-    vals: I,
-) -> impl Iterator<Item = HostVal> {
-    let host = host.clone();
-    vals.map(move |v| EnvVal {
-        env: host.clone(),
-        val: RawVal::from_u32(v),
-    })
+pub(crate) fn to_rawval_u32<I: Iterator<Item = u32>>(vals: I) -> impl Iterator<Item = RawVal> {
+    vals.map(move |v| RawVal::from_u32(v))
 }

--- a/soroban-env-host/src/host/comparison.rs
+++ b/soroban-env-host/src/host/comparison.rs
@@ -119,6 +119,9 @@ macro_rules! impl_compare_fixed_size_ord_type {
     };
 }
 
+// TODO: we should pass in the indivial size (in bytes) of each type and have the budget charge
+// that given amount. This is similar to self.charge(CostType::BytesCmp, mem::size_of<T>)?;
+// but we are passing the size in explicitly (because the `size_of` is unstable).
 impl_compare_fixed_size_ord_type!(bool);
 
 impl_compare_fixed_size_ord_type!(u32);

--- a/soroban-env-host/src/host/comparison.rs
+++ b/soroban-env-host/src/host/comparison.rs
@@ -1,4 +1,4 @@
-use std::cmp::{min, Ordering};
+use core::cmp::{min, Ordering};
 
 use soroban_env_common::{
     xdr::{
@@ -110,10 +110,27 @@ macro_rules! impl_compare_fixed_size_ord_type {
                 self.compare(&FixedSizeOrdType(a), &FixedSizeOrdType(b))
             }
         }
+        impl Compare<$t> for Host {
+            type Error = HostError;
+            fn compare(&self, a: &$t, b: &$t) -> Result<Ordering, Self::Error> {
+                self.as_budget().compare(a, b)
+            }
+        }
     };
 }
 
+impl_compare_fixed_size_ord_type!(bool);
+
 impl_compare_fixed_size_ord_type!(u32);
+impl_compare_fixed_size_ord_type!(i32);
+impl_compare_fixed_size_ord_type!(u64);
+impl_compare_fixed_size_ord_type!(i64);
+impl_compare_fixed_size_ord_type!(u128);
+impl_compare_fixed_size_ord_type!(i128);
+
+impl_compare_fixed_size_ord_type!(crate::Symbol);
+impl_compare_fixed_size_ord_type!(crate::Status);
+impl_compare_fixed_size_ord_type!(crate::Static);
 
 impl_compare_fixed_size_ord_type!(Hash);
 impl_compare_fixed_size_ord_type!(Uint256);

--- a/soroban-env-host/src/host/data_helper.rs
+++ b/soroban-env-host/src/host/data_helper.rs
@@ -1,4 +1,4 @@
-use std::cmp::min;
+use core::cmp::min;
 
 use soroban_env_common::{CheckedEnv, InvokerType};
 

--- a/soroban-env-host/src/host/metered_map.rs
+++ b/soroban-env-host/src/host/metered_map.rs
@@ -214,8 +214,15 @@ where
         match self.find(key, ctx)? {
             Ok(found) if found > 0 => {
                 // There's a nonempty prefix to preserve.
-                let init = self.map.iter().take(found - 1).cloned();
-                let fini = self.map.iter().skip(found).cloned();
+                // [0,1,2] remove_pos == 1
+                // take(1) + skip(2)
+                // [0] [2]
+                if found == usize::MAX - 1 {
+                    // TODO: something better for integer overflow.
+                    return Err(ScHostObjErrorCode::VecIndexOutOfBound.into());
+                }
+                let init = self.map.iter().take(found).cloned();
+                let fini = self.map.iter().skip(found + 1).cloned();
                 let iter = init.chain(fini);
                 let new = Self::from_exact_iter(iter, ctx)?;
                 let res = self.map[found].1.metered_clone(ctx.as_budget())?;

--- a/soroban-env-host/src/host/metered_map.rs
+++ b/soroban-env-host/src/host/metered_map.rs
@@ -217,10 +217,8 @@ where
                 // [0,1,2] remove_pos == 1
                 // take(1) + skip(2)
                 // [0] [2]
-                if found == usize::MAX - 1 {
-                    // TODO: something better for integer overflow.
-                    return Err(ScHostObjErrorCode::VecIndexOutOfBound.into());
-                }
+                // `found` cannot be > `usize::MAX` - 1, since that means the map contains more than
+                // `usize::MAX` elements. Therefore `found + 1` is guaranteed to not overflow.
                 let init = self.map.iter().take(found).cloned();
                 let fini = self.map.iter().skip(found + 1).cloned();
                 let iter = init.chain(fini);

--- a/soroban-env-host/src/native_contract/base_types.rs
+++ b/soroban-env-host/src/native_contract/base_types.rs
@@ -3,18 +3,32 @@ use crate::host::{Host, HostError};
 use core::cmp::Ordering;
 use soroban_env_common::xdr::{AccountId, ScObjectType};
 use soroban_env_common::{
-    CheckedEnv, ConversionError, EnvBase, EnvVal, Object, RawVal, TryFromVal, TryIntoVal,
+    CheckedEnv, Compare, ConversionError, EnvBase, Object, RawVal, TryFromVal, TryIntoVal,
 };
 
 #[derive(Clone)]
-pub struct Bytes(EnvVal<Host, Object>);
+pub struct Bytes {
+    host: Host,
+    object: Object,
+}
+
+impl Compare<Bytes> for Host {
+    type Error = HostError;
+
+    fn compare(&self, a: &Bytes, b: &Bytes) -> Result<Ordering, Self::Error> {
+        self.compare(&a.object, &b.object)
+    }
+}
 
 impl TryFromVal<Host, Object> for Bytes {
     type Error = HostError;
 
     fn try_from_val(env: &Host, val: Object) -> Result<Self, Self::Error> {
         if val.is_obj_type(ScObjectType::Bytes) {
-            Ok(Bytes(val.in_env(env)))
+            Ok(Bytes {
+                host: env.clone(),
+                object: val,
+            })
         } else {
             Err(ConversionError.into())
         }
@@ -41,61 +55,59 @@ impl TryIntoVal<Host, RawVal> for Bytes {
     type Error = HostError;
 
     fn try_into_val(self, _env: &Host) -> Result<RawVal, Self::Error> {
-        Ok(self.0.val.into())
+        Ok(self.object.into())
     }
 }
 
 impl From<Bytes> for Object {
     fn from(b: Bytes) -> Self {
-        b.0.val
+        b.object
     }
 }
 
 impl<const N: usize> From<BytesN<N>> for Bytes {
     fn from(b: BytesN<N>) -> Self {
-        Self(b.0)
+        Self {
+            host: b.host.clone(),
+            object: b.object,
+        }
     }
 }
 
 impl Bytes {
     pub fn push(&mut self, x: u8) -> Result<(), HostError> {
         let x32: u32 = x.into();
-        self.0 = self
-            .0
-            .env
-            .bytes_push(self.0.val, x32.into())?
-            .in_env(&self.0.env);
+        self.object = self.host.bytes_push(self.object, x32.into())?;
         Ok(())
     }
 
     pub fn append(&mut self, other: Bytes) -> Result<(), HostError> {
-        self.0 = self
-            .0
-            .env
-            .bytes_append(self.0.val, other.0.val)?
-            .in_env(&self.0.env);
+        self.object = self.host.bytes_append(self.object, other.object)?;
         Ok(())
     }
 
     #[cfg(test)]
     pub(crate) fn to_vec(&self) -> std::vec::Vec<u8> {
         use soroban_env_common::RawValConvertible;
-        let env = self.0.env();
         let mut res = std::vec::Vec::<u8>::new();
         let size = unsafe {
             <u32 as RawValConvertible>::unchecked_from_val(
-                env.bytes_len(self.0.to_object()).unwrap(),
+                self.host.bytes_len(self.object).unwrap(),
             )
         };
         res.resize(size as usize, 0);
-        env.bytes_copy_to_slice(self.0.to_object(), RawVal::U32_ZERO, &mut res[..])
+        self.host
+            .bytes_copy_to_slice(self.object, RawVal::U32_ZERO, &mut res[..])
             .unwrap();
         res
     }
 }
 
 #[derive(Clone)]
-pub struct BytesN<const N: usize>(EnvVal<Host, Object>);
+pub struct BytesN<const N: usize> {
+    host: Host,
+    object: Object,
+}
 
 impl<const N: usize> TryFromVal<Host, Object> for BytesN<N> {
     type Error = HostError;
@@ -106,30 +118,21 @@ impl<const N: usize> TryFromVal<Host, Object> for BytesN<N> {
             == N.try_into()
                 .map_err(|_| env.err_general("bytes buffer overflow"))?
         {
-            Ok(Self(val.in_env(env)))
+            Ok(Self {
+                host: env.clone(),
+                object: val,
+            })
         } else {
             Err(ConversionError.into())
         }
     }
 }
 
-impl<const N: usize> Eq for BytesN<N> {}
+impl<const N: usize> Compare<BytesN<N>> for Host {
+    type Error = HostError;
 
-impl<const N: usize> PartialEq for BytesN<N> {
-    fn eq(&self, other: &Self) -> bool {
-        self.partial_cmp(other) == Some(Ordering::Equal)
-    }
-}
-
-impl<const N: usize> PartialOrd for BytesN<N> {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(Ord::cmp(self, other))
-    }
-}
-
-impl<const N: usize> Ord for BytesN<N> {
-    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        self.0.cmp(&other.0)
+    fn compare(&self, a: &BytesN<N>, b: &BytesN<N>) -> Result<Ordering, Self::Error> {
+        self.compare(&a.object, &b.object)
     }
 }
 
@@ -153,19 +156,19 @@ impl<const N: usize> TryIntoVal<Host, RawVal> for BytesN<N> {
     type Error = HostError;
 
     fn try_into_val(self, _env: &Host) -> Result<RawVal, Self::Error> {
-        Ok(self.0.val.into())
+        Ok(self.object.into())
     }
 }
 
 impl<const N: usize> From<BytesN<N>> for Object {
     fn from(bytes: BytesN<N>) -> Self {
-        bytes.0.val
+        bytes.object
     }
 }
 
 impl<const N: usize> BytesN<N> {
     pub fn compare(&self, other: &BytesN<N>) -> Result<Ordering, HostError> {
-        let res = self.0.env.obj_cmp(self.0.val.into(), other.0.val.into())?;
+        let res = self.host.obj_cmp(self.object.into(), other.object.into())?;
         Ok(res.cmp(&0))
     }
 }
@@ -173,16 +176,19 @@ impl<const N: usize> BytesN<N> {
 impl<const N: usize> BytesN<N> {
     #[inline(always)]
     pub fn to_array(&self) -> Result<[u8; N], HostError> {
-        let env = self.0.env();
         let mut slice = [0_u8; N];
-        env.charge_budget(CostType::BytesClone, 4)?;
-        env.bytes_copy_to_slice(self.0.to_object(), RawVal::U32_ZERO, &mut slice)?;
+        self.host.charge_budget(CostType::BytesClone, N as u64)?;
+        self.host
+            .bytes_copy_to_slice(self.object, RawVal::U32_ZERO, &mut slice)?;
         Ok(slice)
     }
 
     #[inline(always)]
     pub fn from_slice(env: &Host, items: &[u8]) -> Result<BytesN<N>, HostError> {
-        Ok(BytesN(env.bytes_new_from_slice(items)?.in_env(env)))
+        Ok(BytesN {
+            host: env.clone(),
+            object: env.bytes_new_from_slice(items)?,
+        })
     }
 
     #[cfg(test)]
@@ -192,17 +198,31 @@ impl<const N: usize> BytesN<N> {
 }
 
 #[derive(Clone)]
-pub struct Map(EnvVal<Host, Object>);
+pub struct Map {
+    host: Host,
+    object: Object,
+}
 
 impl TryFromVal<Host, Object> for Map {
     type Error = HostError;
 
     fn try_from_val(env: &Host, val: Object) -> Result<Self, Self::Error> {
         if val.is_obj_type(ScObjectType::Map) {
-            Ok(Map(val.in_env(env)))
+            Ok(Map {
+                host: env.clone(),
+                object: val,
+            })
         } else {
             Err(ConversionError.into())
         }
+    }
+}
+
+impl Compare<Map> for Host {
+    type Error = HostError;
+
+    fn compare(&self, a: &Map, b: &Map) -> Result<Ordering, Self::Error> {
+        self.compare(&a.object, &b.object)
     }
 }
 
@@ -226,20 +246,23 @@ impl TryIntoVal<Host, RawVal> for Map {
     type Error = HostError;
 
     fn try_into_val(self, _env: &Host) -> Result<RawVal, Self::Error> {
-        Ok(self.0.val.into())
+        Ok(self.object.into())
     }
 }
 
 impl From<Map> for Object {
     fn from(map: Map) -> Self {
-        map.0.val
+        map.object
     }
 }
 
 impl Map {
     pub fn new(env: &Host) -> Result<Self, HostError> {
         let map = env.map_new()?;
-        Ok(Self(map.in_env(env)))
+        Ok(Self {
+            host: env.clone(),
+            object: map,
+        })
     }
 
     pub fn get<K: TryIntoVal<Host, RawVal>, V: TryFromVal<Host, RawVal>>(
@@ -250,9 +273,9 @@ impl Map {
         HostError: From<<K as TryIntoVal<Host, RawVal>>::Error>,
         HostError: From<<V as TryFromVal<Host, RawVal>>::Error>,
     {
-        let k_rv = k.try_into_val(&self.0.env)?;
-        let v_rv = self.0.env.map_get(self.0.val, k_rv)?;
-        Ok(V::try_from_val(&self.0.env, v_rv)?)
+        let k_rv = k.try_into_val(&self.host)?;
+        let v_rv = self.host.map_get(self.object, k_rv)?;
+        Ok(V::try_from_val(&self.host, v_rv)?)
     }
 
     pub fn set<K: TryIntoVal<Host, RawVal>, V: TryIntoVal<Host, RawVal>>(
@@ -264,22 +287,36 @@ impl Map {
         HostError: From<<K as TryIntoVal<Host, RawVal>>::Error>,
         HostError: From<<V as TryIntoVal<Host, RawVal>>::Error>,
     {
-        let k_rv = k.try_into_val(&self.0.env)?;
-        let v_rv = v.try_into_val(&self.0.env)?;
-        self.0.val = self.0.env.map_put(self.0.val, k_rv, v_rv)?;
+        let k_rv = k.try_into_val(&self.host)?;
+        let v_rv = v.try_into_val(&self.host)?;
+        self.object = self.host.map_put(self.object, k_rv, v_rv)?;
         Ok(())
     }
 }
 
 #[derive(Clone)]
-pub struct Vec(EnvVal<Host, Object>);
+pub struct Vec {
+    host: Host,
+    object: Object,
+}
+
+impl Compare<Vec> for Host {
+    type Error = HostError;
+
+    fn compare(&self, a: &Vec, b: &Vec) -> Result<Ordering, Self::Error> {
+        self.compare(&a.object, &b.object)
+    }
+}
 
 impl TryFromVal<Host, Object> for Vec {
     type Error = HostError;
 
     fn try_from_val(env: &Host, val: Object) -> Result<Self, Self::Error> {
         if val.is_obj_type(ScObjectType::Vec) {
-            Ok(Vec(val.in_env(env)))
+            Ok(Vec {
+                host: env.clone(),
+                object: val,
+            })
         } else {
             Err(ConversionError.into())
         }
@@ -306,45 +343,48 @@ impl TryIntoVal<Host, RawVal> for Vec {
     type Error = HostError;
 
     fn try_into_val(self, _env: &Host) -> Result<RawVal, Self::Error> {
-        Ok(self.0.val.into())
+        Ok(self.object.into())
     }
 }
 
 impl From<Vec> for Object {
     fn from(vec: Vec) -> Self {
-        vec.0.val
+        vec.object
     }
 }
 
 impl Vec {
     pub fn new(env: &Host) -> Result<Self, HostError> {
         let vec = env.vec_new(().into())?;
-        Ok(Self(vec.in_env(env)))
+        Ok(Self {
+            host: env.clone(),
+            object: vec,
+        })
     }
 
     pub fn get<T: TryFromVal<Host, RawVal>>(&self, i: u32) -> Result<T, HostError>
     where
         HostError: From<<T as TryFromVal<Host, RawVal>>::Error>,
     {
-        let rv = self.0.env.vec_get(self.0.val, i.into())?;
-        Ok(T::try_from_val(&self.0.env, rv)?)
+        let rv = self.host.vec_get(self.object, i.into())?;
+        Ok(T::try_from_val(&self.host, rv)?)
     }
 
     pub fn len(&self) -> Result<u32, HostError> {
-        let rv = self.0.env.vec_len(self.0.val)?;
-        Ok(u32::try_from_val(&self.0.env, rv)?)
+        let rv = self.host.vec_len(self.object)?;
+        Ok(u32::try_from_val(&self.host, rv)?)
     }
 
     pub fn push<T: TryIntoVal<Host, RawVal>>(&mut self, x: T) -> Result<(), HostError>
     where
         HostError: From<<T as TryIntoVal<Host, RawVal>>::Error>,
     {
-        let rv = x.try_into_val(&self.0.env)?;
+        let rv = x.try_into_val(&self.host)?;
         self.push_raw(rv)
     }
 
     pub fn push_raw(&mut self, x: RawVal) -> Result<(), HostError> {
-        self.0.val = self.0.env.vec_push_back(self.0.val, x)?;
+        self.object = self.host.vec_push_back(self.object, x)?;
         Ok(())
     }
 }

--- a/soroban-env-host/src/native_contract/invoker.rs
+++ b/soroban-env-host/src/native_contract/invoker.rs
@@ -5,7 +5,7 @@ use crate::{Host, HostError};
 
 use super::base_types::BytesN;
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone)]
 #[contracttype]
 pub enum Invoker {
     Account(AccountId),

--- a/soroban-env-host/src/native_contract/token/admin.rs
+++ b/soroban-env-host/src/native_contract/token/admin.rs
@@ -2,7 +2,7 @@ use crate::host::Host;
 use crate::native_contract::token::public_types::{Identifier, Signature};
 use crate::native_contract::token::storage_types::DataKey;
 use crate::{err, HostError};
-use soroban_env_common::{CheckedEnv, TryFromVal, TryIntoVal};
+use soroban_env_common::{CheckedEnv, Compare, TryFromVal, TryIntoVal};
 
 use super::error::ContractError;
 
@@ -25,7 +25,7 @@ pub fn check_admin(e: &Host, auth: &Signature) -> Result<(), HostError> {
     let admin = read_administrator(e)?;
     let id = auth.get_identifier(e)?;
 
-    if id != admin {
+    if e.compare(&id, &admin)? != core::cmp::Ordering::Equal {
         Err(err!(
             e,
             ContractError::UnauthorizedError,

--- a/soroban-env-host/src/native_contract/token/contract.rs
+++ b/soroban-env-host/src/native_contract/token/contract.rs
@@ -1,3 +1,5 @@
+use core::cmp::Ordering;
+
 use crate::host::metered_clone::MeteredClone;
 use crate::host::Host;
 use crate::native_contract::base_types::{Bytes, BytesN, Vec};
@@ -16,7 +18,7 @@ use crate::native_contract::token::public_types::{Identifier, Metadata, Signatur
 use crate::{err, HostError};
 
 use soroban_env_common::xdr::Asset;
-use soroban_env_common::{CheckedEnv, EnvBase, Symbol, TryFromVal, TryIntoVal};
+use soroban_env_common::{CheckedEnv, Compare, EnvBase, Symbol, TryFromVal, TryIntoVal};
 use soroban_native_sdk_macros::contractimpl;
 
 use super::error::ContractError;
@@ -138,7 +140,7 @@ impl TokenTrait for Token {
         let curr_contract_id = BytesN::<32>::try_from_val(e, e.get_current_contract()?)?;
         let expected_contract_id =
             BytesN::<32>::try_from_val(e, e.get_contract_id_from_asset(asset.clone())?)?;
-        if curr_contract_id != expected_contract_id {
+        if e.compare(&curr_contract_id, &expected_contract_id)? != Ordering::Equal {
             return Err(err!(
                 e,
                 ContractError::InternalError,

--- a/soroban-env-host/src/native_contract/token/public_types.rs
+++ b/soroban-env-host/src/native_contract/token/public_types.rs
@@ -60,7 +60,7 @@ impl Signature {
     }
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone)]
 #[contracttype]
 pub enum Identifier {
     Contract(BytesN<32>),

--- a/soroban-env-host/src/storage.rs
+++ b/soroban-env-host/src/storage.rs
@@ -33,7 +33,7 @@ pub enum AccessType {
 impl Compare<AccessType> for Host {
     type Error = HostError;
 
-    fn compare(&self, a: &AccessType, b: &AccessType) -> Result<std::cmp::Ordering, Self::Error> {
+    fn compare(&self, a: &AccessType, b: &AccessType) -> Result<core::cmp::Ordering, Self::Error> {
         Ok(a.cmp(b))
     }
 }
@@ -41,7 +41,7 @@ impl Compare<AccessType> for Host {
 impl Compare<AccessType> for Budget {
     type Error = HostError;
 
-    fn compare(&self, a: &AccessType, b: &AccessType) -> Result<std::cmp::Ordering, Self::Error> {
+    fn compare(&self, a: &AccessType, b: &AccessType) -> Result<core::cmp::Ordering, Self::Error> {
         Ok(a.cmp(b))
     }
 }

--- a/soroban-env-host/src/test/map.rs
+++ b/soroban-env-host/src/test/map.rs
@@ -39,6 +39,66 @@ fn map_put_has_and_get() -> Result<(), HostError> {
 }
 
 #[test]
+fn map_put_insert_and_remove() -> Result<(), HostError> {
+    let host = Host::default();
+    let scmap: ScMap = host.map_err(
+        vec![
+            ScMapEntry {
+                key: ScVal::U32(1),
+                val: ScVal::U32(10),
+            },
+            ScMapEntry {
+                key: ScVal::U32(3),
+                val: ScVal::U32(30),
+            },
+        ]
+        .try_into(),
+    )?;
+    let scobj = ScObject::Map(scmap);
+    let mut obj = host.to_host_obj(&scobj)?;
+
+    obj = host.map_put(obj, 0_u32.into(), 0_u32.into())?;
+    obj = host.map_put(obj, 2_u32.into(), 20_u32.into())?;
+    obj = host.map_put(obj, 4_u32.into(), 40_u32.into())?;
+
+    let scmap_r: ScMap = host.map_err(
+        vec![
+            ScMapEntry {
+                key: ScVal::U32(0),
+                val: ScVal::U32(0),
+            },
+            ScMapEntry {
+                key: ScVal::U32(1),
+                val: ScVal::U32(10),
+            },
+            ScMapEntry {
+                key: ScVal::U32(2),
+                val: ScVal::U32(20),
+            },
+            ScMapEntry {
+                key: ScVal::U32(3),
+                val: ScVal::U32(30),
+            },
+            ScMapEntry {
+                key: ScVal::U32(4),
+                val: ScVal::U32(40),
+            },
+        ]
+        .try_into(),
+    )?;
+    let scobj_r = ScObject::Map(scmap_r);
+    let obj_r = host.to_host_obj(&scobj_r)?;
+    assert_eq!(host.obj_cmp(obj_r.into(), obj.into())?, 0);
+
+    obj = host.map_del(obj, 0_u32.into())?;
+    obj = host.map_del(obj, 2_u32.into())?;
+    obj = host.map_del(obj, 4_u32.into())?;
+    let obj_o = host.to_host_obj(&scobj)?;
+    assert_eq!(host.obj_cmp(obj_o.into(), obj.into())?, 0);
+    Ok(())
+}
+
+#[test]
 fn map_prev_and_next() -> Result<(), HostError> {
     let host = Host::default();
     let scmap: ScMap = host.map_err(

--- a/soroban-env-host/src/test/vec.rs
+++ b/soroban-env-host/src/test/vec.rs
@@ -1,4 +1,4 @@
-use std::cmp::Ordering;
+use core::cmp::Ordering;
 
 use soroban_env_common::Compare;
 

--- a/soroban-env-host/tests/integration.rs
+++ b/soroban-env-host/tests/integration.rs
@@ -1,22 +1,30 @@
-use soroban_env_host::{events::HostEvent, xdr::ScObjectType, Env, EnvBase, Host, Object, RawVal};
+use soroban_env_host::{
+    events::HostEvent, xdr::ScObjectType, Compare, Env, EnvBase, Host, Object, RawVal,
+};
 
 #[test]
 fn vec_as_seen_by_user() -> Result<(), ()> {
     let host = Host::default();
-    let int1 = host.obj_from_i64(5).in_env(&host);
+    let int1 = host.obj_from_i64(5);
 
-    let vec1a = host.vec_new(RawVal::from_void()).in_env(&host);
-    let vec1b = host.vec_push_back(vec1a.val, *int1.as_ref()).in_env(&host);
+    let vec1a = host.vec_new(RawVal::from_void());
+    let vec1b = host.vec_push_back(vec1a, *int1.as_ref());
 
     assert_ne!(vec1a.as_raw().get_payload(), vec1b.as_raw().get_payload());
 
-    let vec2a = host.vec_new(RawVal::from_void()).in_env(&host);
-    let vec2b = host.vec_push_back(vec2a.val, *int1.as_ref()).in_env(&host);
+    let vec2a = host.vec_new(RawVal::from_void());
+    let vec2b = host.vec_push_back(vec2a, *int1.as_ref());
 
     assert_ne!(vec2a.as_raw().get_payload(), vec2b.as_raw().get_payload());
     assert_ne!(vec1b.as_raw().get_payload(), vec2b.as_raw().get_payload());
-    assert_eq!(vec1a, vec2a);
-    assert_eq!(vec1b, vec2b);
+    assert_eq!(
+        host.compare(&vec1a, &vec2a).unwrap(),
+        core::cmp::Ordering::Equal
+    );
+    assert_eq!(
+        host.compare(&vec1b, &vec2b).unwrap(),
+        core::cmp::Ordering::Equal
+    );
     Ok(())
 }
 


### PR DESCRIPTION
### What

To rebase and merge the `EnvVal` removal part of https://github.com/stellar/rs-soroban-env/pull/600. 

See https://github.com/stellar/rs-soroban-env/pull/600#issue-1481017527 for description

### Why

At @graydon 's suggestion to split out the `EnvVal` removal part of https://github.com/stellar/rs-soroban-env/pull/600 and merge it first, since it is mostly just clean up and is self-contained. 
It makes the code base much cleaner. 

### Known limitations

[TODO or N/A]
