### PR TITLE
Update interface

### DIFF
--- a/soroban-env-host/src/native_contract/token/balance.rs
+++ b/soroban-env-host/src/native_contract/token/balance.rs
@@ -126,8 +126,7 @@ pub fn is_authorized(e: &Host, id: Identifier) -> Result<bool, HostError> {
         Identifier::Contract(_) | Identifier::Ed25519(_) => {
             let key = DataKey::State(id);
             if let Ok(state) = e.get_contract_data(key.try_into_val(e)?) {
-                // The flag stored at this key is true if the balance is deauthorized
-                Ok(!(state.try_into()?))
+                Ok(state.try_into()?)
             } else {
                 Ok(true)
             }
@@ -141,8 +140,7 @@ pub fn write_authorization(e: &Host, id: Identifier, authorize: bool) -> Result<
         Identifier::Account(acc_id) => set_authorization(e, acc_id, authorize),
         Identifier::Contract(_) | Identifier::Ed25519(_) => {
             let key = DataKey::State(id);
-            // The flag stored at this key is true if the balance is deauthorized
-            e.put_contract_data(key.try_into_val(e)?, (!authorize).into())?;
+            e.put_contract_data(key.try_into_val(e)?, authorize.into())?;
             Ok(())
         }
     }

--- a/soroban-env-host/src/native_contract/token/balance.rs
+++ b/soroban-env-host/src/native_contract/token/balance.rs
@@ -45,7 +45,10 @@ fn write_balance(e: &Host, id: Identifier, amount: i128) -> Result<(), HostError
 // Metering: covered by components.
 pub fn receive_balance(e: &Host, id: Identifier, amount: i128) -> Result<(), HostError> {
     if !is_authorized(e, id.clone())? {
-        return Err(e.err_status_msg(ContractError::BalanceFrozenError, "balance is frozen"));
+        return Err(e.err_status_msg(
+            ContractError::BalanceDeauthorizedError,
+            "balance is deauthorized",
+        ));
     }
 
     match id {
@@ -107,7 +110,10 @@ pub fn spend_balance_no_authorization_check(
 // Metering: covered by components.
 pub fn spend_balance(e: &Host, id: Identifier, amount: i128) -> Result<(), HostError> {
     if !is_authorized(e, id.clone())? {
-        return Err(e.err_status_msg(ContractError::BalanceFrozenError, "balance is frozen"));
+        return Err(e.err_status_msg(
+            ContractError::BalanceDeauthorizedError,
+            "balance is deauthorized",
+        ));
     }
 
     spend_balance_no_authorization_check(e, id, amount)

--- a/soroban-env-host/src/native_contract/token/contract.rs
+++ b/soroban-env-host/src/native_contract/token/contract.rs
@@ -33,7 +33,7 @@ pub trait TokenTrait {
     /// called by the create_token_from_asset host function for this reason.
     ///
     /// No admin will be set for the Native token, so any function that checks the admin
-    /// (burn, freeze, unfreeze, mint, set_admin) will always fail
+    /// (clawback, freeze, unfreeze, mint, set_admin) will always fail
     fn init_asset(e: &Host, asset_bytes: Bytes) -> Result<(), HostError>;
 
     fn nonce(e: &Host, id: Identifier) -> Result<i128, HostError>;
@@ -91,7 +91,7 @@ pub trait TokenTrait {
         amount: i128,
     ) -> Result<(), HostError>;
 
-    fn burn(
+    fn clawback(
         e: &Host,
         admin: Signature,
         nonce: i128,
@@ -323,7 +323,7 @@ impl TokenTrait for Token {
     }
 
     // Metering: covered by components
-    fn burn(
+    fn clawback(
         e: &Host,
         admin: Signature,
         nonce: i128,
@@ -339,10 +339,10 @@ impl TokenTrait for Token {
         args.push(nonce.clone())?;
         args.push(from.clone())?;
         args.push(amount.clone())?;
-        check_auth(&e, admin, nonce, Symbol::from_str("burn"), args)?;
-        // admin can burn a frozen balance
+        check_auth(&e, admin, nonce, Symbol::from_str("clawback"), args)?;
+        // admin can clawback a frozen balance
         spend_balance_no_freeze_check(&e, from.clone(), amount.clone())?;
-        event::burn(e, admin_id, from, amount)?;
+        event::clawback(e, admin_id, from, amount)?;
         Ok(())
     }
 

--- a/soroban-env-host/src/native_contract/token/contract.rs
+++ b/soroban-env-host/src/native_contract/token/contract.rs
@@ -36,7 +36,7 @@ pub trait TokenTrait {
     /// called by the create_token_from_asset host function for this reason.
     ///
     /// No admin will be set for the Native token, so any function that checks the admin
-    /// (clawback, freeze, unfreeze, mint, set_admin) will always fail
+    /// (clawback, set_auth, mint, set_admin) will always fail
     fn init_asset(e: &Host, asset_bytes: Bytes) -> Result<(), HostError>;
 
     fn nonce(e: &Host, id: Identifier) -> Result<i128, HostError>;
@@ -405,7 +405,7 @@ impl TokenTrait for Token {
         args.push(from.clone())?;
         args.push(amount.clone())?;
         check_auth(&e, admin, nonce, Symbol::from_str("clawback"), args)?;
-        // admin can clawback a frozen balance
+        // admin can clawback a deauthorized balance
         spend_balance_no_authorization_check(&e, from.clone(), amount.clone())?;
         event::clawback(e, admin_id, from, amount)?;
         Ok(())

--- a/soroban-env-host/src/native_contract/token/contract.rs
+++ b/soroban-env-host/src/native_contract/token/contract.rs
@@ -6,7 +6,7 @@ use crate::native_contract::base_types::{Bytes, BytesN, Vec};
 use crate::native_contract::token::admin::{check_admin, write_administrator};
 use crate::native_contract::token::allowance::{read_allowance, spend_allowance, write_allowance};
 use crate::native_contract::token::balance::{
-    is_deauthorized, read_balance, receive_balance, spend_balance, write_authorization,
+    is_authorized, read_balance, receive_balance, spend_balance, write_authorization,
 };
 use crate::native_contract::token::cryptography::check_auth;
 use crate::native_contract::token::event;
@@ -295,7 +295,7 @@ impl TokenTrait for Token {
 
     // Metering: covered by components
     fn is_frozen(e: &Host, id: Identifier) -> Result<bool, HostError> {
-        is_deauthorized(&e, id)
+        Ok(!is_authorized(&e, id)?)
     }
 
     // Metering: covered by components

--- a/soroban-env-host/src/native_contract/token/contract.rs
+++ b/soroban-env-host/src/native_contract/token/contract.rs
@@ -63,7 +63,7 @@ pub trait TokenTrait {
 
     fn spendable(e: &Host, id: Identifier) -> Result<i128, HostError>;
 
-    fn is_frozen(e: &Host, id: Identifier) -> Result<bool, HostError>;
+    fn authorized(e: &Host, id: Identifier) -> Result<bool, HostError>;
 
     fn xfer(
         e: &Host,
@@ -298,8 +298,8 @@ impl TokenTrait for Token {
     }
 
     // Metering: covered by components
-    fn is_frozen(e: &Host, id: Identifier) -> Result<bool, HostError> {
-        Ok(!is_authorized(&e, id)?)
+    fn authorized(e: &Host, id: Identifier) -> Result<bool, HostError> {
+        is_authorized(&e, id)
     }
 
     // Metering: covered by components

--- a/soroban-env-host/src/native_contract/token/error.rs
+++ b/soroban-env-host/src/native_contract/token/error.rs
@@ -16,7 +16,7 @@ pub enum ContractError {
     NegativeAmountError = 9,
     AllowanceError = 10,
     BalanceError = 11,
-    BalanceFrozenError = 12,
+    BalanceDeauthorizedError = 12,
     OverflowError = 13,
     TrustlineMissingError = 14,
 }

--- a/soroban-env-host/src/native_contract/token/event.rs
+++ b/soroban-env-host/src/native_contract/token/event.rs
@@ -4,14 +4,28 @@ use crate::native_contract::token::public_types::Identifier;
 use crate::HostError;
 use soroban_env_common::{CheckedEnv, Symbol, TryIntoVal};
 
-pub(crate) fn approve(
+pub(crate) fn incr_allow(
     e: &Host,
     from: Identifier,
     to: Identifier,
     amount: i128,
 ) -> Result<(), HostError> {
     let mut topics = Vec::new(e)?;
-    topics.push(Symbol::from_str("approve"))?;
+    topics.push(Symbol::from_str("incr_allow"))?;
+    topics.push(from)?;
+    topics.push(to)?;
+    e.contract_event(topics.into(), amount.try_into_val(e)?)?;
+    Ok(())
+}
+
+pub(crate) fn decr_allow(
+    e: &Host,
+    from: Identifier,
+    to: Identifier,
+    amount: i128,
+) -> Result<(), HostError> {
+    let mut topics = Vec::new(e)?;
+    topics.push(Symbol::from_str("decr_allow"))?;
     topics.push(from)?;
     topics.push(to)?;
     e.contract_event(topics.into(), amount.try_into_val(e)?)?;

--- a/soroban-env-host/src/native_contract/token/event.rs
+++ b/soroban-env-host/src/native_contract/token/event.rs
@@ -60,14 +60,14 @@ pub(crate) fn mint(
     Ok(())
 }
 
-pub(crate) fn burn(
+pub(crate) fn clawback(
     e: &Host,
     admin: Identifier,
     from: Identifier,
     amount: i128,
 ) -> Result<(), HostError> {
     let mut topics = Vec::new(e)?;
-    topics.push(Symbol::from_str("burn"))?;
+    topics.push(Symbol::from_str("clawback"))?;
     topics.push(admin)?;
     topics.push(from)?;
     e.contract_event(topics.into(), amount.try_into_val(e)?)?;

--- a/soroban-env-host/src/native_contract/token/event.rs
+++ b/soroban-env-host/src/native_contract/token/event.rs
@@ -74,19 +74,17 @@ pub(crate) fn clawback(
     Ok(())
 }
 
-pub(crate) fn freeze(e: &Host, admin: Identifier, id: Identifier) -> Result<(), HostError> {
+pub(crate) fn set_auth(
+    e: &Host,
+    admin: Identifier,
+    id: Identifier,
+    authorize: bool,
+) -> Result<(), HostError> {
     let mut topics = Vec::new(e)?;
-    topics.push(Symbol::from_str("freeze"))?;
+    topics.push(Symbol::from_str("set_auth"))?;
     topics.push(admin)?;
-    e.contract_event(topics.into(), id.try_into_val(e)?)?;
-    Ok(())
-}
-
-pub(crate) fn unfreeze(e: &Host, admin: Identifier, id: Identifier) -> Result<(), HostError> {
-    let mut topics = Vec::new(e)?;
-    topics.push(Symbol::from_str("unfreeze"))?;
-    topics.push(admin)?;
-    e.contract_event(topics.into(), id.try_into_val(e)?)?;
+    topics.push(id)?;
+    e.contract_event(topics.into(), authorize.try_into_val(e)?)?;
     Ok(())
 }
 

--- a/soroban-env-host/src/native_contract/token/event.rs
+++ b/soroban-env-host/src/native_contract/token/event.rs
@@ -101,3 +101,11 @@ pub(crate) fn set_admin(
     e.contract_event(topics.into(), new_admin.try_into_val(e)?)?;
     Ok(())
 }
+
+pub(crate) fn burn(e: &Host, from: Identifier, amount: i128) -> Result<(), HostError> {
+    let mut topics = Vec::new(e)?;
+    topics.push(Symbol::from_str("burn"))?;
+    topics.push(from)?;
+    e.contract_event(topics.into(), amount.try_into_val(e)?)?;
+    Ok(())
+}

--- a/soroban-env-host/src/native_contract/token/test_token.rs
+++ b/soroban-env-host/src/native_contract/token/test_token.rs
@@ -60,7 +60,7 @@ impl<'a> TestToken<'a> {
             .try_into_val(self.host)?)
     }
 
-    pub(crate) fn approve(
+    pub(crate) fn incr_allow(
         &self,
         from: &TestSigner,
         nonce: i128,
@@ -70,7 +70,7 @@ impl<'a> TestToken<'a> {
         let signature = sign_args(
             self.host,
             from,
-            "approve",
+            "incr_allow",
             &self.id,
             host_vec![
                 self.host,
@@ -85,7 +85,38 @@ impl<'a> TestToken<'a> {
             .host
             .call(
                 self.id.clone().into(),
-                Symbol::from_str("approve").into(),
+                Symbol::from_str("incr_allow").into(),
+                host_vec![self.host, signature, nonce, spender, amount].into(),
+            )?
+            .try_into()?)
+    }
+
+    pub(crate) fn decr_allow(
+        &self,
+        from: &TestSigner,
+        nonce: i128,
+        spender: Identifier,
+        amount: i128,
+    ) -> Result<(), HostError> {
+        let signature = sign_args(
+            self.host,
+            from,
+            "decr_allow",
+            &self.id,
+            host_vec![
+                self.host,
+                from.get_identifier(self.host),
+                nonce.clone(),
+                spender.clone(),
+                amount.clone()
+            ],
+        );
+
+        Ok(self
+            .host
+            .call(
+                self.id.clone().into(),
+                Symbol::from_str("decr_allow").into(),
                 host_vec![self.host, signature, nonce, spender, amount].into(),
             )?
             .try_into()?)

--- a/soroban-env-host/src/native_contract/token/test_token.rs
+++ b/soroban-env-host/src/native_contract/token/test_token.rs
@@ -308,7 +308,7 @@ impl<'a> TestToken<'a> {
             .try_into()?)
     }
 
-    pub(crate) fn burn(
+    pub(crate) fn clawback(
         &self,
         admin: &TestSigner,
         nonce: i128,
@@ -318,7 +318,7 @@ impl<'a> TestToken<'a> {
         let signature = sign_args(
             self.host,
             admin,
-            "burn",
+            "clawback",
             &self.id,
             host_vec![
                 self.host,
@@ -333,7 +333,7 @@ impl<'a> TestToken<'a> {
             .host
             .call(
                 self.id.clone().into(),
-                Symbol::from_str("burn").into(),
+                Symbol::from_str("clawback").into(),
                 host_vec![self.host, signature, nonce, from, amount].into(),
             )?
             .try_into()?)

--- a/soroban-env-host/src/native_contract/token/test_token.rs
+++ b/soroban-env-host/src/native_contract/token/test_token.rs
@@ -208,6 +208,66 @@ impl<'a> TestToken<'a> {
             .try_into()?)
     }
 
+    pub(crate) fn burn(
+        &self,
+        from: &TestSigner,
+        nonce: i128,
+        amount: i128,
+    ) -> Result<(), HostError> {
+        let signature = sign_args(
+            self.host,
+            from,
+            "burn",
+            &self.id,
+            host_vec![
+                self.host,
+                from.get_identifier(self.host),
+                nonce.clone(),
+                amount.clone()
+            ],
+        );
+
+        Ok(self
+            .host
+            .call(
+                self.id.clone().into(),
+                Symbol::from_str("burn").into(),
+                host_vec![self.host, signature, nonce, amount].into(),
+            )?
+            .try_into()?)
+    }
+
+    pub(crate) fn burn_from(
+        &self,
+        spender: &TestSigner,
+        nonce: i128,
+        from: Identifier,
+        amount: i128,
+    ) -> Result<(), HostError> {
+        let signature = sign_args(
+            self.host,
+            spender,
+            "burn_from",
+            &self.id,
+            host_vec![
+                self.host,
+                spender.get_identifier(self.host),
+                nonce.clone(),
+                from.clone(),
+                amount.clone()
+            ],
+        );
+
+        Ok(self
+            .host
+            .call(
+                self.id.clone().into(),
+                Symbol::from_str("burn_from").into(),
+                host_vec![self.host, signature, nonce, from, amount].into(),
+            )?
+            .try_into()?)
+    }
+
     pub(crate) fn freeze(
         &self,
         admin: &TestSigner,

--- a/soroban-env-host/src/native_contract/token/test_token.rs
+++ b/soroban-env-host/src/native_contract/token/test_token.rs
@@ -268,22 +268,24 @@ impl<'a> TestToken<'a> {
             .try_into()?)
     }
 
-    pub(crate) fn freeze(
+    pub(crate) fn set_auth(
         &self,
         admin: &TestSigner,
         nonce: i128,
         id: Identifier,
+        authorize: bool,
     ) -> Result<(), HostError> {
         let signature = sign_args(
             self.host,
             admin,
-            "freeze",
+            "set_auth",
             &self.id,
             host_vec![
                 self.host,
                 admin.get_identifier(self.host),
                 nonce.clone(),
-                id.clone()
+                id.clone(),
+                authorize
             ],
         );
 
@@ -291,37 +293,8 @@ impl<'a> TestToken<'a> {
             .host
             .call(
                 self.id.clone().into(),
-                Symbol::from_str("freeze").into(),
-                host_vec![self.host, signature, nonce, id].into(),
-            )?
-            .try_into()?)
-    }
-
-    pub(crate) fn unfreeze(
-        &self,
-        admin: &TestSigner,
-        nonce: i128,
-        id: Identifier,
-    ) -> Result<(), HostError> {
-        let signature = sign_args(
-            self.host,
-            admin,
-            "unfreeze",
-            &self.id,
-            host_vec![
-                self.host,
-                admin.get_identifier(self.host),
-                nonce.clone(),
-                id.clone()
-            ],
-        );
-
-        Ok(self
-            .host
-            .call(
-                self.id.clone().into(),
-                Symbol::from_str("unfreeze").into(),
-                host_vec![self.host, signature, nonce, id].into(),
+                Symbol::from_str("set_auth").into(),
+                host_vec![self.host, signature, nonce, id, authorize].into(),
             )?
             .try_into()?)
     }

--- a/soroban-env-host/src/native_contract/token/test_token.rs
+++ b/soroban-env-host/src/native_contract/token/test_token.rs
@@ -299,12 +299,12 @@ impl<'a> TestToken<'a> {
             .try_into()?)
     }
 
-    pub(crate) fn is_frozen(&self, id: Identifier) -> Result<bool, HostError> {
+    pub(crate) fn authorized(&self, id: Identifier) -> Result<bool, HostError> {
         Ok(self
             .host
             .call(
                 self.id.clone().into(),
-                Symbol::from_str("is_frozen").into(),
+                Symbol::from_str("authorized").into(),
                 host_vec![self.host, id].into(),
             )?
             .try_into_val(self.host)?)

--- a/soroban-env-host/src/test/token.rs
+++ b/soroban-env-host/src/test/token.rs
@@ -779,7 +779,7 @@ fn test_freeze_and_unfreeze() {
 }
 
 #[test]
-fn test_burn() {
+fn test_clawback() {
     let test = TokenTest::setup();
     let admin = TestSigner::Ed25519(&test.admin_key);
     let token = test.default_token(&admin);
@@ -800,7 +800,7 @@ fn test_burn() {
     );
 
     token
-        .burn(
+        .clawback(
             &admin,
             token.nonce(admin.get_identifier(&test.host)).unwrap(),
             user.get_identifier(&test.host),
@@ -813,11 +813,11 @@ fn test_burn() {
         60_000_000
     );
 
-    // Can't burn more than the balance
+    // Can't clawback more than the balance
     assert_eq!(
         to_contract_err(
             token
-                .burn(
+                .clawback(
                     &admin,
                     token.nonce(admin.get_identifier(&test.host)).unwrap(),
                     user.get_identifier(&test.host),
@@ -829,9 +829,9 @@ fn test_burn() {
         ContractError::BalanceError
     );
 
-    // Burn everything else
+    // clawback everything else
     token
-        .burn(
+        .clawback(
             &admin,
             token.nonce(admin.get_identifier(&test.host)).unwrap(),
             user.get_identifier(&test.host),
@@ -888,7 +888,7 @@ fn test_set_admin() {
     assert_eq!(
         to_contract_err(
             token
-                .burn(
+                .clawback(
                     &admin,
                     token.nonce(admin.get_identifier(&test.host)).unwrap(),
                     new_admin.get_identifier(&test.host),
@@ -936,7 +936,7 @@ fn test_set_admin() {
         )
         .unwrap();
     token
-        .burn(
+        .clawback(
             &new_admin,
             token.nonce(new_admin.get_identifier(&test.host)).unwrap(),
             admin.get_identifier(&test.host),
@@ -1054,7 +1054,7 @@ fn test_trustline_auth() {
 
     assert_eq!(token.balance(user_id.clone()).unwrap(), 1000);
 
-    // transfer 1 back to the issuer (which is a burn)
+    // transfer 1 back to the issuer (which gets burned)
     test.run_from_account(user_acc.clone(), || {
         token.xfer(&acc_invoker, 0, admin_id.clone(), 1)
     })
@@ -1144,7 +1144,7 @@ fn test_trustline_auth() {
     assert_eq!(
         to_contract_err(
             test.run_from_account(admin_acc.clone(), || {
-                token.burn(&acc_invoker, 0, user_id.clone(), 10)
+                token.clawback(&acc_invoker, 0, user_id.clone(), 10)
             })
             .err()
             .unwrap()
@@ -1165,7 +1165,7 @@ fn test_trustline_auth() {
     );
 
     test.run_from_account(admin_acc.clone(), || {
-        token.burn(&acc_invoker, 0, user_id.clone(), 10)
+        token.clawback(&acc_invoker, 0, user_id.clone(), 10)
     })
     .unwrap();
 
@@ -1430,7 +1430,7 @@ fn test_auth_rejected_with_incorrect_nonce() {
     assert_eq!(
         to_contract_err(
             token
-                .burn(&admin, 2, user.get_identifier(&test.host), 10_000_000,)
+                .clawback(&admin, 2, user.get_identifier(&test.host), 10_000_000,)
                 .err()
                 .unwrap()
         ),
@@ -1510,7 +1510,7 @@ fn test_auth_rejected_for_incorrect_function_name() {
     let signature = sign_args(
         &test.host,
         &admin,
-        "burn",
+        "clawback",
         &token.id,
         host_vec![
             &test.host,
@@ -1849,7 +1849,7 @@ fn test_negative_amounts_are_not_allowed() {
     assert_eq!(
         to_contract_err(
             token
-                .burn(
+                .clawback(
                     &admin,
                     token.nonce(admin.get_identifier(&test.host)).unwrap(),
                     user.get_identifier(&test.host),

--- a/soroban-env-host/src/test/token.rs
+++ b/soroban-env-host/src/test/token.rs
@@ -816,10 +816,11 @@ fn test_burn() {
 
     // Freeze the balance of `user` and then try to burn.
     token
-        .freeze(
+        .set_auth(
             &admin,
             token.nonce(admin.get_identifier(&test.host)).unwrap(),
             user.get_identifier(&test.host),
+            false,
         )
         .unwrap();
 
@@ -840,10 +841,11 @@ fn test_burn() {
 
     // Unfreeze the balance of `user` and then burn.
     token
-        .unfreeze(
+        .set_auth(
             &admin,
             token.nonce(admin.get_identifier(&test.host)).unwrap(),
             user.get_identifier(&test.host),
+            true,
         )
         .unwrap();
 
@@ -926,7 +928,7 @@ fn test_cannot_burn_native() {
 }
 
 #[test]
-fn test_freeze_and_unfreeze() {
+fn test_token_authorization() {
     let test = TokenTest::setup();
     let admin = TestSigner::Ed25519(&test.admin_key);
     let token = test.default_token(&admin);
@@ -954,10 +956,11 @@ fn test_freeze_and_unfreeze() {
 
     // Freeze the balance of `user`.
     token
-        .freeze(
+        .set_auth(
             &admin,
             token.nonce(admin.get_identifier(&test.host)).unwrap(),
             user.get_identifier(&test.host),
+            false,
         )
         .unwrap();
 
@@ -994,10 +997,11 @@ fn test_freeze_and_unfreeze() {
 
     // Unfreeze the balance of `user`.
     token
-        .unfreeze(
+        .set_auth(
             &admin,
             token.nonce(admin.get_identifier(&test.host)).unwrap(),
             user.get_identifier(&test.host),
+            true,
         )
         .unwrap();
 
@@ -1145,10 +1149,11 @@ fn test_set_admin() {
     assert_eq!(
         to_contract_err(
             token
-                .freeze(
+                .set_auth(
                     &admin,
                     token.nonce(admin.get_identifier(&test.host)).unwrap(),
                     new_admin.get_identifier(&test.host),
+                    false
                 )
                 .err()
                 .unwrap()
@@ -1158,10 +1163,11 @@ fn test_set_admin() {
     assert_eq!(
         to_contract_err(
             token
-                .unfreeze(
+                .set_auth(
                     &admin,
                     token.nonce(admin.get_identifier(&test.host)).unwrap(),
                     new_admin.get_identifier(&test.host),
+                    true
                 )
                 .err()
                 .unwrap()
@@ -1187,17 +1193,19 @@ fn test_set_admin() {
         )
         .unwrap();
     token
-        .freeze(
+        .set_auth(
             &new_admin,
             token.nonce(new_admin.get_identifier(&test.host)).unwrap(),
             admin.get_identifier(&test.host),
+            false,
         )
         .unwrap();
     token
-        .unfreeze(
+        .set_auth(
             &new_admin,
             token.nonce(new_admin.get_identifier(&test.host)).unwrap(),
             admin.get_identifier(&test.host),
+            true,
         )
         .unwrap();
 
@@ -1310,7 +1318,7 @@ fn test_trustline_auth() {
     assert_eq!(
         to_contract_err(
             test.run_from_account(admin_acc.clone(), || {
-                token.freeze(&acc_invoker, 0, user_id.clone())
+                token.set_auth(&acc_invoker, 0, user_id.clone(), false)
             })
             .err()
             .unwrap()
@@ -1332,7 +1340,7 @@ fn test_trustline_auth() {
 
     // trustline should be deauthorized now.
     test.run_from_account(admin_acc.clone(), || {
-        token.freeze(&acc_invoker, 0, user_id.clone())
+        token.set_auth(&acc_invoker, 0, user_id.clone(), false)
     })
     .unwrap();
 
@@ -1362,7 +1370,7 @@ fn test_trustline_auth() {
 
     // Now authorize trustline
     test.run_from_account(admin_acc.clone(), || {
-        token.unfreeze(&acc_invoker, 0, user_id.clone())
+        token.set_auth(&acc_invoker, 0, user_id.clone(), true)
     })
     .unwrap();
 

--- a/soroban-env-host/src/test/token.rs
+++ b/soroban-env-host/src/test/token.rs
@@ -814,7 +814,7 @@ fn test_burn() {
         45_000_000
     );
 
-    // Freeze the balance of `user` and then try to burn.
+    // Deauthorize the balance of `user` and then try to burn.
     token
         .set_auth(
             &admin,
@@ -824,7 +824,7 @@ fn test_burn() {
         )
         .unwrap();
 
-    // Can't burn while frozen
+    // Can't burn while deauthorized
     assert_eq!(
         to_contract_err(
             token
@@ -836,10 +836,10 @@ fn test_burn() {
                 .err()
                 .unwrap()
         ),
-        ContractError::BalanceFrozenError
+        ContractError::BalanceDeauthorizedError
     );
 
-    // Unfreeze the balance of `user` and then burn.
+    // Authorize the balance of `user` and then burn.
     token
         .set_auth(
             &admin,
@@ -954,7 +954,7 @@ fn test_token_authorization() {
 
     assert!(token.authorized(user.get_identifier(&test.host)).unwrap());
 
-    // Freeze the balance of `user`.
+    // Deauthorize the balance of `user`.
     token
         .set_auth(
             &admin,
@@ -978,7 +978,7 @@ fn test_token_authorization() {
                 .err()
                 .unwrap()
         ),
-        ContractError::BalanceFrozenError
+        ContractError::BalanceDeauthorizedError
     );
     assert_eq!(
         to_contract_err(
@@ -992,10 +992,10 @@ fn test_token_authorization() {
                 .err()
                 .unwrap()
         ),
-        ContractError::BalanceFrozenError
+        ContractError::BalanceDeauthorizedError
     );
 
-    // Unfreeze the balance of `user`.
+    // Authorize the balance of `user`.
     token
         .set_auth(
             &admin,
@@ -1353,7 +1353,7 @@ fn test_trustline_auth() {
             .err()
             .unwrap()
         ),
-        ContractError::BalanceFrozenError
+        ContractError::BalanceDeauthorizedError
     );
 
     // mint should also fail for the same reason
@@ -1365,7 +1365,7 @@ fn test_trustline_auth() {
             .err()
             .unwrap()
         ),
-        ContractError::BalanceFrozenError
+        ContractError::BalanceDeauthorizedError
     );
 
     // Now authorize trustline
@@ -2719,7 +2719,7 @@ fn test_classic_transfers_not_possible_for_unauthorized_asset() {
                 .err()
                 .unwrap()
         ),
-        ContractError::BalanceFrozenError
+        ContractError::BalanceDeauthorizedError
     );
 
     // Trustline balance stays the same.

--- a/soroban-env-host/src/test/token.rs
+++ b/soroban-env-host/src/test/token.rs
@@ -952,7 +952,7 @@ fn test_token_authorization() {
         )
         .unwrap();
 
-    assert!(!token.is_frozen(user.get_identifier(&test.host)).unwrap());
+    assert!(token.authorized(user.get_identifier(&test.host)).unwrap());
 
     // Freeze the balance of `user`.
     token
@@ -964,7 +964,7 @@ fn test_token_authorization() {
         )
         .unwrap();
 
-    assert!(token.is_frozen(user.get_identifier(&test.host)).unwrap());
+    assert!(!token.authorized(user.get_identifier(&test.host)).unwrap());
     // Make sure neither outgoing nor incoming balance transfers are possible.
     assert_eq!(
         to_contract_err(
@@ -1005,7 +1005,7 @@ fn test_token_authorization() {
         )
         .unwrap();
 
-    assert!(!token.is_frozen(user.get_identifier(&test.host)).unwrap());
+    assert!(token.authorized(user.get_identifier(&test.host)).unwrap());
     // Make sure balance transfers are possible now.
     token
         .xfer(


### PR DESCRIPTION
### What

1. `burn` -> `clawback`
2. Add `burn` and `burnFrom` functions.
3. Remove `approve` and replace with `incr_allow` and `decr_allow` (we have a 10 character limit at the moment. We will update these names once we can work around this limit.
4. Because of the 10 character limit, I did not change `freeze`, `unfreeze`, and `is_frozen` to `authorize`, `deauthorize` (doesn't fit), and `is_authorized` (doesn't fit). We'll come back to this later.