### PR TITLE
Fix `first/last_index_of` functions to use deep object comparison

### DIFF
--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -1649,7 +1649,7 @@ impl VmCallerCheckedEnv for Host {
     ) -> Result<RawVal, Self::Error> {
         self.visit_obj(v, |hv: &HostVec| {
             Ok(
-                match hv.first_index_of(|other| x.shallow_eq(other), &self.as_budget())? {
+                match hv.first_index_of(|other| self.compare(&x, other), &self.as_budget())? {
                     Some(u) => self.usize_to_rawval_u32(u)?,
                     None => RawVal::from_void(),
                 },
@@ -1665,7 +1665,7 @@ impl VmCallerCheckedEnv for Host {
     ) -> Result<RawVal, Self::Error> {
         self.visit_obj(v, |hv: &HostVec| {
             Ok(
-                match hv.last_index_of(|other| x.shallow_eq(other), self.as_budget())? {
+                match hv.last_index_of(|other| self.compare(&x, other), self.as_budget())? {
                     Some(u) => self.usize_to_rawval_u32(u)?,
                     None => RawVal::from_void(),
                 },


### PR DESCRIPTION
### What

Fix the bug in examples discovered earlier by @sisuresh, by using deep object comparisons in host vector's `first/last_index_of` functions

### Why

`HostVec` contains `RawVal`s which may be objects of the identical in content have different object handles, thus deep comparison is needed. 

### Known limitations

[TODO or N/A]
