### PR TITLE
Reduce TryInto{,Val} to a blanket, remove several redundant impls

### DIFF
--- a/soroban-env-common/src/array.rs
+++ b/soroban-env-common/src/array.rs
@@ -27,44 +27,26 @@ impl<E: Env, const N: usize> TryFromVal<E, RawVal> for [u8; N] {
     }
 }
 
-impl<E: Env, const N: usize> TryIntoVal<E, [u8; N]> for RawVal {
-    type Error = <[u8; N] as TryFromVal<E, RawVal>>::Error;
-    #[inline(always)]
-    fn try_into_val(self, env: &E) -> Result<[u8; N], Self::Error> {
-        <_ as TryFromVal<_, _>>::try_from_val(env, self)
+impl<E: Env> TryFromVal<E, &[u8]> for RawVal {
+    type Error = Status;
+    fn try_from_val(env: &E, v: &[u8]) -> Result<Self, Self::Error> {
+        Ok(env.bytes_new_from_slice(v)?.to_raw())
     }
 }
 
-impl<E: Env> TryIntoVal<E, RawVal> for &[u8] {
+impl<E: Env, const N: usize> TryFromVal<E, [u8; N]> for RawVal {
     type Error = Status;
-    #[inline(always)]
-    fn try_into_val(self, env: &E) -> Result<RawVal, Self::Error> {
-        Ok(env.bytes_new_from_slice(self)?.to_raw())
-    }
-}
 
-impl<E: Env, const N: usize> TryIntoVal<E, RawVal> for [u8; N] {
-    type Error = Status;
-    #[inline(always)]
-    fn try_into_val(self, env: &E) -> Result<RawVal, Self::Error> {
-        self.as_slice().try_into_val(env)
+    fn try_from_val(env: &E, v: [u8; N]) -> Result<Self, Self::Error> {
+        v.as_slice().try_into_val(env)
     }
 }
 
 #[cfg(feature = "std")]
-impl<E: Env> TryIntoVal<E, RawVal> for Vec<u8> {
+impl<E: Env> TryFromVal<E, Vec<u8>> for RawVal {
     type Error = Status;
-    #[inline(always)]
-    fn try_into_val(self, env: &E) -> Result<RawVal, Self::Error> {
-        (&self).try_into_val(env)
-    }
-}
 
-#[cfg(feature = "std")]
-impl<E: Env> TryIntoVal<E, RawVal> for &Vec<u8> {
-    type Error = Status;
-    #[inline(always)]
-    fn try_into_val(self, env: &E) -> Result<RawVal, Self::Error> {
-        self.as_slice().try_into_val(env)
+    fn try_from_val(env: &E, v: Vec<u8>) -> Result<Self, Self::Error> {
+        v.as_slice().try_into_val(env)
     }
 }

--- a/soroban-env-common/src/env_val.rs
+++ b/soroban-env-common/src/env_val.rs
@@ -12,15 +12,6 @@ use super::{
     Env,
 };
 
-pub trait IntoVal<E: Env, V>: Sized {
-    fn into_val(self, env: &E) -> V;
-}
-
-pub trait TryIntoVal<E: Env, V>: Sized {
-    type Error;
-    fn try_into_val(self, env: &E) -> Result<V, Self::Error>;
-}
-
 pub trait FromVal<E: Env, V>: Sized {
     fn from_val(env: &E, v: V) -> Self;
 }
@@ -29,6 +20,93 @@ pub trait TryFromVal<E: Env, V>: Sized {
     type Error;
     fn try_from_val(env: &E, v: V) -> Result<Self, Self::Error>;
 }
+
+/// As with the design in the Rust stdlib's Into type, the IntoVal
+/// trait is defined as a convenience form with a blanket impl that
+/// calls into the corresponding FromVal impl.
+pub trait IntoVal<E: Env, V>: Sized {
+    fn into_val(self, env: &E) -> V;
+}
+
+impl<E: Env, T, F> IntoVal<E, T> for F
+where
+    T: FromVal<E, F>,
+{
+    fn into_val(self, env: &E) -> T {
+        T::from_val(env, self)
+    }
+}
+
+/// As with the design in the Rust stdlib's Into type, the TryIntoVal
+/// trait is defined as a convenience form with a blanket impl that
+/// calls into the corresponding TryFromVal impl.
+pub trait TryIntoVal<E: Env, V>: Sized {
+    type Error;
+    fn try_into_val(self, env: &E) -> Result<V, Self::Error>;
+}
+
+impl<E: Env, T, F> TryIntoVal<E, T> for F
+where
+    T: TryFromVal<E, F>,
+{
+    type Error = T::Error;
+
+    fn try_into_val(self, env: &E) -> Result<T, Self::Error> {
+        T::try_from_val(env, self)
+    }
+}
+
+// In the Rust stdlib's TryFrom type, an infallible conversion is semantically
+// equivalent to a fallible conversion with an uninhabited error type.
+//
+// Unfortunately since all other impls of TryFromVal are blankets -- unlike most
+// concrete TryFrom impls in the Rust stdlib, our impls are generic in E:Env --
+// we can't have this blanket impl here for any generic type T, as it will be
+// considered as colliding with all other blankets. Blankets are apparently
+// considered for collision against one another but not concrete impls. The
+// orphan rules are subtle.
+/*
+impl<E:Env, T, F> TryFromVal<E, F> for T
+where
+    F: IntoVal<E, T>
+{
+    type Error = Infallible;
+
+    fn try_from_val(env: &E, v: F) -> Result<Self, Self::Error> {
+        Ok(F::into_val(v, env))
+    }
+}
+*/
+
+// Similarly, we'd like to have that an environment-free `F: Into<T>` implies
+// `T: FromVal<E, F>` that ignores its environment, but this will collide with
+// all other generic FromVal impls.
+/*
+impl<E:Env, T, F> FromVal<E, F> for T
+where
+    F: Into<T>
+{
+    fn from_val(_env: &E, v: F) -> Self {
+        v.into()
+    }
+}
+*/
+
+// Similarly, we'd like to have that an environment-free `F: TryInto<T>`
+// implies `T: TryFromVal<E, F>` that ignores its environment, but this
+// will collide with all other generic TryFromVal impls.
+/*
+impl<E:Env, T, F> TryFromVal<E, F> for T
+where
+    F: TryInto<T>
+{
+    type Error = F::Error;
+
+    fn try_from_val(_env: &E, v: F) -> Result<Self, Self::Error> {
+        v.try_into()
+    }
+}
+*/
 
 pub(crate) fn log_err_convert<T>(env: &impl Env, val: &impl AsRef<RawVal>) {
     // Logging here is best-effort; ignore failures (they only arise if we're
@@ -55,34 +133,21 @@ impl<E: Env> TryFromVal<E, RawVal> for i64 {
         }
     }
 }
-
-impl<E: Env> IntoVal<E, RawVal> for i64 {
-    fn into_val(self, env: &E) -> RawVal {
-        if self >= 0 {
-            unsafe { RawVal::unchecked_from_u63(self) }
-        } else {
-            env.obj_from_i64(self).to_raw()
-        }
-    }
-}
-
-impl<E: Env> IntoVal<E, RawVal> for &i64 {
-    fn into_val(self, env: &E) -> RawVal {
-        (*self).into_val(env)
-    }
-}
-
-impl<E: Env> TryIntoVal<E, RawVal> for i64 {
+// This is only required for the UDT code to call, users should
+// call FromVal since it's not fallible.
+impl<E: Env> TryFromVal<E, i64> for RawVal {
     type Error = ConversionError;
-    fn try_into_val(self, env: &E) -> Result<RawVal, Self::Error> {
-        Ok(IntoVal::into_val(self, env))
+    fn try_from_val(env: &E, v: i64) -> Result<Self, Self::Error> {
+        Ok(v.into_val(env))
     }
 }
-
-impl<E: Env> TryIntoVal<E, i64> for RawVal {
-    type Error = <i64 as TryFromVal<E, RawVal>>::Error;
-    fn try_into_val(self, env: &E) -> Result<i64, Self::Error> {
-        <_ as TryFromVal<_, _>>::try_from_val(env, self)
+impl<E: Env> FromVal<E, i64> for RawVal {
+    fn from_val(env: &E, v: i64) -> Self {
+        if v >= 0 {
+            unsafe { RawVal::unchecked_from_u63(v) }
+        } else {
+            env.obj_from_i64(v).to_raw()
+        }
     }
 }
 
@@ -100,146 +165,82 @@ impl<E: Env> TryFromVal<E, RawVal> for u64 {
     }
 }
 
-impl<E: Env> IntoVal<E, RawVal> for u64 {
-    fn into_val(self, env: &E) -> RawVal {
-        env.obj_from_u64(self).to_raw()
-    }
-}
-
-impl<E: Env> IntoVal<E, RawVal> for &u64 {
-    fn into_val(self, env: &E) -> RawVal {
-        (*self).into_val(env)
-    }
-}
-
-impl<E: Env> TryIntoVal<E, RawVal> for u64 {
-    type Error = ConversionError;
-    fn try_into_val(self, env: &E) -> Result<RawVal, Self::Error> {
-        Ok(IntoVal::into_val(self, env))
-    }
-}
-
-impl<E: Env> TryIntoVal<E, u64> for RawVal {
-    type Error = <u64 as TryFromVal<E, RawVal>>::Error;
-    fn try_into_val(self, env: &E) -> Result<u64, Self::Error> {
-        <_ as TryFromVal<_, _>>::try_from_val(env, self)
+impl<E: Env> FromVal<E, u64> for RawVal {
+    fn from_val(env: &E, v: u64) -> Self {
+        env.obj_from_u64(v).to_raw()
     }
 }
 
 // Innermost conversions: infallible {ui}128 -> Object and
 // fallible Object -> {ui}128
-impl<E: Env> IntoVal<E, Object> for u128 {
-    fn into_val(self, env: &E) -> Object {
-        env.obj_from_u128_pieces(self as u64, (self >> 64) as u64)
+impl<E: Env> FromVal<E, u128> for Object {
+    fn from_val(env: &E, v: u128) -> Self {
+        env.obj_from_u128_pieces(v as u64, (v >> 64) as u64)
     }
 }
 
-impl<E: Env> IntoVal<E, Object> for i128 {
-    fn into_val(self, env: &E) -> Object {
-        env.obj_from_i128_pieces(self as u64, (self as u128 >> 64) as u64)
+impl<E: Env> FromVal<E, i128> for Object {
+    fn from_val(env: &E, v: i128) -> Self {
+        env.obj_from_i128_pieces(v as u64, (v as u128 >> 64) as u64)
     }
 }
 
-impl<E: Env> TryIntoVal<E, u128> for Object {
+impl<E: Env> TryFromVal<E, Object> for u128 {
     type Error = ConversionError;
 
-    fn try_into_val(self, env: &E) -> Result<u128, Self::Error> {
-        let lo = env.obj_to_u128_lo64(self);
-        let hi = env.obj_to_u128_hi64(self);
+    fn try_from_val(env: &E, v: Object) -> Result<Self, Self::Error> {
+        let lo = env.obj_to_u128_lo64(v);
+        let hi = env.obj_to_u128_hi64(v);
         let u: u128 = (lo as u128) | ((hi as u128) << 64);
         Ok(u)
     }
 }
 
-impl<E: Env> TryIntoVal<E, i128> for Object {
+impl<E: Env> TryFromVal<E, Object> for i128 {
     type Error = ConversionError;
 
-    fn try_into_val(self, env: &E) -> Result<i128, Self::Error> {
-        let lo = env.obj_to_i128_lo64(self);
-        let hi = env.obj_to_i128_hi64(self);
+    fn try_from_val(env: &E, v: Object) -> Result<Self, Self::Error> {
+        let lo = env.obj_to_i128_lo64(v);
+        let hi = env.obj_to_i128_hi64(v);
         let u: u128 = (lo as u128) | ((hi as u128) << 64);
         Ok(u as i128)
     }
 }
 
-macro_rules! decl_int128_conversions {
+macro_rules! decl_rawval_conversions_via_object {
     ($T:ty) => {
-        // RawVal-typed versions delegate to Object-typed
-        impl<E: Env> IntoVal<E, RawVal> for $T {
-            fn into_val(self, env: &E) -> RawVal {
-                <Self as IntoVal<E, Object>>::into_val(self, env).to_raw()
-            }
-        }
-        impl<E: Env> TryIntoVal<E, $T> for RawVal {
-            type Error = ConversionError;
-            fn try_into_val(self, env: &E) -> Result<$T, Self::Error> {
-                let ob: Object = self.try_into_val(env)?;
-                <Object as TryIntoVal<E, $T>>::try_into_val(ob, env)
-            }
-        }
-        // Infallible reference-types delegate to deref
-        impl<E: Env> IntoVal<E, Object> for &$T {
-            fn into_val(self, env: &E) -> Object {
-                (*self).into_val(env)
-            }
-        }
-        impl<E: Env> IntoVal<E, RawVal> for &$T {
-            fn into_val(self, env: &E) -> RawVal {
-                (*self).into_val(env)
-            }
-        }
-        // Fallibe versions of infallibe injections just delegate to them.
-        impl<E: Env> TryIntoVal<E, RawVal> for $T {
-            type Error = ConversionError;
-
-            fn try_into_val(self, env: &E) -> Result<RawVal, Self::Error> {
-                Ok(<Self as IntoVal<E, RawVal>>::into_val(self, env).into())
-            }
-        }
-
-        impl<E: Env> TryIntoVal<E, RawVal> for &$T {
-            type Error = ConversionError;
-
-            fn try_into_val(self, env: &E) -> Result<RawVal, Self::Error> {
-                Ok(<Self as IntoVal<E, RawVal>>::into_val(self, env).into())
-            }
-        }
-
-        impl<E: Env> TryIntoVal<E, Object> for $T {
-            type Error = ConversionError;
-
-            fn try_into_val(self, env: &E) -> Result<Object, Self::Error> {
-                Ok(<Self as IntoVal<E, Object>>::into_val(self, env).into())
-            }
-        }
-
-        impl<E: Env> TryIntoVal<E, Object> for &$T {
-            type Error = ConversionError;
-
-            fn try_into_val(self, env: &E) -> Result<Object, Self::Error> {
-                Ok(<Self as IntoVal<E, Object>>::into_val(self, env).into())
-            }
-        }
-        // TryFrom impls delegate to TryInto impls the other direction
         impl<E: Env> TryFromVal<E, RawVal> for $T {
             type Error = ConversionError;
 
             fn try_from_val(env: &E, val: RawVal) -> Result<Self, Self::Error> {
-                <RawVal as TryIntoVal<E, $T>>::try_into_val(val, env)
+                let ob: Object = val.try_into()?;
+                ob.try_into_val(env)
             }
         }
-        impl<E: Env> TryFromVal<E, Object> for $T {
+        // This is only required for the UDT code to call, users should
+        // call FromVal since it's not fallible.
+        impl<E: Env> TryFromVal<E, $T> for RawVal {
             type Error = ConversionError;
-
-            fn try_from_val(env: &E, val: Object) -> Result<Self, Self::Error> {
-                <Object as TryIntoVal<E, $T>>::try_into_val(val, env)
+            fn try_from_val(env: &E, v: $T) -> Result<Self, Self::Error> {
+                let ob: Object = v.into_val(env);
+                Ok(ob.to_raw())
+            }
+        }
+        impl<E: Env> FromVal<E, $T> for RawVal {
+            fn from_val(env: &E, v: $T) -> Self {
+                let ob: Object = v.into_val(env);
+                ob.to_raw()
             }
         }
     };
 }
 
-decl_int128_conversions!(u128);
-decl_int128_conversions!(i128);
+// TODO: we should arrange to convert all object types to and from Object and
+// RawVal the same way; u128 and i128 work differently than the others here --
+// fallibility differs, the fast path differs, the use of delegation differs --
+// which is wrong. Not fatally wrong, but pointless difference.
+decl_rawval_conversions_via_object!(u128);
+decl_rawval_conversions_via_object!(i128);
 
 #[cfg(feature = "std")]
 impl<E: Env> TryFromVal<E, RawVal> for ScVal
@@ -299,25 +300,14 @@ where
 }
 
 #[cfg(feature = "std")]
-impl<E: Env> TryIntoVal<E, ScVal> for RawVal
-where
-    ScObject: TryFromVal<E, Object>,
-{
-    type Error = <ScVal as TryFromVal<E, RawVal>>::Error;
-
-    fn try_into_val(self, env: &E) -> Result<ScVal, Self::Error> {
-        <_ as TryFromVal<E, RawVal>>::try_from_val(env, self)
-    }
-}
-
-#[cfg(feature = "std")]
-impl<E: Env> TryIntoVal<E, RawVal> for &ScVal
+impl<E: Env> TryFromVal<E, &ScVal> for RawVal
 where
     for<'a> &'a ScObject: TryIntoVal<E, Object>,
 {
     type Error = ConversionError;
-    fn try_into_val(self, env: &E) -> Result<RawVal, Self::Error> {
-        Ok(match self {
+
+    fn try_from_val(env: &E, v: &ScVal) -> Result<Self, Self::Error> {
+        Ok(match v {
             ScVal::U63(i) => {
                 if *i >= 0 {
                     unsafe { RawVal::unchecked_from_u63(*i) }
@@ -345,14 +335,14 @@ where
         })
     }
 }
-
 #[cfg(feature = "std")]
-impl<E: Env> TryIntoVal<E, RawVal> for ScVal
+impl<E: Env> TryFromVal<E, ScVal> for RawVal
 where
     for<'a> &'a ScObject: TryIntoVal<E, Object>,
 {
     type Error = ConversionError;
-    fn try_into_val(self, env: &E) -> Result<RawVal, Self::Error> {
-        (&self).try_into_val(env)
+
+    fn try_from_val(env: &E, v: ScVal) -> Result<Self, Self::Error> {
+        (&v).try_into_val(env)
     }
 }

--- a/soroban-env-common/src/object.rs
+++ b/soroban-env-common/src/object.rs
@@ -62,49 +62,55 @@ where
     }
 }
 
-impl<'a, E> TryIntoVal<E, Object> for &'a ScObject
+impl<'a, E> TryFromVal<E, &'a ScObject> for Object
 where
     E: Env + Convert<&'a ScObject, Object>,
 {
     type Error = E::Error;
-    fn try_into_val(self, env: &E) -> Result<Object, Self::Error> {
-        env.convert(self)
+
+    fn try_from_val(env: &E, v: &'a ScObject) -> Result<Self, Self::Error> {
+        env.convert(v)
     }
 }
 
-impl<E> TryIntoVal<E, Object> for ScObject
+impl<E> TryFromVal<E, ScObject> for Object
 where
     E: Env + Convert<ScObject, Object>,
 {
     type Error = E::Error;
-    fn try_into_val(self, env: &E) -> Result<Object, Self::Error> {
-        env.convert(self)
+
+    fn try_from_val(env: &E, v: ScObject) -> Result<Self, Self::Error> {
+        env.convert(v)
     }
 }
 
-impl<'a, E> TryIntoVal<E, Object> for &'a ScVal
+impl<'a, E> TryFromVal<E, &'a ScVal> for Object
 where
     E: Env + Convert<&'a ScObject, Object>,
 {
     type Error = E::Error;
-    fn try_into_val(self, env: &E) -> Result<Object, Self::Error> {
-        if let ScVal::Object(Some(o)) = self {
+
+    fn try_from_val(env: &E, v: &'a ScVal) -> Result<Self, Self::Error> {
+        if let ScVal::Object(Some(o)) = v {
             o.try_into_val(env)
         } else {
+            // TODO: synthesize the appropriate error
             todo!()
         }
     }
 }
 
-impl<E> TryIntoVal<E, Object> for ScVal
+impl<E> TryFromVal<E, ScVal> for Object
 where
     E: Env + Convert<ScObject, Object>,
 {
     type Error = E::Error;
-    fn try_into_val(self, env: &E) -> Result<Object, Self::Error> {
-        if let ScVal::Object(Some(o)) = self {
+
+    fn try_from_val(env: &E, v: ScVal) -> Result<Self, Self::Error> {
+        if let ScVal::Object(Some(o)) = v {
             o.try_into_val(env)
         } else {
+            // TODO: synthesize the appropriate error
             todo!()
         }
     }

--- a/soroban-env-common/src/option.rs
+++ b/soroban-env-common/src/option.rs
@@ -1,10 +1,10 @@
-use crate::{Env, IntoVal, RawVal, TryFromVal, TryIntoVal};
+use crate::{Env, FromVal, IntoVal, RawVal, TryFromVal, TryIntoVal};
 
 impl<E: Env, T> TryFromVal<E, RawVal> for Option<T>
 where
     T: TryFromVal<E, RawVal>,
 {
-    type Error = T::Error;
+    type Error = <RawVal as TryIntoVal<E, T>>::Error;
 
     fn try_from_val(env: &E, val: RawVal) -> Result<Self, Self::Error> {
         if val.is_void() {
@@ -15,37 +15,41 @@ where
     }
 }
 
-impl<E: Env, T> TryIntoVal<E, Option<T>> for RawVal
+impl<E: Env, T> TryFromVal<E, Option<T>> for RawVal
 where
-    T: TryFromVal<E, RawVal>,
+    T: TryIntoVal<E, RawVal>,
 {
     type Error = T::Error;
-    #[inline(always)]
-    fn try_into_val(self, env: &E) -> Result<Option<T>, Self::Error> {
-        <_ as TryFromVal<E, RawVal>>::try_from_val(env, self)
-    }
-}
 
-impl<E: Env, T> IntoVal<E, RawVal> for &Option<T>
-where
-    for<'a> &'a T: IntoVal<E, RawVal>,
-{
-    fn into_val(self, env: &E) -> RawVal {
-        match self {
-            Some(t) => t.into_val(env),
-            None => RawVal::from_void(),
+    fn try_from_val(env: &E, v: Option<T>) -> Result<Self, Self::Error> {
+        match v {
+            Some(e) => e.try_into_val(env),
+            None => Ok(RawVal::VOID),
         }
     }
 }
 
-impl<E: Env, T> IntoVal<E, RawVal> for Option<T>
+impl<E: Env, T> FromVal<E, RawVal> for Option<T>
+where
+    T: FromVal<E, RawVal>,
+{
+    fn from_val(env: &E, v: RawVal) -> Self {
+        if v.is_void() {
+            None
+        } else {
+            Some(v.into_val(env))
+        }
+    }
+}
+
+impl<E: Env, T> FromVal<E, Option<T>> for RawVal
 where
     T: IntoVal<E, RawVal>,
 {
-    fn into_val(self, env: &E) -> RawVal {
-        match self {
+    fn from_val(env: &E, v: Option<T>) -> Self {
+        match v {
             Some(t) => t.into_val(env),
-            None => RawVal::from_void(),
+            None => RawVal::VOID,
         }
     }
 }

--- a/soroban-env-common/src/result.rs
+++ b/soroban-env-common/src/result.rs
@@ -1,4 +1,4 @@
-use crate::{ConversionError, Env, IntoVal, RawVal, Status, TryFromVal, TryIntoVal};
+use crate::{ConversionError, Env, FromVal, IntoVal, RawVal, Status, TryFromVal};
 
 impl<E: Env, T, R> TryFromVal<E, RawVal> for Result<T, R>
 where
@@ -9,7 +9,7 @@ where
 
     #[inline(always)]
     fn try_from_val(env: &E, val: RawVal) -> Result<Self, Self::Error> {
-        if let Ok(status) = Status::try_from_val(env, val) {
+        if let Ok(status) = Status::try_from(val) {
             Ok(Err(status.try_into().map_err(|_| ConversionError)?))
         } else {
             Ok(Ok(T::try_from_val(env, val)?))
@@ -17,48 +17,33 @@ where
     }
 }
 
-impl<E: Env, T, R> TryIntoVal<E, Result<T, R>> for RawVal
-where
-    T: TryFromVal<E, RawVal, Error = ConversionError>,
-    R: TryFrom<Status>,
-{
-    type Error = ConversionError;
-
-    #[inline(always)]
-    fn try_into_val(self, env: &E) -> Result<Result<T, R>, Self::Error> {
-        <_ as TryFromVal<E, RawVal>>::try_from_val(env, self)
-    }
-}
-
-impl<E: Env, T, R> IntoVal<E, RawVal> for Result<T, R>
+impl<E: Env, T, R> FromVal<E, Result<T, R>> for RawVal
 where
     T: IntoVal<E, RawVal>,
     R: Into<Status>,
 {
-    #[inline(always)]
-    fn into_val(self, env: &E) -> RawVal {
-        match self {
+    fn from_val(env: &E, v: Result<T, R>) -> Self {
+        match v {
             Ok(t) => t.into_val(env),
             Err(r) => {
                 let status: Status = r.into();
-                status.into_val(env)
+                status.into()
             }
         }
     }
 }
 
-impl<E: Env, T, R> IntoVal<E, RawVal> for &Result<T, R>
+impl<E: Env, T, R> FromVal<E, &Result<T, R>> for RawVal
 where
     for<'a> &'a T: IntoVal<E, RawVal>,
     for<'a> &'a R: Into<Status>,
 {
-    #[inline(always)]
-    fn into_val(self, env: &E) -> RawVal {
-        match self {
+    fn from_val(env: &E, v: &Result<T, R>) -> Self {
+        match v {
             Ok(t) => t.into_val(env),
             Err(r) => {
                 let status: Status = r.into();
-                status.into_val(env)
+                status.into()
             }
         }
     }

--- a/soroban-env-common/src/str.rs
+++ b/soroban-env-common/src/str.rs
@@ -1,10 +1,10 @@
-use crate::{ConversionError, Env, RawVal, TryIntoVal};
+use crate::{ConversionError, Env, RawVal, TryFromVal};
 
 #[cfg(feature = "std")]
 use stellar_xdr::ScObjectType;
 
 #[cfg(feature = "std")]
-use crate::{Object, RawValConvertible, TryFromVal};
+use crate::{Object, RawValConvertible, TryIntoVal};
 
 // TODO: these conversions happen as RawVal, but they actually take and produce
 // Objects; consider making the signatures tighter.
@@ -15,7 +15,7 @@ impl<E: Env> TryFromVal<E, RawVal> for String {
 
     #[inline(always)]
     fn try_from_val(env: &E, val: RawVal) -> Result<Self, Self::Error> {
-        let obj: Object = val.try_into_val(env)?;
+        let obj: Object = val.try_into()?;
         if obj.is_obj_type(ScObjectType::Bytes) {
             let len = unsafe { <u32 as RawValConvertible>::unchecked_from_val(env.bytes_len(obj)) };
             let mut vec = std::vec![0; len as usize];
@@ -28,41 +28,31 @@ impl<E: Env> TryFromVal<E, RawVal> for String {
     }
 }
 
-#[cfg(feature = "std")]
-impl<E: Env> TryIntoVal<E, String> for RawVal {
+impl<E: Env> TryFromVal<E, &str> for RawVal {
     type Error = ConversionError;
 
-    #[inline(always)]
-    fn try_into_val(self, env: &E) -> Result<String, Self::Error> {
-        <_ as TryFromVal<E, RawVal>>::try_from_val(env, self)
-    }
-}
-
-impl<E: Env> TryIntoVal<E, RawVal> for &str {
-    type Error = ConversionError;
-    #[inline(always)]
-    fn try_into_val(self, env: &E) -> Result<RawVal, Self::Error> {
+    fn try_from_val(env: &E, v: &str) -> Result<Self, Self::Error> {
         Ok(env
-            .bytes_new_from_slice(self.as_bytes())
+            .bytes_new_from_slice(v.as_bytes())
             .map_err(|_| ConversionError)?
             .to_raw())
     }
 }
 
 #[cfg(feature = "std")]
-impl<E: Env> TryIntoVal<E, RawVal> for String {
+impl<E: Env> TryFromVal<E, String> for RawVal {
     type Error = ConversionError;
-    #[inline(always)]
-    fn try_into_val(self, env: &E) -> Result<RawVal, Self::Error> {
-        (&self).try_into_val(env)
+
+    fn try_from_val(env: &E, v: String) -> Result<Self, Self::Error> {
+        v.as_str().try_into_val(env)
     }
 }
 
 #[cfg(feature = "std")]
-impl<E: Env> TryIntoVal<E, RawVal> for &String {
+impl<E: Env> TryFromVal<E, &String> for RawVal {
     type Error = ConversionError;
-    #[inline(always)]
-    fn try_into_val(self, env: &E) -> Result<RawVal, Self::Error> {
-        self.as_str().try_into_val(env)
+
+    fn try_from_val(env: &E, v: &String) -> Result<Self, Self::Error> {
+        v.as_str().try_into_val(env)
     }
 }

--- a/soroban-env-host/src/native_contract/base_types.rs
+++ b/soroban-env-host/src/native_contract/base_types.rs
@@ -43,19 +43,11 @@ impl TryFromVal<Host, RawVal> for Bytes {
     }
 }
 
-impl TryIntoVal<Host, Bytes> for RawVal {
+impl TryFromVal<Host, Bytes> for RawVal {
     type Error = HostError;
 
-    fn try_into_val(self, env: &Host) -> Result<Bytes, Self::Error> {
-        <_ as TryFromVal<_, RawVal>>::try_from_val(env, self.try_into()?)
-    }
-}
-
-impl TryIntoVal<Host, RawVal> for Bytes {
-    type Error = HostError;
-
-    fn try_into_val(self, _env: &Host) -> Result<RawVal, Self::Error> {
-        Ok(self.object.into())
+    fn try_from_val(_env: &Host, val: Bytes) -> Result<RawVal, Self::Error> {
+        Ok(val.object.into())
     }
 }
 
@@ -144,19 +136,11 @@ impl<const N: usize> TryFromVal<Host, RawVal> for BytesN<N> {
     }
 }
 
-impl<const N: usize> TryIntoVal<Host, BytesN<N>> for RawVal {
+impl<const N: usize> TryFromVal<Host, BytesN<N>> for RawVal {
     type Error = HostError;
 
-    fn try_into_val(self, env: &Host) -> Result<BytesN<N>, Self::Error> {
-        <_ as TryFromVal<_, RawVal>>::try_from_val(env, self.try_into()?)
-    }
-}
-
-impl<const N: usize> TryIntoVal<Host, RawVal> for BytesN<N> {
-    type Error = HostError;
-
-    fn try_into_val(self, _env: &Host) -> Result<RawVal, Self::Error> {
-        Ok(self.object.into())
+    fn try_from_val(_env: &Host, val: BytesN<N>) -> Result<RawVal, Self::Error> {
+        Ok(val.object.into())
     }
 }
 
@@ -234,19 +218,11 @@ impl TryFromVal<Host, RawVal> for Map {
     }
 }
 
-impl TryIntoVal<Host, Map> for RawVal {
+impl TryFromVal<Host, Map> for RawVal {
     type Error = HostError;
 
-    fn try_into_val(self, env: &Host) -> Result<Map, Self::Error> {
-        <_ as TryFromVal<_, RawVal>>::try_from_val(env, self.try_into()?)
-    }
-}
-
-impl TryIntoVal<Host, RawVal> for Map {
-    type Error = HostError;
-
-    fn try_into_val(self, _env: &Host) -> Result<RawVal, Self::Error> {
-        Ok(self.object.into())
+    fn try_from_val(_env: &Host, val: Map) -> Result<RawVal, Self::Error> {
+        Ok(val.object.into())
     }
 }
 
@@ -331,19 +307,19 @@ impl TryFromVal<Host, RawVal> for Vec {
     }
 }
 
-impl TryIntoVal<Host, Vec> for RawVal {
+impl TryFromVal<Host, Vec> for RawVal {
     type Error = HostError;
 
-    fn try_into_val(self, env: &Host) -> Result<Vec, Self::Error> {
-        <_ as TryFromVal<_, RawVal>>::try_from_val(env, self.try_into()?)
+    fn try_from_val(_env: &Host, val: Vec) -> Result<RawVal, Self::Error> {
+        Ok(val.object.into())
     }
 }
 
-impl TryIntoVal<Host, RawVal> for Vec {
+impl TryFromVal<Host, Vec> for Object {
     type Error = HostError;
 
-    fn try_into_val(self, _env: &Host) -> Result<RawVal, Self::Error> {
-        Ok(self.object.into())
+    fn try_from_val(_env: &Host, val: Vec) -> Result<Object, Self::Error> {
+        Ok(val.object)
     }
 }
 
@@ -372,7 +348,7 @@ impl Vec {
 
     pub fn len(&self) -> Result<u32, HostError> {
         let rv = self.host.vec_len(self.object)?;
-        Ok(u32::try_from_val(&self.host, rv)?)
+        Ok(u32::try_from(rv)?)
     }
 
     pub fn push<T: TryIntoVal<Host, RawVal>>(&mut self, x: T) -> Result<(), HostError>


### PR DESCRIPTION
This is Yet Another Attempt at cleaning up the {Try,}{From,Into}{,Val} traits. The logic at work in this attempt is:

1. Try to follow the rust stdlib design where `Into` variants are _only_ defined as blankets that delegate to `From` variants. Specifically this means:
  - We keep the `Into` variants around as syntactic convenience (so we can use them as constraints in impls and call `.into()` or `.into_val()` or `.try_into_val()` when needed), which avoids the problem in earlier attempts of having to contort code to make up for only one direction being defined. Both are allowed and you can write whichever makes sense in a constraint or call.
  -  But: we do not define, or encourage users to define, any `Into` variants besides the blankets. **Only ever write `From` variants in our code, UDT-generated or otherwise**. This mostly accomplishes the original goal of "less conversion boilerplate".
2. Unfortunately, since all our impls are generic in `E:Env`, we can't have any blanket `TryFromVal` that delegates to `FromVal` or `From`: those are considered colliding by the coherence rules. So we can't _totally_ follow the rust stdlib design that does such delegation; we have to write a few redundant imlpls if we want `TryFromVal` for all types.
3. We could just ignore `TryFromVal` in cases we don't need it -- tell users to call `FromVal` or `From` as appropriate -- but the UDT code calls `TryFromVal` on everything, because it has no idea which types need it. So we do need the otherwise-redundant `TryFromVal` impls.

I haven't gone through the SDK yet to see how this approach fares there, but it appears to be not-terribly-disruptive in the env, so I'm hopeful. Will do the SDK next.

There is also a remaining design question to answer about how much to chain conversions of object types via `Object` specifically vs. converting to and from `RawVal` directly. But I think this is a step in the right direction.

(Incidentally I'm also thinking of renaming `TryFromVal` into `TryFromVia`, because the `Val` suffix really isn't meaningful here and the relevant difference is that it uses an auxiliary environment argument to help with the conversion. WDYT?)