### PR TITLE
Reform TryFromVal to reduce number of impls.

### DIFF
--- a/soroban-env-common/src/array.rs
+++ b/soroban-env-common/src/array.rs
@@ -1,14 +1,15 @@
 use crate::xdr::ScHostValErrorCode;
-use core::borrow::Borrow;
 use stellar_xdr::ScObjectType;
 
-use crate::{ConversionError, Env, Object, RawVal, RawValConvertible, Status, TryFromVal};
+use crate::{
+    ConversionError, Env, Object, RawVal, RawValConvertible, Status, TryFromVal, TryIntoVal,
+};
 
 impl<E: Env, const N: usize> TryFromVal<E, RawVal> for [u8; N] {
     type Error = Status;
 
-    fn try_from_val(env: &E, val: impl Borrow<RawVal>) -> Result<Self, Self::Error> {
-        let val = *val.borrow();
+    fn try_from_val(env: &E, val: &RawVal) -> Result<Self, Self::Error> {
+        let val = *val;
         if !Object::val_is_obj_type(val, ScObjectType::Bytes) {
             return Err(ScHostValErrorCode::UnexpectedValType.into());
         }
@@ -27,8 +28,8 @@ impl<E: Env, const N: usize> TryFromVal<E, RawVal> for [u8; N] {
 impl<E: Env> TryFromVal<E, RawVal> for Vec<u8> {
     type Error = Status;
 
-    fn try_from_val(env: &E, val: impl Borrow<RawVal>) -> Result<Self, Self::Error> {
-        let val = *val.borrow();
+    fn try_from_val(env: &E, val: &RawVal) -> Result<Self, Self::Error> {
+        let val = *val;
         if !Object::val_is_obj_type(val, ScObjectType::Bytes) {
             return Err(ScHostValErrorCode::UnexpectedValType.into());
         }
@@ -40,41 +41,27 @@ impl<E: Env> TryFromVal<E, RawVal> for Vec<u8> {
     }
 }
 
-impl<E: Env> TryFromVal<E, [u8]> for RawVal {
+impl<E: Env> TryFromVal<E, &[u8]> for RawVal {
     type Error = Status;
     #[inline(always)]
-    fn try_from_val(env: &E, v: impl Borrow<[u8]>) -> Result<RawVal, Self::Error> {
-        Ok(env.bytes_new_from_slice(v.borrow())?.to_raw())
+    fn try_from_val(env: &E, v: &&[u8]) -> Result<RawVal, Self::Error> {
+        Ok(env.bytes_new_from_slice(v)?.to_raw())
     }
 }
 
-// Technically this impl is redundant but it makes users have to type less
-// boilerplate at call sites when converting [u8;N]
 impl<E: Env, const N: usize> TryFromVal<E, [u8; N]> for RawVal {
     type Error = Status;
 
-    fn try_from_val(env: &E, v: impl Borrow<[u8; N]>) -> Result<Self, Self::Error> {
-        <RawVal as TryFromVal<E, [u8]>>::try_from_val(env, v.borrow().as_slice())
+    fn try_from_val(env: &E, v: &[u8; N]) -> Result<Self, Self::Error> {
+        v.as_slice().try_into_val(env)
     }
 }
 
-// Technically this impl is redundant but it makes users have to type less
-// boilerplate at call sites when converting &[u8]
-impl<'a, E: Env> TryFromVal<E, &'a [u8]> for RawVal {
-    type Error = Status;
-
-    fn try_from_val(env: &E, v: impl Borrow<&'a [u8]>) -> Result<Self, Self::Error> {
-        <RawVal as TryFromVal<E, [u8]>>::try_from_val(env, *v.borrow())
-    }
-}
-
-// Technically this impl is redundant but it makes users have to type less
-// boilerplate at call sites when converting Vec<u8>
 #[cfg(feature = "std")]
 impl<E: Env> TryFromVal<E, Vec<u8>> for RawVal {
     type Error = Status;
 
-    fn try_from_val(env: &E, v: impl Borrow<Vec<u8>>) -> Result<Self, Self::Error> {
-        <RawVal as TryFromVal<E, [u8]>>::try_from_val(env, v.borrow().as_slice())
+    fn try_from_val(env: &E, v: &Vec<u8>) -> Result<Self, Self::Error> {
+        v.as_slice().try_into_val(env)
     }
 }

--- a/soroban-env-common/src/array.rs
+++ b/soroban-env-common/src/array.rs
@@ -1,24 +1,20 @@
 use crate::xdr::ScHostValErrorCode;
+use core::borrow::Borrow;
 use stellar_xdr::ScObjectType;
 
-use crate::{
-    ConversionError, Env, Object, RawVal, RawValConvertible, Status, TryFromVal, TryIntoVal,
-};
-
-// TODO: these conversions happen as RawVal, but they actually take and produce
-// Objects; consider making the signatures tighter.
+use crate::{ConversionError, Env, Object, RawVal, RawValConvertible, Status, TryFromVal};
 
 impl<E: Env, const N: usize> TryFromVal<E, RawVal> for [u8; N] {
     type Error = Status;
 
-    fn try_from_val(env: &E, val: RawVal) -> Result<Self, Self::Error> {
+    fn try_from_val(env: &E, val: impl Borrow<RawVal>) -> Result<Self, Self::Error> {
+        let val = *val.borrow();
         if !Object::val_is_obj_type(val, ScObjectType::Bytes) {
             return Err(ScHostValErrorCode::UnexpectedValType.into());
         }
-        let env = env.clone();
         let bytes = unsafe { Object::unchecked_from_val(val) };
-        let len = unsafe { u32::unchecked_from_val(env.bytes_len(bytes)) };
-        if len as usize != N {
+        let len = unsafe { u32::unchecked_from_val(env.bytes_len(bytes)) } as usize;
+        if len != N {
             return Err(ConversionError.into());
         }
         let mut arr = [0u8; N];
@@ -27,44 +23,58 @@ impl<E: Env, const N: usize> TryFromVal<E, RawVal> for [u8; N] {
     }
 }
 
-impl<E: Env, const N: usize> TryIntoVal<E, [u8; N]> for RawVal {
-    type Error = <[u8; N] as TryFromVal<E, RawVal>>::Error;
-    #[inline(always)]
-    fn try_into_val(self, env: &E) -> Result<[u8; N], Self::Error> {
-        <_ as TryFromVal<_, _>>::try_from_val(env, self)
-    }
-}
-
-impl<E: Env> TryIntoVal<E, RawVal> for &[u8] {
-    type Error = Status;
-    #[inline(always)]
-    fn try_into_val(self, env: &E) -> Result<RawVal, Self::Error> {
-        Ok(env.bytes_new_from_slice(self)?.to_raw())
-    }
-}
-
-impl<E: Env, const N: usize> TryIntoVal<E, RawVal> for [u8; N] {
-    type Error = Status;
-    #[inline(always)]
-    fn try_into_val(self, env: &E) -> Result<RawVal, Self::Error> {
-        self.as_slice().try_into_val(env)
-    }
-}
-
 #[cfg(feature = "std")]
-impl<E: Env> TryIntoVal<E, RawVal> for Vec<u8> {
+impl<E: Env> TryFromVal<E, RawVal> for Vec<u8> {
     type Error = Status;
-    #[inline(always)]
-    fn try_into_val(self, env: &E) -> Result<RawVal, Self::Error> {
-        (&self).try_into_val(env)
+
+    fn try_from_val(env: &E, val: impl Borrow<RawVal>) -> Result<Self, Self::Error> {
+        let val = *val.borrow();
+        if !Object::val_is_obj_type(val, ScObjectType::Bytes) {
+            return Err(ScHostValErrorCode::UnexpectedValType.into());
+        }
+        let bytes = unsafe { Object::unchecked_from_val(val) };
+        let len = unsafe { u32::unchecked_from_val(env.bytes_len(bytes)) } as usize;
+        let mut vec = vec![0u8; len];
+        env.bytes_copy_to_slice(bytes, RawVal::U32_ZERO, &mut vec)?;
+        Ok(vec)
     }
 }
 
-#[cfg(feature = "std")]
-impl<E: Env> TryIntoVal<E, RawVal> for &Vec<u8> {
+impl<E: Env> TryFromVal<E, [u8]> for RawVal {
     type Error = Status;
     #[inline(always)]
-    fn try_into_val(self, env: &E) -> Result<RawVal, Self::Error> {
-        self.as_slice().try_into_val(env)
+    fn try_from_val(env: &E, v: impl Borrow<[u8]>) -> Result<RawVal, Self::Error> {
+        Ok(env.bytes_new_from_slice(v.borrow())?.to_raw())
+    }
+}
+
+// Technically this impl is redundant but it makes users have to type less
+// boilerplate at call sites when converting [u8;N]
+impl<E: Env, const N: usize> TryFromVal<E, [u8; N]> for RawVal {
+    type Error = Status;
+
+    fn try_from_val(env: &E, v: impl Borrow<[u8; N]>) -> Result<Self, Self::Error> {
+        <RawVal as TryFromVal<E, [u8]>>::try_from_val(env, v.borrow().as_slice())
+    }
+}
+
+// Technically this impl is redundant but it makes users have to type less
+// boilerplate at call sites when converting &[u8]
+impl<'a, E: Env> TryFromVal<E, &'a [u8]> for RawVal {
+    type Error = Status;
+
+    fn try_from_val(env: &E, v: impl Borrow<&'a [u8]>) -> Result<Self, Self::Error> {
+        <RawVal as TryFromVal<E, [u8]>>::try_from_val(env, *v.borrow())
+    }
+}
+
+// Technically this impl is redundant but it makes users have to type less
+// boilerplate at call sites when converting Vec<u8>
+#[cfg(feature = "std")]
+impl<E: Env> TryFromVal<E, Vec<u8>> for RawVal {
+    type Error = Status;
+
+    fn try_from_val(env: &E, v: impl Borrow<Vec<u8>>) -> Result<Self, Self::Error> {
+        <RawVal as TryFromVal<E, [u8]>>::try_from_val(env, v.borrow().as_slice())
     }
 }

--- a/soroban-env-common/src/convert.rs
+++ b/soroban-env-common/src/convert.rs
@@ -1,6 +1,7 @@
+use core::fmt::Debug;
 /// General trait representing a the ability of some object to perform a
 /// (possibly unsuccessful) conversion between two other types.
 pub trait Convert<F, T> {
-    type Error;
+    type Error: Debug;
     fn convert(&self, f: F) -> Result<T, Self::Error>;
 }

--- a/soroban-env-common/src/env_val.rs
+++ b/soroban-env-common/src/env_val.rs
@@ -1,3 +1,4 @@
+use core::fmt::Debug;
 use stellar_xdr::ScObjectType;
 
 #[cfg(feature = "std")]
@@ -13,12 +14,12 @@ use super::{
 };
 
 pub trait TryIntoVal<E: Env, V> {
-    type Error;
+    type Error: Debug;
     fn try_into_val(&self, env: &E) -> Result<V, Self::Error>;
 }
 
 pub trait TryFromVal<E: Env, V: ?Sized>: Sized {
-    type Error;
+    type Error: Debug;
     fn try_from_val(env: &E, v: &V) -> Result<Self, Self::Error>;
 }
 

--- a/soroban-env-common/src/env_val.rs
+++ b/soroban-env-common/src/env_val.rs
@@ -1,4 +1,3 @@
-use core::borrow::Borrow;
 use stellar_xdr::ScObjectType;
 
 #[cfg(feature = "std")]
@@ -20,7 +19,7 @@ pub trait TryIntoVal<E: Env, V> {
 
 pub trait TryFromVal<E: Env, V: ?Sized>: Sized {
     type Error;
-    fn try_from_val(env: &E, v: impl Borrow<V>) -> Result<Self, Self::Error>;
+    fn try_from_val(env: &E, v: &V) -> Result<Self, Self::Error>;
 }
 
 // Blanket-impl uses of TryIntoVal to TryFromVal, so that we
@@ -51,8 +50,8 @@ pub(crate) fn log_err_convert<T>(env: &impl Env, val: &impl AsRef<RawVal>) {
 impl<E: Env> TryFromVal<E, RawVal> for i64 {
     type Error = ConversionError;
 
-    fn try_from_val(env: &E, val: impl Borrow<RawVal>) -> Result<Self, Self::Error> {
-        let val = *val.borrow();
+    fn try_from_val(env: &E, val: &RawVal) -> Result<Self, Self::Error> {
+        let val = *val;
         if val.is_u63() {
             Ok(unsafe { val.unchecked_as_u63() })
         } else if Object::val_is_obj_type(val, ScObjectType::I64) {
@@ -68,8 +67,8 @@ impl<E: Env> TryFromVal<E, RawVal> for i64 {
 impl<E: Env> TryFromVal<E, i64> for RawVal {
     type Error = ConversionError;
 
-    fn try_from_val(env: &E, v: impl Borrow<i64>) -> Result<Self, Self::Error> {
-        let v = *v.borrow();
+    fn try_from_val(env: &E, v: &i64) -> Result<Self, Self::Error> {
+        let v = *v;
         if v >= 0 {
             Ok(unsafe { RawVal::unchecked_from_u63(v) })
         } else {
@@ -83,8 +82,8 @@ impl<E: Env> TryFromVal<E, i64> for RawVal {
 impl<E: Env> TryFromVal<E, RawVal> for u64 {
     type Error = ConversionError;
 
-    fn try_from_val(env: &E, val: impl Borrow<RawVal>) -> Result<Self, Self::Error> {
-        let val = *val.borrow();
+    fn try_from_val(env: &E, val: &RawVal) -> Result<Self, Self::Error> {
+        let val = *val;
         if Object::val_is_obj_type(val, ScObjectType::U64) {
             let obj = unsafe { Object::unchecked_from_val(val) };
             Ok(env.obj_to_u64(obj))
@@ -98,8 +97,8 @@ impl<E: Env> TryFromVal<E, RawVal> for u64 {
 impl<E: Env> TryFromVal<E, u64> for RawVal {
     type Error = ConversionError;
 
-    fn try_from_val(env: &E, v: impl Borrow<u64>) -> Result<Self, Self::Error> {
-        Ok(env.obj_from_u64(*v.borrow()).to_raw())
+    fn try_from_val(env: &E, v: &u64) -> Result<Self, Self::Error> {
+        Ok(env.obj_from_u64(*v).to_raw())
     }
 }
 
@@ -108,8 +107,8 @@ impl<E: Env> TryFromVal<E, u64> for RawVal {
 impl<E: Env> TryFromVal<E, RawVal> for i128 {
     type Error = ConversionError;
 
-    fn try_from_val(env: &E, v: impl Borrow<RawVal>) -> Result<Self, Self::Error> {
-        let v = *v.borrow();
+    fn try_from_val(env: &E, v: &RawVal) -> Result<Self, Self::Error> {
+        let v = *v;
         let obj = v.try_into()?;
         let lo = env.obj_to_i128_lo64(obj);
         let hi = env.obj_to_i128_hi64(obj);
@@ -120,8 +119,8 @@ impl<E: Env> TryFromVal<E, RawVal> for i128 {
 impl<E: Env> TryFromVal<E, i128> for RawVal {
     type Error = ConversionError;
 
-    fn try_from_val(env: &E, v: impl Borrow<i128>) -> Result<Self, Self::Error> {
-        let v = *v.borrow();
+    fn try_from_val(env: &E, v: &i128) -> Result<Self, Self::Error> {
+        let v = *v;
         Ok(env
             .obj_from_i128_pieces(v as u64, (v as u128 >> 64) as u64)
             .into())
@@ -133,8 +132,8 @@ impl<E: Env> TryFromVal<E, i128> for RawVal {
 impl<E: Env> TryFromVal<E, RawVal> for u128 {
     type Error = ConversionError;
 
-    fn try_from_val(env: &E, v: impl Borrow<RawVal>) -> Result<Self, Self::Error> {
-        let v = *v.borrow();
+    fn try_from_val(env: &E, v: &RawVal) -> Result<Self, Self::Error> {
+        let v = *v;
         let obj = v.try_into()?;
         let lo = env.obj_to_u128_lo64(obj);
         let hi = env.obj_to_u128_hi64(obj);
@@ -145,8 +144,8 @@ impl<E: Env> TryFromVal<E, RawVal> for u128 {
 impl<E: Env> TryFromVal<E, u128> for RawVal {
     type Error = ConversionError;
 
-    fn try_from_val(env: &E, v: impl Borrow<u128>) -> Result<Self, Self::Error> {
-        let v = *v.borrow();
+    fn try_from_val(env: &E, v: &u128) -> Result<Self, Self::Error> {
+        let v = *v;
         Ok(env.obj_from_u128_pieces(v as u64, (v >> 64) as u64).into())
     }
 }
@@ -160,8 +159,8 @@ where
 {
     type Error = ConversionError;
 
-    fn try_from_val(env: &E, val: impl Borrow<RawVal>) -> Result<Self, Self::Error> {
-        let val = *val.borrow();
+    fn try_from_val(env: &E, val: &RawVal) -> Result<Self, Self::Error> {
+        let val = *val;
         if val.is_u63() {
             Ok(ScVal::U63(unsafe { val.unchecked_as_u63() }))
         } else {
@@ -190,7 +189,7 @@ where
                 }
                 Tag::Object => unsafe {
                     let ob = <Object as RawValConvertible>::unchecked_from_val(val);
-                    let scob = ScObject::try_from_val(&env, ob).map_err(|_| ConversionError)?;
+                    let scob = ScObject::try_from_val(&env, &ob).map_err(|_| ConversionError)?;
                     Ok(ScVal::Object(Some(scob)))
                 },
                 Tag::Symbol => {
@@ -217,8 +216,8 @@ where
     Object: TryFromVal<E, ScObject>,
 {
     type Error = ConversionError;
-    fn try_from_val(env: &E, val: impl Borrow<ScVal>) -> Result<RawVal, Self::Error> {
-        Ok(match val.borrow() {
+    fn try_from_val(env: &E, val: &ScVal) -> Result<RawVal, Self::Error> {
+        Ok(match val {
             ScVal::U63(i) => {
                 if *i >= 0 {
                     unsafe { RawVal::unchecked_from_u63(*i) }

--- a/soroban-env-common/src/lib.rs
+++ b/soroban-env-common/src/lib.rs
@@ -70,7 +70,7 @@ pub use checked_env::CheckedEnv;
 pub use compare::Compare;
 pub use convert::Convert;
 pub use env::{call_macro_with_all_host_functions, Env, EnvBase};
-pub use env_val::{FromVal, IntoVal, TryFromVal, TryIntoVal};
+pub use env_val::{TryFromVal, TryIntoVal};
 pub use unimplemented_env::UnimplementedEnv;
 pub use vmcaller_checked_env::{VmCaller, VmCallerCheckedEnv};
 

--- a/soroban-env-common/src/object.rs
+++ b/soroban-env-common/src/object.rs
@@ -1,7 +1,7 @@
 use crate::{
     impl_wrapper_common, xdr::ScObjectType, ConversionError, Convert, Env, RawVal, Tag, TryFromVal,
 };
-use core::{borrow::Borrow, fmt::Debug};
+use core::fmt::Debug;
 use stellar_xdr::ScObject;
 
 /// Wrapper for a [RawVal] that is tagged with [Tag::Object], interpreting the
@@ -57,8 +57,8 @@ where
     E: Env + Convert<Object, ScObject>,
 {
     type Error = E::Error;
-    fn try_from_val(env: &E, val: impl Borrow<Object>) -> Result<Self, Self::Error> {
-        env.convert(*val.borrow())
+    fn try_from_val(env: &E, val: &Object) -> Result<Self, Self::Error> {
+        env.convert(*val)
     }
 }
 
@@ -75,8 +75,8 @@ where
 
     type Error = ConversionError;
 
-    fn try_from_val(env: &E, v: impl Borrow<ScObject>) -> Result<Self, Self::Error> {
-        let scob: &ScObject = v.borrow();
+    fn try_from_val(env: &E, v: &ScObject) -> Result<Self, Self::Error> {
+        let scob: &ScObject = v;
         match env.convert(scob) {
             Ok(obj) => Ok(obj),
             Err(_) => Err(ConversionError),

--- a/soroban-env-common/src/object.rs
+++ b/soroban-env-common/src/object.rs
@@ -1,8 +1,9 @@
 use crate::{
     impl_wrapper_common, xdr::ScObjectType, ConversionError, Convert, Env, RawVal, Tag, TryFromVal,
+    TryIntoVal,
 };
 use core::fmt::Debug;
-use stellar_xdr::ScObject;
+use stellar_xdr::{ScObject, ScVal};
 
 /// Wrapper for a [RawVal] that is tagged with [Tag::Object], interpreting the
 /// [RawVal]'s body as a pair of a 28-bit object-type code and a 32-bit handle
@@ -80,6 +81,21 @@ where
         match env.convert(scob) {
             Ok(obj) => Ok(obj),
             Err(_) => Err(ConversionError),
+        }
+    }
+}
+
+impl<E> TryFromVal<E, ScVal> for Object
+where
+    E: Env + for<'a> Convert<&'a ScObject, Object>,
+{
+    type Error = ConversionError;
+
+    fn try_from_val(env: &E, v: &ScVal) -> Result<Self, Self::Error> {
+        if let ScVal::Object(Some(o)) = v {
+            o.try_into_val(env)
+        } else {
+            Err(ConversionError)
         }
     }
 }

--- a/soroban-env-common/src/object.rs
+++ b/soroban-env-common/src/object.rs
@@ -1,8 +1,8 @@
 use crate::{
-    impl_wrapper_common, xdr::ScObjectType, Convert, Env, RawVal, Tag, TryFromVal, TryIntoVal,
+    impl_wrapper_common, xdr::ScObjectType, ConversionError, Convert, Env, RawVal, Tag, TryFromVal,
 };
-use core::fmt::Debug;
-use stellar_xdr::{ScObject, ScVal};
+use core::{borrow::Borrow, fmt::Debug};
+use stellar_xdr::ScObject;
 
 /// Wrapper for a [RawVal] that is tagged with [Tag::Object], interpreting the
 /// [RawVal]'s body as a pair of a 28-bit object-type code and a 32-bit handle
@@ -57,55 +57,29 @@ where
     E: Env + Convert<Object, ScObject>,
 {
     type Error = E::Error;
-    fn try_from_val(env: &E, val: Object) -> Result<Self, Self::Error> {
-        env.convert(val)
+    fn try_from_val(env: &E, val: impl Borrow<Object>) -> Result<Self, Self::Error> {
+        env.convert(*val.borrow())
     }
 }
 
-impl<'a, E> TryIntoVal<E, Object> for &'a ScObject
+impl<E> TryFromVal<E, ScObject> for Object
 where
-    E: Env + Convert<&'a ScObject, Object>,
+    E: Env + for<'a> Convert<&'a ScObject, Object>,
 {
-    type Error = E::Error;
-    fn try_into_val(self, env: &E) -> Result<Object, Self::Error> {
-        env.convert(self)
-    }
-}
+    // We want this:
+    //
+    //   type Error = <E as for<'a> Convert<&'a ScObject, Object>>::Error;
+    //
+    // But due to lifetime difficulties we will use a simpler error for now.
+    // (This is temporary anyways, we'll be moving the errors to EnvBase soon)
 
-impl<E> TryIntoVal<E, Object> for ScObject
-where
-    E: Env + Convert<ScObject, Object>,
-{
-    type Error = E::Error;
-    fn try_into_val(self, env: &E) -> Result<Object, Self::Error> {
-        env.convert(self)
-    }
-}
+    type Error = ConversionError;
 
-impl<'a, E> TryIntoVal<E, Object> for &'a ScVal
-where
-    E: Env + Convert<&'a ScObject, Object>,
-{
-    type Error = E::Error;
-    fn try_into_val(self, env: &E) -> Result<Object, Self::Error> {
-        if let ScVal::Object(Some(o)) = self {
-            o.try_into_val(env)
-        } else {
-            todo!()
-        }
-    }
-}
-
-impl<E> TryIntoVal<E, Object> for ScVal
-where
-    E: Env + Convert<ScObject, Object>,
-{
-    type Error = E::Error;
-    fn try_into_val(self, env: &E) -> Result<Object, Self::Error> {
-        if let ScVal::Object(Some(o)) = self {
-            o.try_into_val(env)
-        } else {
-            todo!()
+    fn try_from_val(env: &E, v: impl Borrow<ScObject>) -> Result<Self, Self::Error> {
+        let scob: &ScObject = v.borrow();
+        match env.convert(scob) {
+            Ok(obj) => Ok(obj),
+            Err(_) => Err(ConversionError),
         }
     }
 }

--- a/soroban-env-common/src/option.rs
+++ b/soroban-env-common/src/option.rs
@@ -1,4 +1,6 @@
-use crate::{Env, IntoVal, RawVal, TryFromVal, TryIntoVal};
+use core::borrow::Borrow;
+
+use crate::{Env, RawVal, TryFromVal, TryIntoVal};
 
 impl<E: Env, T> TryFromVal<E, RawVal> for Option<T>
 where
@@ -6,7 +8,8 @@ where
 {
     type Error = T::Error;
 
-    fn try_from_val(env: &E, val: RawVal) -> Result<Self, Self::Error> {
+    fn try_from_val(env: &E, val: impl Borrow<RawVal>) -> Result<Self, Self::Error> {
+        let val = *val.borrow();
         if val.is_void() {
             Ok(None)
         } else {
@@ -15,37 +18,16 @@ where
     }
 }
 
-impl<E: Env, T> TryIntoVal<E, Option<T>> for RawVal
+impl<E: Env, T> TryFromVal<E, Option<T>> for RawVal
 where
-    T: TryFromVal<E, RawVal>,
+    T: TryIntoVal<E, RawVal>,
 {
     type Error = T::Error;
-    #[inline(always)]
-    fn try_into_val(self, env: &E) -> Result<Option<T>, Self::Error> {
-        <_ as TryFromVal<E, RawVal>>::try_from_val(env, self)
-    }
-}
 
-impl<E: Env, T> IntoVal<E, RawVal> for &Option<T>
-where
-    for<'a> &'a T: IntoVal<E, RawVal>,
-{
-    fn into_val(self, env: &E) -> RawVal {
-        match self {
-            Some(t) => t.into_val(env),
-            None => RawVal::from_void(),
-        }
-    }
-}
-
-impl<E: Env, T> IntoVal<E, RawVal> for Option<T>
-where
-    T: IntoVal<E, RawVal>,
-{
-    fn into_val(self, env: &E) -> RawVal {
-        match self {
-            Some(t) => t.into_val(env),
-            None => RawVal::from_void(),
+    fn try_from_val(env: &E, v: impl Borrow<Option<T>>) -> Result<Self, Self::Error> {
+        match v.borrow() {
+            Some(t) => t.try_into_val(env),
+            None => Ok(RawVal::from_void()),
         }
     }
 }

--- a/soroban-env-common/src/option.rs
+++ b/soroban-env-common/src/option.rs
@@ -1,5 +1,3 @@
-use core::borrow::Borrow;
-
 use crate::{Env, RawVal, TryFromVal, TryIntoVal};
 
 impl<E: Env, T> TryFromVal<E, RawVal> for Option<T>
@@ -8,12 +6,12 @@ where
 {
     type Error = T::Error;
 
-    fn try_from_val(env: &E, val: impl Borrow<RawVal>) -> Result<Self, Self::Error> {
-        let val = *val.borrow();
+    fn try_from_val(env: &E, val: &RawVal) -> Result<Self, Self::Error> {
+        let val = *val;
         if val.is_void() {
             Ok(None)
         } else {
-            Ok(Some(T::try_from_val(env, val)?))
+            Ok(Some(T::try_from_val(env, &val)?))
         }
     }
 }
@@ -24,8 +22,8 @@ where
 {
     type Error = T::Error;
 
-    fn try_from_val(env: &E, v: impl Borrow<Option<T>>) -> Result<Self, Self::Error> {
-        match v.borrow() {
+    fn try_from_val(env: &E, v: &Option<T>) -> Result<Self, Self::Error> {
+        match v {
             Some(t) => t.try_into_val(env),
             None => Ok(RawVal::from_void()),
         }

--- a/soroban-env-common/src/raw_val.rs
+++ b/soroban-env-common/src/raw_val.rs
@@ -1,9 +1,7 @@
 use stellar_xdr::{ScStatic, ScStatus, ScStatusType};
 
-use super::{
-    BitSet, Env, FromVal, IntoVal, Object, Static, Status, Symbol, TryFromVal, TryIntoVal,
-};
-use core::{convert::Infallible, fmt::Debug};
+use super::{BitSet, Env, Object, Static, Status, Symbol, TryFromVal};
+use core::{borrow::Borrow, convert::Infallible, fmt::Debug};
 
 extern crate static_assertions as sa;
 
@@ -120,55 +118,10 @@ impl AsMut<RawVal> for RawVal {
     }
 }
 
-impl<E: Env> FromVal<E, RawVal> for RawVal {
-    fn from_val(_env: &E, val: RawVal) -> Self {
-        val
-    }
-}
-
-impl<E: Env> FromVal<E, &RawVal> for RawVal {
-    fn from_val(_env: &E, val: &RawVal) -> Self {
-        *val
-    }
-}
-
 impl<E: Env> TryFromVal<E, RawVal> for RawVal {
     type Error = Infallible;
-    fn try_from_val(_env: &E, val: RawVal) -> Result<Self, Self::Error> {
-        Ok(val)
-    }
-}
-
-impl<E: Env> TryFromVal<E, &RawVal> for RawVal {
-    type Error = Infallible;
-    fn try_from_val(_env: &E, val: &RawVal) -> Result<Self, Self::Error> {
-        Ok(*val)
-    }
-}
-
-impl<E: Env> IntoVal<E, RawVal> for RawVal {
-    fn into_val(self, _env: &E) -> RawVal {
-        self
-    }
-}
-
-impl<E: Env> IntoVal<E, RawVal> for &RawVal {
-    fn into_val(self, _env: &E) -> RawVal {
-        *self
-    }
-}
-
-impl<E: Env> TryIntoVal<E, RawVal> for RawVal {
-    type Error = Infallible;
-    fn try_into_val(self, _env: &E) -> Result<RawVal, Self::Error> {
-        Ok(self)
-    }
-}
-
-impl<E: Env> TryIntoVal<E, RawVal> for &RawVal {
-    type Error = Infallible;
-    fn try_into_val(self, _env: &E) -> Result<RawVal, Self::Error> {
-        Ok(*self)
+    fn try_from_val(_env: &E, val: impl Borrow<RawVal>) -> Result<Self, Self::Error> {
+        Ok(*val.borrow())
     }
 }
 
@@ -250,33 +203,17 @@ macro_rules! declare_tryfrom {
                 }
             }
         }
-        impl<E: Env> IntoVal<E, RawVal> for $T {
-            fn into_val(self, _env: &E) -> RawVal {
-                self.into()
-            }
-        }
-        impl<E: Env> IntoVal<E, RawVal> for &$T {
-            fn into_val(self, _env: &E) -> RawVal {
-                (*self).into()
-            }
-        }
         impl<E: Env> TryFromVal<E, RawVal> for $T {
             type Error = ConversionError;
             #[inline(always)]
-            fn try_from_val(_env: &E, val: RawVal) -> Result<Self, Self::Error> {
-                Self::try_from(val)
+            fn try_from_val(_env: &E, val: impl Borrow<RawVal>) -> Result<Self, Self::Error> {
+                Self::try_from(*val.borrow())
             }
         }
-        impl<E: Env> TryIntoVal<E, RawVal> for $T {
+        impl<E: Env> TryFromVal<E, $T> for RawVal {
             type Error = ConversionError;
-            fn try_into_val(self, _env: &E) -> Result<RawVal, Self::Error> {
-                Ok(self.into())
-            }
-        }
-        impl<E: Env> TryIntoVal<E, $T> for RawVal {
-            type Error = ConversionError;
-            fn try_into_val(self, env: &E) -> Result<$T, Self::Error> {
-                <_ as TryFromVal<E, RawVal>>::try_from_val(&env, self)
+            fn try_from_val(_env: &E, val: impl Borrow<$T>) -> Result<Self, Self::Error> {
+                Ok((*val.borrow()).into())
             }
         }
     };

--- a/soroban-env-common/src/raw_val.rs
+++ b/soroban-env-common/src/raw_val.rs
@@ -119,7 +119,7 @@ impl AsMut<RawVal> for RawVal {
 }
 
 impl<E: Env> TryFromVal<E, RawVal> for RawVal {
-    type Error = Infallible;
+    type Error = ConversionError;
     fn try_from_val(_env: &E, val: &RawVal) -> Result<Self, Self::Error> {
         Ok(*val)
     }

--- a/soroban-env-common/src/raw_val.rs
+++ b/soroban-env-common/src/raw_val.rs
@@ -1,7 +1,7 @@
 use stellar_xdr::{ScStatic, ScStatus, ScStatusType};
 
 use super::{BitSet, Env, Object, Static, Status, Symbol, TryFromVal};
-use core::{borrow::Borrow, convert::Infallible, fmt::Debug};
+use core::{convert::Infallible, fmt::Debug};
 
 extern crate static_assertions as sa;
 
@@ -120,8 +120,8 @@ impl AsMut<RawVal> for RawVal {
 
 impl<E: Env> TryFromVal<E, RawVal> for RawVal {
     type Error = Infallible;
-    fn try_from_val(_env: &E, val: impl Borrow<RawVal>) -> Result<Self, Self::Error> {
-        Ok(*val.borrow())
+    fn try_from_val(_env: &E, val: &RawVal) -> Result<Self, Self::Error> {
+        Ok(*val)
     }
 }
 
@@ -206,14 +206,14 @@ macro_rules! declare_tryfrom {
         impl<E: Env> TryFromVal<E, RawVal> for $T {
             type Error = ConversionError;
             #[inline(always)]
-            fn try_from_val(_env: &E, val: impl Borrow<RawVal>) -> Result<Self, Self::Error> {
-                Self::try_from(*val.borrow())
+            fn try_from_val(_env: &E, val: &RawVal) -> Result<Self, Self::Error> {
+                Self::try_from(*val)
             }
         }
         impl<E: Env> TryFromVal<E, $T> for RawVal {
             type Error = ConversionError;
-            fn try_from_val(_env: &E, val: impl Borrow<$T>) -> Result<Self, Self::Error> {
-                Ok((*val.borrow()).into())
+            fn try_from_val(_env: &E, val: &$T) -> Result<Self, Self::Error> {
+                Ok((*val).into())
             }
         }
     };

--- a/soroban-env-common/src/result.rs
+++ b/soroban-env-common/src/result.rs
@@ -1,64 +1,39 @@
-use crate::{ConversionError, Env, IntoVal, RawVal, Status, TryFromVal, TryIntoVal};
+use crate::{ConversionError, Env, RawVal, Status, TryFromVal, TryIntoVal};
+use core::borrow::Borrow;
 
 impl<E: Env, T, R> TryFromVal<E, RawVal> for Result<T, R>
 where
-    T: TryFromVal<E, RawVal, Error = ConversionError>,
+    T: TryFromVal<E, RawVal>,
     R: TryFrom<Status>,
 {
     type Error = ConversionError;
 
     #[inline(always)]
-    fn try_from_val(env: &E, val: RawVal) -> Result<Self, Self::Error> {
+    fn try_from_val(env: &E, val: impl Borrow<RawVal>) -> Result<Self, Self::Error> {
+        let val = *val.borrow();
         if let Ok(status) = Status::try_from_val(env, val) {
             Ok(Err(status.try_into().map_err(|_| ConversionError)?))
         } else {
-            Ok(Ok(T::try_from_val(env, val)?))
+            let converted = T::try_from_val(env, val).map_err(|_| ConversionError)?;
+            Ok(Ok(converted))
         }
     }
 }
 
-impl<E: Env, T, R> TryIntoVal<E, Result<T, R>> for RawVal
+impl<E: Env, T, R> TryFromVal<E, Result<T, R>> for RawVal
 where
-    T: TryFromVal<E, RawVal, Error = ConversionError>,
-    R: TryFrom<Status>,
+    RawVal: TryFromVal<E, T>,
+    Status: for<'a> TryFrom<&'a R>,
 {
     type Error = ConversionError;
 
     #[inline(always)]
-    fn try_into_val(self, env: &E) -> Result<Result<T, R>, Self::Error> {
-        <_ as TryFromVal<E, RawVal>>::try_from_val(env, self)
-    }
-}
-
-impl<E: Env, T, R> IntoVal<E, RawVal> for Result<T, R>
-where
-    T: IntoVal<E, RawVal>,
-    R: Into<Status>,
-{
-    #[inline(always)]
-    fn into_val(self, env: &E) -> RawVal {
-        match self {
-            Ok(t) => t.into_val(env),
+    fn try_from_val(env: &E, v: impl Borrow<Result<T, R>>) -> Result<Self, Self::Error> {
+        match v.borrow() {
+            Ok(t) => t.try_into_val(env).map_err(|_| ConversionError),
             Err(r) => {
-                let status: Status = r.into();
-                status.into_val(env)
-            }
-        }
-    }
-}
-
-impl<E: Env, T, R> IntoVal<E, RawVal> for &Result<T, R>
-where
-    for<'a> &'a T: IntoVal<E, RawVal>,
-    for<'a> &'a R: Into<Status>,
-{
-    #[inline(always)]
-    fn into_val(self, env: &E) -> RawVal {
-        match self {
-            Ok(t) => t.into_val(env),
-            Err(r) => {
-                let status: Status = r.into();
-                status.into_val(env)
+                let status: Status = Status::try_from(r).map_err(|_| ConversionError)?;
+                Ok(status.into())
             }
         }
     }

--- a/soroban-env-common/src/str.rs
+++ b/soroban-env-common/src/str.rs
@@ -1,68 +1,59 @@
-use crate::{ConversionError, Env, RawVal, TryIntoVal};
+use crate::{ConversionError, Env, RawVal, TryFromVal};
+use core::borrow::Borrow;
 
 #[cfg(feature = "std")]
 use stellar_xdr::ScObjectType;
 
 #[cfg(feature = "std")]
-use crate::{Object, RawValConvertible, TryFromVal};
-
-// TODO: these conversions happen as RawVal, but they actually take and produce
-// Objects; consider making the signatures tighter.
+use crate::{Object, RawValConvertible, TryIntoVal};
 
 #[cfg(feature = "std")]
 impl<E: Env> TryFromVal<E, RawVal> for String {
     type Error = ConversionError;
 
     #[inline(always)]
-    fn try_from_val(env: &E, val: RawVal) -> Result<Self, Self::Error> {
-        let obj: Object = val.try_into_val(env)?;
-        if obj.is_obj_type(ScObjectType::Bytes) {
-            let len = unsafe { <u32 as RawValConvertible>::unchecked_from_val(env.bytes_len(obj)) };
-            let mut vec = std::vec![0; len as usize];
-            env.bytes_copy_to_slice(obj, RawVal::U32_ZERO, &mut vec)
-                .map_err(|_| ConversionError)?;
-            String::from_utf8(vec).map_err(|_| ConversionError)
-        } else {
-            Err(ConversionError)
+    fn try_from_val(env: &E, val: impl Borrow<RawVal>) -> Result<Self, Self::Error> {
+        let val = *val.borrow();
+        if !Object::val_is_obj_type(val, ScObjectType::Bytes) {
+            return Err(ConversionError);
         }
+        let obj: Object = val.try_into_val(env)?;
+        let len = unsafe { <u32 as RawValConvertible>::unchecked_from_val(env.bytes_len(obj)) };
+        let mut vec = std::vec![0; len as usize];
+        env.bytes_copy_to_slice(obj, RawVal::U32_ZERO, &mut vec)
+            .map_err(|_| ConversionError)?;
+        String::from_utf8(vec).map_err(|_| ConversionError)
     }
 }
 
-#[cfg(feature = "std")]
-impl<E: Env> TryIntoVal<E, String> for RawVal {
-    type Error = ConversionError;
-
-    #[inline(always)]
-    fn try_into_val(self, env: &E) -> Result<String, Self::Error> {
-        <_ as TryFromVal<E, RawVal>>::try_from_val(env, self)
-    }
-}
-
-impl<E: Env> TryIntoVal<E, RawVal> for &str {
+impl<E: Env> TryFromVal<E, str> for RawVal {
     type Error = ConversionError;
     #[inline(always)]
-    fn try_into_val(self, env: &E) -> Result<RawVal, Self::Error> {
+    fn try_from_val(env: &E, val: impl Borrow<str>) -> Result<RawVal, Self::Error> {
         Ok(env
-            .bytes_new_from_slice(self.as_bytes())
+            .bytes_new_from_slice(val.borrow().as_bytes())
             .map_err(|_| ConversionError)?
             .to_raw())
     }
 }
 
-#[cfg(feature = "std")]
-impl<E: Env> TryIntoVal<E, RawVal> for String {
+// Technically this impl is redundant but it makes users have to type less
+// boilerplate at call sites when converting &str
+impl<'a, E: Env> TryFromVal<E, &'a str> for RawVal {
     type Error = ConversionError;
-    #[inline(always)]
-    fn try_into_val(self, env: &E) -> Result<RawVal, Self::Error> {
-        (&self).try_into_val(env)
+
+    fn try_from_val(env: &E, v: impl Borrow<&'a str>) -> Result<Self, Self::Error> {
+        <RawVal as TryFromVal<E, str>>::try_from_val(env, *v.borrow())
     }
 }
 
+// Technically this impl is redundant but it makes users have to type less
+// boilerplate at call sites when converting String
 #[cfg(feature = "std")]
-impl<E: Env> TryIntoVal<E, RawVal> for &String {
+impl<'a, E: Env> TryFromVal<E, String> for RawVal {
     type Error = ConversionError;
-    #[inline(always)]
-    fn try_into_val(self, env: &E) -> Result<RawVal, Self::Error> {
-        self.as_str().try_into_val(env)
+
+    fn try_from_val(env: &E, v: impl Borrow<String>) -> Result<Self, Self::Error> {
+        <RawVal as TryFromVal<E, str>>::try_from_val(env, v.borrow().as_str())
     }
 }

--- a/soroban-env-common/src/val_wrapper.rs
+++ b/soroban-env-common/src/val_wrapper.rs
@@ -96,11 +96,8 @@ macro_rules! impl_wrapper_from {
         impl<E: Env> $crate::TryFromVal<E, $tagname> for $fromty {
             type Error = $crate::ConversionError;
             #[inline(always)]
-            fn try_from_val(
-                _env: &E,
-                val: impl core::borrow::Borrow<$tagname>,
-            ) -> Result<Self, Self::Error> {
-                Self::try_from((*val.borrow()).to_raw())
+            fn try_from_val(_env: &E, val: &$tagname) -> Result<Self, Self::Error> {
+                Self::try_from((*val).to_raw())
             }
         }
     };

--- a/soroban-env-common/src/val_wrapper.rs
+++ b/soroban-env-common/src/val_wrapper.rs
@@ -96,8 +96,11 @@ macro_rules! impl_wrapper_from {
         impl<E: Env> $crate::TryFromVal<E, $tagname> for $fromty {
             type Error = $crate::ConversionError;
             #[inline(always)]
-            fn try_from_val(_env: &E, val: $tagname) -> Result<Self, Self::Error> {
-                Self::try_from(val.to_raw())
+            fn try_from_val(
+                _env: &E,
+                val: impl core::borrow::Borrow<$tagname>,
+            ) -> Result<Self, Self::Error> {
+                Self::try_from((*val.borrow()).to_raw())
             }
         }
     };

--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -532,7 +532,7 @@ impl Host {
         // For an `Object`, the actual structural conversion (such as byte
         // cloning) occurs in `from_host_obj` and is metered there.
         self.charge_budget(CostType::ValXdrConv, 1)?;
-        ScVal::try_from_val(self, val)
+        ScVal::try_from_val(self, &val)
             .map_err(|_| self.err_status(ScHostValErrorCode::UnknownError))
     }
 

--- a/soroban-env-host/src/native_contract/base_types.rs
+++ b/soroban-env-host/src/native_contract/base_types.rs
@@ -1,9 +1,10 @@
 use crate::budget::CostType;
 use crate::host::{Host, HostError};
+use core::borrow::Borrow;
 use core::cmp::Ordering;
 use soroban_env_common::xdr::{AccountId, ScObjectType};
 use soroban_env_common::{
-    CheckedEnv, Compare, ConversionError, EnvBase, Object, RawVal, TryFromVal, TryIntoVal,
+    CheckedEnv, Compare, ConversionError, EnvBase, Object, RawVal, TryFromVal,
 };
 
 #[derive(Clone)]
@@ -23,7 +24,8 @@ impl Compare<Bytes> for Host {
 impl TryFromVal<Host, Object> for Bytes {
     type Error = HostError;
 
-    fn try_from_val(env: &Host, val: Object) -> Result<Self, Self::Error> {
+    fn try_from_val(env: &Host, val: impl Borrow<Object>) -> Result<Self, Self::Error> {
+        let val = *val.borrow();
         if val.is_obj_type(ScObjectType::Bytes) {
             Ok(Bytes {
                 host: env.clone(),
@@ -38,24 +40,18 @@ impl TryFromVal<Host, Object> for Bytes {
 impl TryFromVal<Host, RawVal> for Bytes {
     type Error = HostError;
 
-    fn try_from_val(env: &Host, val: RawVal) -> Result<Self, Self::Error> {
-        <_ as TryFromVal<_, Object>>::try_from_val(env, val.try_into()?)
+    fn try_from_val(env: &Host, val: impl Borrow<RawVal>) -> Result<Self, Self::Error> {
+        let val = *val.borrow();
+        let obj: Object = val.try_into()?;
+        Bytes::try_from_val(env, obj)
     }
 }
 
-impl TryIntoVal<Host, Bytes> for RawVal {
+impl TryFromVal<Host, Bytes> for RawVal {
     type Error = HostError;
 
-    fn try_into_val(self, env: &Host) -> Result<Bytes, Self::Error> {
-        <_ as TryFromVal<_, RawVal>>::try_from_val(env, self.try_into()?)
-    }
-}
-
-impl TryIntoVal<Host, RawVal> for Bytes {
-    type Error = HostError;
-
-    fn try_into_val(self, _env: &Host) -> Result<RawVal, Self::Error> {
-        Ok(self.object.into())
+    fn try_from_val(_env: &Host, val: impl Borrow<Bytes>) -> Result<RawVal, Self::Error> {
+        Ok(val.borrow().object.into())
     }
 }
 
@@ -112,7 +108,8 @@ pub struct BytesN<const N: usize> {
 impl<const N: usize> TryFromVal<Host, Object> for BytesN<N> {
     type Error = HostError;
 
-    fn try_from_val(env: &Host, val: Object) -> Result<Self, Self::Error> {
+    fn try_from_val(env: &Host, val: impl Borrow<Object>) -> Result<Self, Self::Error> {
+        let val = *val.borrow();
         let len: u32 = env.bytes_len(val)?.try_into()?;
         if len
             == N.try_into()
@@ -139,24 +136,18 @@ impl<const N: usize> Compare<BytesN<N>> for Host {
 impl<const N: usize> TryFromVal<Host, RawVal> for BytesN<N> {
     type Error = HostError;
 
-    fn try_from_val(env: &Host, val: RawVal) -> Result<Self, Self::Error> {
-        <_ as TryFromVal<_, Object>>::try_from_val(env, val.try_into()?)
+    fn try_from_val(env: &Host, val: impl Borrow<RawVal>) -> Result<Self, Self::Error> {
+        let val = *val.borrow();
+        let obj: Object = val.try_into()?;
+        <BytesN<N>>::try_from_val(env, obj)
     }
 }
 
-impl<const N: usize> TryIntoVal<Host, BytesN<N>> for RawVal {
+impl<const N: usize> TryFromVal<Host, BytesN<N>> for RawVal {
     type Error = HostError;
 
-    fn try_into_val(self, env: &Host) -> Result<BytesN<N>, Self::Error> {
-        <_ as TryFromVal<_, RawVal>>::try_from_val(env, self.try_into()?)
-    }
-}
-
-impl<const N: usize> TryIntoVal<Host, RawVal> for BytesN<N> {
-    type Error = HostError;
-
-    fn try_into_val(self, _env: &Host) -> Result<RawVal, Self::Error> {
-        Ok(self.object.into())
+    fn try_from_val(_env: &Host, val: impl Borrow<BytesN<N>>) -> Result<RawVal, Self::Error> {
+        Ok(val.borrow().object.into())
     }
 }
 
@@ -206,7 +197,8 @@ pub struct Map {
 impl TryFromVal<Host, Object> for Map {
     type Error = HostError;
 
-    fn try_from_val(env: &Host, val: Object) -> Result<Self, Self::Error> {
+    fn try_from_val(env: &Host, val: impl Borrow<Object>) -> Result<Self, Self::Error> {
+        let val = *val.borrow();
         if val.is_obj_type(ScObjectType::Map) {
             Ok(Map {
                 host: env.clone(),
@@ -229,24 +221,18 @@ impl Compare<Map> for Host {
 impl TryFromVal<Host, RawVal> for Map {
     type Error = HostError;
 
-    fn try_from_val(env: &Host, val: RawVal) -> Result<Self, Self::Error> {
-        <_ as TryFromVal<_, Object>>::try_from_val(env, val.try_into()?)
+    fn try_from_val(env: &Host, val: impl Borrow<RawVal>) -> Result<Self, Self::Error> {
+        let val = *val.borrow();
+        let obj: Object = val.try_into()?;
+        Map::try_from_val(env, obj)
     }
 }
 
-impl TryIntoVal<Host, Map> for RawVal {
+impl TryFromVal<Host, Map> for RawVal {
     type Error = HostError;
 
-    fn try_into_val(self, env: &Host) -> Result<Map, Self::Error> {
-        <_ as TryFromVal<_, RawVal>>::try_from_val(env, self.try_into()?)
-    }
-}
-
-impl TryIntoVal<Host, RawVal> for Map {
-    type Error = HostError;
-
-    fn try_into_val(self, _env: &Host) -> Result<RawVal, Self::Error> {
-        Ok(self.object.into())
+    fn try_from_val(_env: &Host, val: impl Borrow<Map>) -> Result<RawVal, Self::Error> {
+        Ok(val.borrow().object.into())
     }
 }
 
@@ -265,30 +251,27 @@ impl Map {
         })
     }
 
-    pub fn get<K: TryIntoVal<Host, RawVal>, V: TryFromVal<Host, RawVal>>(
-        &self,
-        k: K,
-    ) -> Result<V, HostError>
+    pub fn get<K, V>(&self, k: impl Borrow<K>) -> Result<V, HostError>
     where
-        HostError: From<<K as TryIntoVal<Host, RawVal>>::Error>,
+        RawVal: TryFromVal<Host, K>,
+        V: TryFromVal<Host, RawVal>,
+        HostError: From<<RawVal as TryFromVal<Host, K>>::Error>,
         HostError: From<<V as TryFromVal<Host, RawVal>>::Error>,
     {
-        let k_rv = k.try_into_val(&self.host)?;
+        let k_rv = RawVal::try_from_val(&self.host, k)?;
         let v_rv = self.host.map_get(self.object, k_rv)?;
         Ok(V::try_from_val(&self.host, v_rv)?)
     }
 
-    pub fn set<K: TryIntoVal<Host, RawVal>, V: TryIntoVal<Host, RawVal>>(
-        &mut self,
-        k: K,
-        v: V,
-    ) -> Result<(), HostError>
+    pub fn set<K, V>(&mut self, k: impl Borrow<K>, v: impl Borrow<V>) -> Result<(), HostError>
     where
-        HostError: From<<K as TryIntoVal<Host, RawVal>>::Error>,
-        HostError: From<<V as TryIntoVal<Host, RawVal>>::Error>,
+        RawVal: TryFromVal<Host, K>,
+        RawVal: TryFromVal<Host, V>,
+        HostError: From<<RawVal as TryFromVal<Host, K>>::Error>,
+        HostError: From<<RawVal as TryFromVal<Host, V>>::Error>,
     {
-        let k_rv = k.try_into_val(&self.host)?;
-        let v_rv = v.try_into_val(&self.host)?;
+        let k_rv = RawVal::try_from_val(&self.host, k)?;
+        let v_rv = RawVal::try_from_val(&self.host, v)?;
         self.object = self.host.map_put(self.object, k_rv, v_rv)?;
         Ok(())
     }
@@ -311,7 +294,8 @@ impl Compare<Vec> for Host {
 impl TryFromVal<Host, Object> for Vec {
     type Error = HostError;
 
-    fn try_from_val(env: &Host, val: Object) -> Result<Self, Self::Error> {
+    fn try_from_val(env: &Host, val: impl Borrow<Object>) -> Result<Self, Self::Error> {
+        let val = *val.borrow();
         if val.is_obj_type(ScObjectType::Vec) {
             Ok(Vec {
                 host: env.clone(),
@@ -326,24 +310,18 @@ impl TryFromVal<Host, Object> for Vec {
 impl TryFromVal<Host, RawVal> for Vec {
     type Error = HostError;
 
-    fn try_from_val(env: &Host, val: RawVal) -> Result<Self, Self::Error> {
-        <_ as TryFromVal<_, Object>>::try_from_val(env, val.try_into()?)
+    fn try_from_val(env: &Host, val: impl Borrow<RawVal>) -> Result<Self, Self::Error> {
+        let val = *val.borrow();
+        let obj: Object = val.try_into()?;
+        Vec::try_from_val(env, obj)
     }
 }
 
-impl TryIntoVal<Host, Vec> for RawVal {
+impl TryFromVal<Host, Vec> for RawVal {
     type Error = HostError;
 
-    fn try_into_val(self, env: &Host) -> Result<Vec, Self::Error> {
-        <_ as TryFromVal<_, RawVal>>::try_from_val(env, self.try_into()?)
-    }
-}
-
-impl TryIntoVal<Host, RawVal> for Vec {
-    type Error = HostError;
-
-    fn try_into_val(self, _env: &Host) -> Result<RawVal, Self::Error> {
-        Ok(self.object.into())
+    fn try_from_val(_env: &Host, val: impl Borrow<Vec>) -> Result<RawVal, Self::Error> {
+        Ok(val.borrow().object.into())
     }
 }
 
@@ -375,11 +353,12 @@ impl Vec {
         Ok(u32::try_from_val(&self.host, rv)?)
     }
 
-    pub fn push<T: TryIntoVal<Host, RawVal>>(&mut self, x: T) -> Result<(), HostError>
+    pub fn push<T>(&mut self, x: impl Borrow<T>) -> Result<(), HostError>
     where
-        HostError: From<<T as TryIntoVal<Host, RawVal>>::Error>,
+        RawVal: TryFromVal<Host, T>,
+        HostError: From<<RawVal as TryFromVal<Host, T>>::Error>,
     {
-        let rv = x.try_into_val(&self.host)?;
+        let rv = RawVal::try_from_val(&self.host, x)?;
         self.push_raw(rv)
     }
 
@@ -392,7 +371,8 @@ impl Vec {
 impl TryFromVal<Host, Object> for AccountId {
     type Error = HostError;
 
-    fn try_from_val(env: &Host, val: Object) -> Result<Self, Self::Error> {
+    fn try_from_val(env: &Host, val: impl Borrow<Object>) -> Result<Self, Self::Error> {
+        let val = *val.borrow();
         env.visit_obj(val, |acc: &AccountId| Ok(acc.clone()))
     }
 }
@@ -400,15 +380,17 @@ impl TryFromVal<Host, Object> for AccountId {
 impl TryFromVal<Host, RawVal> for AccountId {
     type Error = HostError;
 
-    fn try_from_val(env: &Host, val: RawVal) -> Result<Self, Self::Error> {
-        <_ as TryFromVal<_, Object>>::try_from_val(env, val.try_into()?)
+    fn try_from_val(env: &Host, val: impl Borrow<RawVal>) -> Result<Self, Self::Error> {
+        let val = *val.borrow();
+        let obj: Object = val.try_into()?;
+        AccountId::try_from_val(env, obj)
     }
 }
 
-impl TryIntoVal<Host, RawVal> for AccountId {
+impl TryFromVal<Host, AccountId> for RawVal {
     type Error = HostError;
 
-    fn try_into_val(self, env: &Host) -> Result<RawVal, Self::Error> {
-        Ok(env.add_host_object(self.clone())?.to_raw())
+    fn try_from_val(env: &Host, val: impl Borrow<AccountId>) -> Result<RawVal, Self::Error> {
+        Ok(env.add_host_object(val.borrow().clone())?.to_raw())
     }
 }

--- a/soroban-env-host/src/native_contract/invoker.rs
+++ b/soroban-env-host/src/native_contract/invoker.rs
@@ -17,11 +17,11 @@ pub fn invoker(env: &Host) -> Result<Invoker, HostError> {
     Ok(match invoker_type {
         InvokerType::Account => Invoker::Account(AccountId::try_from_val(
             env,
-            Host::get_invoking_account(&env)?,
+            &Host::get_invoking_account(&env)?,
         )?),
         InvokerType::Contract => Invoker::Contract(BytesN::<32>::try_from_val(
             env,
-            Host::get_invoking_contract(&env)?,
+            &Host::get_invoking_contract(&env)?,
         )?),
     })
 }

--- a/soroban-env-host/src/native_contract/testutils.rs
+++ b/soroban-env-host/src/native_contract/testutils.rs
@@ -45,7 +45,7 @@ pub(crate) fn generate_keypair() -> Keypair {
 pub(crate) fn generate_bytes(host: &Host) -> BytesN<32> {
     BytesN::<32>::try_from_val(
         host,
-        host.bytes_new_from_slice(&generate_bytes_array()).unwrap(),
+        &host.bytes_new_from_slice(&generate_bytes_array()).unwrap(),
     )
     .unwrap()
 }
@@ -53,7 +53,7 @@ pub(crate) fn generate_bytes(host: &Host) -> BytesN<32> {
 pub(crate) fn signer_to_id_bytes(host: &Host, key: &Keypair) -> BytesN<32> {
     BytesN::<32>::try_from_val(
         host,
-        host.bytes_new_from_slice(&key.public.to_bytes()).unwrap(),
+        &host.bytes_new_from_slice(&key.public.to_bytes()).unwrap(),
     )
     .unwrap()
 }
@@ -114,13 +114,13 @@ pub(crate) fn sign_args(
     let msg = SignaturePayload::V0(SignaturePayloadV0 {
         name: Symbol::from_str(fn_name),
         contract: contract_id.clone(),
-        network: Bytes::try_from_val(host, host.get_ledger_network_passphrase().unwrap()).unwrap(),
+        network: Bytes::try_from_val(host, &host.get_ledger_network_passphrase().unwrap()).unwrap(),
         args,
     });
     let msg_bin = host
         .serialize_to_bytes(msg.try_into_val(host).unwrap())
         .unwrap();
-    let msg_bytes = Bytes::try_from_val(host, msg_bin).unwrap().to_vec();
+    let msg_bytes = Bytes::try_from_val(host, &msg_bin).unwrap().to_vec();
     let payload = &msg_bytes[..];
 
     match signer {
@@ -132,7 +132,7 @@ pub(crate) fn sign_args(
             signatures: {
                 let mut signatures = HostVec::new(&host).unwrap();
                 for key in &account_signer.signers {
-                    signatures.push(sign_payload(host, key, payload)).unwrap();
+                    signatures.push(&sign_payload(host, key, payload)).unwrap();
                 }
                 signatures
             },
@@ -144,13 +144,15 @@ fn sign_payload(host: &Host, signer: &Keypair, payload: &[u8]) -> Ed25519Signatu
     Ed25519Signature {
         public_key: BytesN::<32>::try_from_val(
             host,
-            host.bytes_new_from_slice(&signer.public.to_bytes())
+            &host
+                .bytes_new_from_slice(&signer.public.to_bytes())
                 .unwrap(),
         )
         .unwrap(),
         signature: BytesN::<64>::try_from_val(
             host,
-            host.bytes_new_from_slice(&signer.sign(payload).to_bytes())
+            &host
+                .bytes_new_from_slice(&signer.sign(payload).to_bytes())
                 .unwrap(),
         )
         .unwrap(),

--- a/soroban-env-host/src/native_contract/token/admin.rs
+++ b/soroban-env-host/src/native_contract/token/admin.rs
@@ -2,7 +2,7 @@ use crate::host::Host;
 use crate::native_contract::token::public_types::{Identifier, Signature};
 use crate::native_contract::token::storage_types::DataKey;
 use crate::{err, HostError};
-use soroban_env_common::{CheckedEnv, Compare, TryFromVal, TryIntoVal};
+use soroban_env_common::{CheckedEnv, Compare, TryIntoVal};
 
 use super::error::ContractError;
 
@@ -10,7 +10,7 @@ use super::error::ContractError;
 fn read_administrator(e: &Host) -> Result<Identifier, HostError> {
     let key = DataKey::Admin;
     let rv = e.get_contract_data(key.try_into_val(e)?)?;
-    Ok(Identifier::try_from_val(e, rv)?)
+    Ok(rv.try_into_val(e)?)
 }
 
 // Metering: covered by components

--- a/soroban-env-host/src/native_contract/token/contract.rs
+++ b/soroban-env-host/src/native_contract/token/contract.rs
@@ -168,9 +168,9 @@ impl TokenTrait for Token {
 
         let asset: Asset = e.metered_from_xdr_obj(asset_bytes.into())?;
 
-        let curr_contract_id = BytesN::<32>::try_from_val(e, e.get_current_contract()?)?;
+        let curr_contract_id = BytesN::<32>::try_from_val(e, &e.get_current_contract()?)?;
         let expected_contract_id =
-            BytesN::<32>::try_from_val(e, e.get_contract_id_from_asset(asset.clone())?)?;
+            BytesN::<32>::try_from_val(e, &e.get_contract_id_from_asset(asset.clone())?)?;
         if e.compare(&curr_contract_id, &expected_contract_id)? != Ordering::Equal {
             return Err(err!(
                 e,
@@ -195,7 +195,7 @@ impl TokenTrait for Token {
                     Metadata::AlphaNum4(AlphaNum4Metadata {
                         asset_code: BytesN::<4>::try_from_val(
                             e,
-                            e.bytes_new_from_slice(&asset4.asset_code.0)?,
+                            &e.bytes_new_from_slice(&asset4.asset_code.0)?,
                         )?,
                         issuer: asset4.issuer,
                     }),
@@ -211,7 +211,7 @@ impl TokenTrait for Token {
                     Metadata::AlphaNum12(AlphaNum12Metadata {
                         asset_code: BytesN::<12>::try_from_val(
                             e,
-                            e.bytes_new_from_slice(&asset12.asset_code.0)?,
+                            &e.bytes_new_from_slice(&asset12.asset_code.0)?,
                         )?,
                         issuer: asset12.issuer,
                     }),
@@ -240,10 +240,10 @@ impl TokenTrait for Token {
         check_nonnegative_amount(e, amount)?;
         let from_id = from.get_identifier(&e)?;
         let mut args = Vec::new(e)?;
-        args.push(from.get_identifier(&e)?)?;
-        args.push(nonce.clone())?;
-        args.push(spender.clone())?;
-        args.push(amount)?;
+        args.push(&from.get_identifier(&e)?)?;
+        args.push(&nonce.clone())?;
+        args.push(&spender.clone())?;
+        args.push(&amount)?;
         check_auth(&e, from, nonce, Symbol::from_str("incr_allow"), args)?;
 
         let allowance = read_allowance(&e, from_id.clone(), spender.clone())?;
@@ -266,10 +266,10 @@ impl TokenTrait for Token {
         check_nonnegative_amount(e, amount)?;
         let from_id = from.get_identifier(&e)?;
         let mut args = Vec::new(e)?;
-        args.push(from.get_identifier(&e)?)?;
-        args.push(nonce.clone())?;
-        args.push(spender.clone())?;
-        args.push(amount)?;
+        args.push(&from.get_identifier(&e)?)?;
+        args.push(&nonce.clone())?;
+        args.push(&spender.clone())?;
+        args.push(&amount)?;
         check_auth(&e, from, nonce, Symbol::from_str("decr_allow"), args)?;
 
         let allowance = read_allowance(&e, from_id.clone(), spender.clone())?;
@@ -308,10 +308,10 @@ impl TokenTrait for Token {
         check_nonnegative_amount(e, amount)?;
         let from_id = from.get_identifier(&e)?;
         let mut args = Vec::new(e)?;
-        args.push(from.get_identifier(&e)?)?;
-        args.push(nonce.clone())?;
-        args.push(to.clone())?;
-        args.push(amount)?;
+        args.push(&from.get_identifier(&e)?)?;
+        args.push(&nonce.clone())?;
+        args.push(&to.clone())?;
+        args.push(&amount)?;
         check_auth(&e, from, nonce, Symbol::from_str("xfer"), args)?;
         spend_balance(&e, from_id.clone(), amount)?;
         receive_balance(&e, to.clone(), amount)?;
@@ -331,11 +331,11 @@ impl TokenTrait for Token {
         check_nonnegative_amount(e, amount)?;
         let spender_id = spender.get_identifier(&e)?;
         let mut args = Vec::new(e)?;
-        args.push(spender.get_identifier(&e)?)?;
-        args.push(nonce.clone())?;
-        args.push(from.clone())?;
-        args.push(to.clone())?;
-        args.push(amount)?;
+        args.push(&spender.get_identifier(&e)?)?;
+        args.push(&nonce.clone())?;
+        args.push(&from.clone())?;
+        args.push(&to.clone())?;
+        args.push(&amount)?;
         check_auth(&e, spender, nonce, Symbol::from_str("xfer_from"), args)?;
         spend_allowance(&e, from.clone(), spender_id, amount)?;
         spend_balance(&e, from.clone(), amount)?;
@@ -350,9 +350,9 @@ impl TokenTrait for Token {
         check_non_native(e)?;
         let from_id = from.get_identifier(&e)?;
         let mut args = Vec::new(e)?;
-        args.push(from.get_identifier(&e)?)?;
-        args.push(nonce.clone())?;
-        args.push(amount)?;
+        args.push(&from.get_identifier(&e)?)?;
+        args.push(&nonce.clone())?;
+        args.push(&amount)?;
         check_auth(&e, from, nonce, Symbol::from_str("burn"), args)?;
         spend_balance(&e, from_id.clone(), amount)?;
         event::burn(e, from_id, amount)?;
@@ -371,10 +371,10 @@ impl TokenTrait for Token {
         check_non_native(e)?;
         let spender_id = spender.get_identifier(&e)?;
         let mut args = Vec::new(e)?;
-        args.push(spender.get_identifier(&e)?)?;
-        args.push(nonce.clone())?;
-        args.push(from.clone())?;
-        args.push(amount)?;
+        args.push(&spender.get_identifier(&e)?)?;
+        args.push(&nonce.clone())?;
+        args.push(&from.clone())?;
+        args.push(&amount)?;
         check_auth(&e, spender, nonce, Symbol::from_str("burn_from"), args)?;
         spend_allowance(&e, from.clone(), spender_id, amount)?;
         spend_balance(&e, from.clone(), amount)?;
@@ -395,10 +395,10 @@ impl TokenTrait for Token {
         check_clawbackable(&e, from.clone())?;
         let mut args = Vec::new(e)?;
         let admin_id = admin.get_identifier(&e)?;
-        args.push(admin_id.clone())?;
-        args.push(nonce.clone())?;
-        args.push(from.clone())?;
-        args.push(amount)?;
+        args.push(&admin_id.clone())?;
+        args.push(&nonce.clone())?;
+        args.push(&from.clone())?;
+        args.push(&amount)?;
         check_auth(&e, admin, nonce, Symbol::from_str("clawback"), args)?;
         // admin can clawback a deauthorized balance
         spend_balance_no_authorization_check(&e, from.clone(), amount)?;
@@ -417,10 +417,10 @@ impl TokenTrait for Token {
         check_admin(&e, &admin)?;
         let mut args = Vec::new(e)?;
         let admin_id = admin.get_identifier(&e)?;
-        args.push(admin_id.clone())?;
-        args.push(nonce.clone())?;
-        args.push(id.clone())?;
-        args.push(authorize)?;
+        args.push(&admin_id.clone())?;
+        args.push(&nonce.clone())?;
+        args.push(&id.clone())?;
+        args.push(&authorize)?;
         check_auth(&e, admin, nonce, Symbol::from_str("set_auth"), args)?;
         write_authorization(&e, id.clone(), authorize)?;
         event::set_auth(e, admin_id, id, authorize)?;
@@ -439,10 +439,10 @@ impl TokenTrait for Token {
         check_admin(&e, &admin)?;
         let mut args = Vec::new(e)?;
         let admin_id = admin.get_identifier(&e)?;
-        args.push(admin_id.clone())?;
-        args.push(nonce.clone())?;
-        args.push(to.clone())?;
-        args.push(amount)?;
+        args.push(&admin_id.clone())?;
+        args.push(&nonce.clone())?;
+        args.push(&to.clone())?;
+        args.push(&amount)?;
         check_auth(&e, admin, nonce, Symbol::from_str("mint"), args)?;
         receive_balance(&e, to.clone(), amount)?;
         event::mint(e, admin_id, to, amount)?;
@@ -459,9 +459,9 @@ impl TokenTrait for Token {
         check_admin(&e, &admin)?;
         let mut args = Vec::new(e)?;
         let admin_id = admin.get_identifier(&e)?;
-        args.push(admin_id.clone())?;
-        args.push(nonce.clone())?;
-        args.push(new_admin.clone())?;
+        args.push(&admin_id.clone())?;
+        args.push(&nonce.clone())?;
+        args.push(&new_admin.clone())?;
         check_auth(&e, admin, nonce, Symbol::from_str("set_admin"), args)?;
         write_administrator(&e, new_admin.clone())?;
         event::set_admin(e, admin_id, new_admin)?;

--- a/soroban-env-host/src/native_contract/token/cryptography.rs
+++ b/soroban-env-host/src/native_contract/token/cryptography.rs
@@ -23,8 +23,8 @@ fn check_ed25519_auth(
 ) -> Result<(), HostError> {
     let msg = SignaturePayloadV0 {
         name,
-        contract: BytesN::<32>::try_from_val(e, e.get_current_contract()?)?,
-        network: Bytes::try_from_val(e, e.get_ledger_network_passphrase()?)?,
+        contract: BytesN::<32>::try_from_val(e, &e.get_current_contract()?)?,
+        network: Bytes::try_from_val(e, &e.get_ledger_network_passphrase()?)?,
         args,
     };
     let msg_bin = e.serialize_to_bytes(SignaturePayload::V0(msg).try_into_val(e)?)?;
@@ -42,8 +42,8 @@ fn check_account_auth(
 ) -> Result<(), HostError> {
     let msg = SignaturePayloadV0 {
         name,
-        contract: BytesN::<32>::try_from_val(e, e.get_current_contract()?)?,
-        network: Bytes::try_from_val(e, e.get_ledger_network_passphrase()?)?,
+        contract: BytesN::<32>::try_from_val(e, &e.get_current_contract()?)?,
+        network: Bytes::try_from_val(e, &e.get_ledger_network_passphrase()?)?,
         args,
     };
     let msg_bin = e.serialize_to_bytes(SignaturePayload::V0(msg).try_into_val(e)?)?;

--- a/soroban-env-host/src/native_contract/token/event.rs
+++ b/soroban-env-host/src/native_contract/token/event.rs
@@ -11,9 +11,9 @@ pub(crate) fn incr_allow(
     amount: i128,
 ) -> Result<(), HostError> {
     let mut topics = Vec::new(e)?;
-    topics.push(Symbol::from_str("incr_allow"))?;
-    topics.push(from)?;
-    topics.push(to)?;
+    topics.push(&Symbol::from_str("incr_allow"))?;
+    topics.push(&from)?;
+    topics.push(&to)?;
     e.contract_event(topics.into(), amount.try_into_val(e)?)?;
     Ok(())
 }
@@ -25,9 +25,9 @@ pub(crate) fn decr_allow(
     amount: i128,
 ) -> Result<(), HostError> {
     let mut topics = Vec::new(e)?;
-    topics.push(Symbol::from_str("decr_allow"))?;
-    topics.push(from)?;
-    topics.push(to)?;
+    topics.push(&Symbol::from_str("decr_allow"))?;
+    topics.push(&from)?;
+    topics.push(&to)?;
     e.contract_event(topics.into(), amount.try_into_val(e)?)?;
     Ok(())
 }
@@ -39,9 +39,9 @@ pub(crate) fn transfer(
     amount: i128,
 ) -> Result<(), HostError> {
     let mut topics = Vec::new(e)?;
-    topics.push(Symbol::from_str("transfer"))?;
-    topics.push(from)?;
-    topics.push(to)?;
+    topics.push(&Symbol::from_str("transfer"))?;
+    topics.push(&from)?;
+    topics.push(&to)?;
     e.contract_event(topics.into(), amount.try_into_val(e)?)?;
     Ok(())
 }
@@ -53,9 +53,9 @@ pub(crate) fn mint(
     amount: i128,
 ) -> Result<(), HostError> {
     let mut topics = Vec::new(e)?;
-    topics.push(Symbol::from_str("mint"))?;
-    topics.push(admin)?;
-    topics.push(to)?;
+    topics.push(&Symbol::from_str("mint"))?;
+    topics.push(&admin)?;
+    topics.push(&to)?;
     e.contract_event(topics.into(), amount.try_into_val(e)?)?;
     Ok(())
 }
@@ -67,9 +67,9 @@ pub(crate) fn clawback(
     amount: i128,
 ) -> Result<(), HostError> {
     let mut topics = Vec::new(e)?;
-    topics.push(Symbol::from_str("clawback"))?;
-    topics.push(admin)?;
-    topics.push(from)?;
+    topics.push(&Symbol::from_str("clawback"))?;
+    topics.push(&admin)?;
+    topics.push(&from)?;
     e.contract_event(topics.into(), amount.try_into_val(e)?)?;
     Ok(())
 }
@@ -81,9 +81,9 @@ pub(crate) fn set_auth(
     authorize: bool,
 ) -> Result<(), HostError> {
     let mut topics = Vec::new(e)?;
-    topics.push(Symbol::from_str("set_auth"))?;
-    topics.push(admin)?;
-    topics.push(id)?;
+    topics.push(&Symbol::from_str("set_auth"))?;
+    topics.push(&admin)?;
+    topics.push(&id)?;
     e.contract_event(topics.into(), authorize.try_into_val(e)?)?;
     Ok(())
 }
@@ -94,16 +94,16 @@ pub(crate) fn set_admin(
     new_admin: Identifier,
 ) -> Result<(), HostError> {
     let mut topics = Vec::new(e)?;
-    topics.push(Symbol::from_str("set_admin"))?;
-    topics.push(admin)?;
+    topics.push(&Symbol::from_str("set_admin"))?;
+    topics.push(&admin)?;
     e.contract_event(topics.into(), new_admin.try_into_val(e)?)?;
     Ok(())
 }
 
 pub(crate) fn burn(e: &Host, from: Identifier, amount: i128) -> Result<(), HostError> {
     let mut topics = Vec::new(e)?;
-    topics.push(Symbol::from_str("burn"))?;
-    topics.push(from)?;
+    topics.push(&Symbol::from_str("burn"))?;
+    topics.push(&from)?;
     e.contract_event(topics.into(), amount.try_into_val(e)?)?;
     Ok(())
 }

--- a/soroban-env-host/src/native_contract/token/metadata.rs
+++ b/soroban-env-host/src/native_contract/token/metadata.rs
@@ -28,14 +28,14 @@ pub fn has_metadata(e: &Host) -> Result<bool, HostError> {
 // Metering: *mostly* covered by components. `bytes_new_from_slice` and `Bytes` not covered.
 pub fn read_name(e: &Host) -> Result<Bytes, HostError> {
     match read_metadata(e)? {
-        Metadata::Native => Ok(Bytes::try_from_val(e, e.bytes_new_from_slice(b"native")?)?),
+        Metadata::Native => Ok(Bytes::try_from_val(e, &e.bytes_new_from_slice(b"native")?)?),
         Metadata::AlphaNum4(asset) => {
             let mut res: Bytes = asset.asset_code.into();
             res.push(b':')?;
             let issuer_id = e.to_u256_from_account(&asset.issuer)?;
             res.append(Bytes::try_from_val(
                 e,
-                e.bytes_new_from_slice(&issuer_id.0)?,
+                &e.bytes_new_from_slice(&issuer_id.0)?,
             )?)?;
             Ok(res)
         }
@@ -45,7 +45,7 @@ pub fn read_name(e: &Host) -> Result<Bytes, HostError> {
             let issuer_id = e.to_u256_from_account(&asset.issuer)?;
             res.append(Bytes::try_from_val(
                 e,
-                e.bytes_new_from_slice(&issuer_id.0)?,
+                &e.bytes_new_from_slice(&issuer_id.0)?,
             )?)?;
             Ok(res)
         }
@@ -55,7 +55,7 @@ pub fn read_name(e: &Host) -> Result<Bytes, HostError> {
 // Metering: *mostly* covered by components.`bytes_new_from_slice` and `Bytes` not covered.
 pub fn read_symbol(e: &Host) -> Result<Bytes, HostError> {
     match read_metadata(e)? {
-        Metadata::Native => Ok(Bytes::try_from_val(e, e.bytes_new_from_slice(b"native")?)?),
+        Metadata::Native => Ok(Bytes::try_from_val(e, &e.bytes_new_from_slice(b"native")?)?),
         Metadata::AlphaNum4(asset) => Ok(asset.asset_code.into()),
         Metadata::AlphaNum12(asset) => Ok(asset.asset_code.into()),
     }

--- a/soroban-env-host/src/native_contract/token/test_token.rs
+++ b/soroban-env-host/src/native_contract/token/test_token.rs
@@ -29,7 +29,7 @@ impl<'a> TestToken<'a> {
             .try_into_val(host)
             .unwrap();
         Self {
-            id: BytesN::<32>::try_from_val(host, id_obj).unwrap(),
+            id: BytesN::<32>::try_from_val(host, &id_obj).unwrap(),
             host,
         }
     }

--- a/soroban-env-host/src/test/basic.rs
+++ b/soroban-env-host/src/test/basic.rs
@@ -1,9 +1,9 @@
-use soroban_env_common::{RawVal, TryFromVal};
+use soroban_env_common::{RawVal, TryFromVal, TryIntoVal};
 
 use crate::{
     host::HostError,
     xdr::{ScObjectType, ScVal},
-    Host, IntoVal, Object, RawValConvertible, Tag,
+    Host, Object, RawValConvertible, Tag,
 };
 
 /// numbers test
@@ -11,7 +11,7 @@ use crate::{
 fn u64_roundtrip() -> Result<(), HostError> {
     let host = Host::default();
     let u: u64 = 38473_u64; // This will be treated as a ScVal::Object::U64
-    let v: RawVal = u.into_val(&host);
+    let v: RawVal = u.try_into_val(&host)?;
     let obj: Object = v.try_into()?;
     assert!(obj.is_obj_type(ScObjectType::U64));
     assert_eq!(obj.get_handle(), 0);
@@ -19,7 +19,7 @@ fn u64_roundtrip() -> Result<(), HostError> {
     assert_eq!(u, j);
 
     let u2: u64 = u64::MAX; // This will be treated as a ScVal::Object::U64
-    let v2: RawVal = u2.into_val(&host);
+    let v2: RawVal = u2.try_into_val(&host)?;
     let obj: Object = v2.try_into()?;
     assert!(obj.is_obj_type(ScObjectType::U64));
     assert_eq!(obj.get_handle(), 1);
@@ -32,12 +32,12 @@ fn u64_roundtrip() -> Result<(), HostError> {
 fn i64_roundtrip() -> Result<(), HostError> {
     let host = Host::default();
     let i: i64 = 12345_i64; // Will be treated as ScVal::I64
-    let v: RawVal = i.into_val(&host);
+    let v: RawVal = i.try_into_val(&host)?;
     let j = i64::try_from_val(&host, v)?;
     assert_eq!(i, j);
 
     let i2: i64 = -13234_i64; // WIll be treated as ScVal::Object::I64
-    let v2: RawVal = i2.into_val(&host);
+    let v2: RawVal = i2.try_into_val(&host)?;
     let obj: Object = v2.try_into()?;
     assert!(obj.is_obj_type(ScObjectType::I64));
     assert_eq!(obj.get_handle(), 0);
@@ -74,7 +74,7 @@ fn i32_as_seen_by_host() -> Result<(), HostError> {
 fn tuple_roundtrip() -> Result<(), HostError> {
     let host = Host::default();
     let t0: (u32, i32) = (5, -4);
-    let ev: RawVal = t0.into_val(&host);
+    let ev: RawVal = t0.try_into_val(&host)?;
     let t0_back: (u32, i32) = <(u32, i32)>::try_from_val(&host, ev)?;
     assert_eq!(t0, t0_back);
     Ok(())

--- a/soroban-env-host/src/test/basic.rs
+++ b/soroban-env-host/src/test/basic.rs
@@ -15,7 +15,7 @@ fn u64_roundtrip() -> Result<(), HostError> {
     let obj: Object = v.try_into()?;
     assert!(obj.is_obj_type(ScObjectType::U64));
     assert_eq!(obj.get_handle(), 0);
-    let j = u64::try_from_val(&host, v)?;
+    let j = u64::try_from_val(&host, &v)?;
     assert_eq!(u, j);
 
     let u2: u64 = u64::MAX; // This will be treated as a ScVal::Object::U64
@@ -23,7 +23,7 @@ fn u64_roundtrip() -> Result<(), HostError> {
     let obj: Object = v2.try_into()?;
     assert!(obj.is_obj_type(ScObjectType::U64));
     assert_eq!(obj.get_handle(), 1);
-    let k = u64::try_from_val(&host, v2)?;
+    let k = u64::try_from_val(&host, &v2)?;
     assert_eq!(u2, k);
     Ok(())
 }
@@ -33,7 +33,7 @@ fn i64_roundtrip() -> Result<(), HostError> {
     let host = Host::default();
     let i: i64 = 12345_i64; // Will be treated as ScVal::I64
     let v: RawVal = i.try_into_val(&host)?;
-    let j = i64::try_from_val(&host, v)?;
+    let j = i64::try_from_val(&host, &v)?;
     assert_eq!(i, j);
 
     let i2: i64 = -13234_i64; // WIll be treated as ScVal::Object::I64
@@ -41,7 +41,7 @@ fn i64_roundtrip() -> Result<(), HostError> {
     let obj: Object = v2.try_into()?;
     assert!(obj.is_obj_type(ScObjectType::I64));
     assert_eq!(obj.get_handle(), 0);
-    let k = i64::try_from_val(&host, v2)?;
+    let k = i64::try_from_val(&host, &v2)?;
     assert_eq!(i2, k);
     Ok(())
 }
@@ -75,7 +75,7 @@ fn tuple_roundtrip() -> Result<(), HostError> {
     let host = Host::default();
     let t0: (u32, i32) = (5, -4);
     let ev: RawVal = t0.try_into_val(&host)?;
-    let t0_back: (u32, i32) = <(u32, i32)>::try_from_val(&host, ev)?;
+    let t0_back: (u32, i32) = <(u32, i32)>::try_from_val(&host, &ev)?;
     assert_eq!(t0, t0_back);
     Ok(())
 }

--- a/soroban-env-host/src/test/token.rs
+++ b/soroban-env-host/src/test/token.rs
@@ -319,7 +319,7 @@ fn test_native_token_smart_roundtrip() {
     let token = TestToken::new_from_asset(&test.host, Asset::Native);
     let expected_token_id = BytesN::<32>::try_from_val(
         &test.host,
-        test.host.get_contract_id_from_asset(Asset::Native).unwrap(),
+        &test.host.get_contract_id_from_asset(Asset::Native).unwrap(),
     )
     .unwrap();
 
@@ -388,7 +388,7 @@ fn test_classic_asset_init(asset_code: &[u8]) {
     let token = TestToken::new_from_asset(&test.host, asset.clone());
     let expected_token_id = BytesN::<32>::try_from_val(
         &test.host,
-        test.host.get_contract_id_from_asset(asset).unwrap(),
+        &test.host.get_contract_id_from_asset(asset).unwrap(),
     )
     .unwrap();
     assert_eq!(token.id.to_vec(), expected_token_id.to_vec());

--- a/soroban-env-host/src/test/tuple.rs
+++ b/soroban-env-host/src/test/tuple.rs
@@ -1,4 +1,4 @@
-use soroban_env_common::{IntoVal, TryIntoVal};
+use soroban_env_common::TryIntoVal;
 
 use crate::{CheckedEnv, Host, HostError, RawVal};
 
@@ -6,7 +6,7 @@ use crate::{CheckedEnv, Host, HostError, RawVal};
 fn tuple_conversions() -> Result<(), HostError> {
     let host = Host::default();
 
-    let raw: RawVal = (1u32, 1i32).into_val(&host);
+    let raw: RawVal = (1u32, 1i32).try_into_val(&host)?;
 
     let mut obj = host.vec_new(RawVal::VOID)?;
     obj = host.vec_push_back(obj, (1u32).into())?;
@@ -24,11 +24,11 @@ fn tuple_conversions() -> Result<(), HostError> {
 fn tuple_array_conversions() -> Result<(), HostError> {
     let host = Host::default();
 
-    let raw: [RawVal; 0] = ().into_val(&host);
+    let raw: [RawVal; 0] = ().try_into_val(&host)?;
     let unit: () = raw.try_into_val(&host)?;
     assert_eq!(unit, ());
 
-    let raw: [RawVal; 2] = (1u32, 1i32).into_val(&host);
+    let raw: [RawVal; 2] = (1u32, 1i32).try_into_val(&host)?;
     let roundtrip: (u32, i32) = raw.try_into_val(&host)?;
     assert_eq!(roundtrip, (1u32, 1i32));
 

--- a/soroban-env-host/tests/option.rs
+++ b/soroban-env-host/tests/option.rs
@@ -1,28 +1,30 @@
-use soroban_env_common::{xdr::ScStatic, IntoVal, RawVal, Static, TryIntoVal};
-use soroban_env_host::Host;
+use soroban_env_common::{xdr::ScStatic, RawVal, Static, TryIntoVal};
+use soroban_env_host::{Host, HostError};
 
 #[test]
-fn some() {
+fn some() -> Result<(), HostError> {
     let host = Host::default();
 
     let some = Some(1u32);
-    let val: RawVal = some.into_val(&host);
+    let val: RawVal = some.try_into_val(&host)?;
     assert!(val.is::<u32>());
-    let u32: u32 = val.try_into_val(&host).unwrap();
+    let u32: u32 = val.try_into_val(&host)?;
     assert_eq!(u32, 1);
 
-    assert_eq!(some, val.try_into_val(&host).unwrap());
+    assert_eq!(some, val.try_into_val(&host)?);
+    Ok(())
 }
 
 #[test]
-fn none() {
+fn none() -> Result<(), HostError> {
     let host = Host::default();
 
     let none: Option<u32> = None;
-    let val: RawVal = none.into_val(&host);
+    let val: RawVal = none.try_into_val(&host)?;
     assert!(val.is::<Static>());
-    let r#static: Static = val.try_into_val(&host).unwrap();
+    let r#static: Static = val.try_into_val(&host)?;
     assert!(r#static.is_type(ScStatic::Void));
 
-    assert_eq!(none, val.try_into_val(&host).unwrap());
+    assert_eq!(none, val.try_into_val(&host)?);
+    Ok(())
 }

--- a/soroban-native-sdk-macros/src/derive_type.rs
+++ b/soroban-native-sdk-macros/src/derive_type.rs
@@ -1,10 +1,10 @@
 use itertools::MultiUnzip;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
-use syn::{spanned::Spanned, DataEnum, DataStruct, Error, Ident, Type, Visibility};
+use syn::{spanned::Spanned, DataEnum, DataStruct, Error, Ident, Visibility};
 
 pub fn derive_type_struct(ident: &Ident, data: &DataStruct) -> TokenStream2 {
-    let (names, tys, map_keys): (Vec<_>, Vec<_>, Vec<_>) = data.fields
+    let (names, map_keys): (Vec<_>, Vec<_>) = data.fields
         .iter()
         .filter(|f| matches!(f.vis, Visibility::Public(_)))
         .enumerate()
@@ -17,7 +17,7 @@ pub fn derive_type_struct(ident: &Ident, data: &DataStruct) -> TokenStream2 {
             let map_key = quote! { // TODO: Handle field names longer than a symbol. Hash the name? Truncate the name?
                 { const k: soroban_env_common::Symbol = soroban_env_common::Symbol::from_str(#name); k }
             };
-            (ident, f.ty.clone(), map_key)
+            (ident, map_key)
         })
         .multiunzip();
 
@@ -37,11 +37,10 @@ pub fn derive_type_struct(ident: &Ident, data: &DataStruct) -> TokenStream2 {
         impl soroban_env_common::TryFromVal<crate::Host, soroban_env_common::Object> for #ident {
             type Error = crate::HostError;
 
-            fn try_from_val(env: &crate::Host, val: impl core::borrow::Borrow<soroban_env_common::Object>) -> Result<Self, Self::Error> {
-                let val = *val.borrow();
+            fn try_from_val(env: &crate::Host, val: &soroban_env_common::Object) -> Result<Self, Self::Error> {
                 let map = Map::try_from_val(env, val)?;
                 Ok(Self {
-                    #(#names: map.get(#map_keys)?,)*
+                    #(#names: map.get(&#map_keys)?,)*
                 })
             }
         }
@@ -49,19 +48,18 @@ pub fn derive_type_struct(ident: &Ident, data: &DataStruct) -> TokenStream2 {
         impl soroban_env_common::TryFromVal<crate::Host, soroban_env_common::RawVal> for #ident {
             type Error = crate::HostError;
 
-            fn try_from_val(env: &crate::Host, val: impl core::borrow::Borrow<soroban_env_common::RawVal>) -> Result<Self, Self::Error> {
-                let val = *val.borrow();
+            fn try_from_val(env: &crate::Host, val: &soroban_env_common::RawVal) -> Result<Self, Self::Error> {
                 let obj: soroban_env_common::Object = val.try_into()?;
-                Self::try_from_val(env, obj)
+                obj.try_into_val(env)
             }
         }
 
         impl soroban_env_common::TryFromVal<crate::Host, #ident> for soroban_env_common::RawVal {
             type Error = crate::HostError;
 
-            fn try_from_val(env: &crate::Host, val: impl core::borrow::Borrow<#ident>) -> Result<Self, Self::Error> {
+            fn try_from_val(env: &crate::Host, val: &#ident) -> Result<Self, Self::Error> {
                 let mut map = Map::new(env)?;
-                #(map.set::<soroban_env_common::Symbol, #tys>(#map_keys, &val.borrow().#names)?;)*
+                #(map.set(&#map_keys, &val.#names)?;)*
                 map.try_into_val(env)
             }
         }
@@ -88,7 +86,7 @@ pub fn derive_type_enum(ident: &Ident, data: &DataEnum) -> TokenStream2 {
                 };
                 let into = quote! {
                     #ident::#case_ident => {
-                        vec.push({ const k: crate::Symbol = crate::Symbol::from_str(#case_name); k })?;
+                        vec.push(&{ const k: crate::Symbol = crate::Symbol::from_str(#case_name); k })?;
                     }
                 };
                 let sym = quote! {
@@ -99,18 +97,13 @@ pub fn derive_type_enum(ident: &Ident, data: &DataEnum) -> TokenStream2 {
                 };
                 (discriminant_const, from, into, sym, compare)
             } else if f.fields.len() == 1 {
-                let ty:Type = match &f.fields {
-                    syn::Fields::Named(fs) => fs.named.first().unwrap().ty.clone(),
-                    syn::Fields::Unnamed(fs) => fs.unnamed.first().unwrap().ty.clone(),
-                    syn::Fields::Unit => syn::parse_quote!{ () },
-                };
                 let from = quote! {
                     #discriminant_ident => Ok(Self::#case_ident(vec.get(1)?))
                 };
                 let into = quote! {
                     #ident::#case_ident(x) => {
-                        vec.push({ const k: crate::Symbol = crate::Symbol::from_str(#case_name); k })?;
-                        vec.push::<#ty>(x)?;
+                        vec.push(&{ const k: crate::Symbol = crate::Symbol::from_str(#case_name); k })?;
+                        vec.push(x)?;
                     }
                 };
                 let sym = quote! {
@@ -158,8 +151,7 @@ pub fn derive_type_enum(ident: &Ident, data: &DataEnum) -> TokenStream2 {
             impl soroban_env_common::TryFromVal<crate::Host, soroban_env_common::Object> for #ident {
                 type Error = crate::HostError;
 
-                fn try_from_val(env: &crate::Host, val: impl core::borrow::Borrow<soroban_env_common::Object>) -> Result<Self, Self::Error> {
-                    let val = *val.borrow();
+                fn try_from_val(env: &crate::Host, val: &soroban_env_common::Object) -> Result<Self, Self::Error> {
                     #(#consts;)*
                     let vec = crate::native_contract::base_types::Vec::try_from_val(env, val)?;
                     let discriminant: soroban_env_common::Symbol = vec.get(0)?;
@@ -173,20 +165,19 @@ pub fn derive_type_enum(ident: &Ident, data: &DataEnum) -> TokenStream2 {
             impl soroban_env_common::TryFromVal<crate::Host, soroban_env_common::RawVal> for #ident {
                 type Error = crate::HostError;
 
-                fn try_from_val(env: &crate::Host, val: impl core::borrow::Borrow<soroban_env_common::RawVal>) -> Result<Self, Self::Error> {
-                    let val = *val.borrow();
+                fn try_from_val(env: &crate::Host, val: &soroban_env_common::RawVal) -> Result<Self, Self::Error> {
                     let obj: soroban_env_common::Object = val.try_into()?;
-                    Self::try_from_val(env, obj)
+                    obj.try_into_val(env)
                 }
             }
 
             impl soroban_env_common::TryFromVal<crate::Host, #ident> for soroban_env_common::RawVal {
                 type Error = crate::HostError;
 
-                fn try_from_val(env: &crate::Host, val: impl core::borrow::Borrow<#ident>) -> Result<soroban_env_common::RawVal, Self::Error> {
+                fn try_from_val(env: &crate::Host, val: &#ident) -> Result<soroban_env_common::RawVal, Self::Error> {
                     #(#consts;)*
                     let mut vec = crate::native_contract::base_types::Vec::new(env)?;
-                    match val.borrow() {
+                    match val {
                         #(#intos)*
                     };
                     vec.try_into_val(env)


### PR DESCRIPTION
## Overview

This is a "minimal" version of the change I've been attempting to make to `TryFromVal` and friends for the past few weeks.

It defers mucking with the error types to a later PR (I have an idea for how to do that but it doesn't _have_ to happen here). The minimal changes here are just to get rid of so many impls to improve maintainability -- net removal of about 300 lines -- while expanding and systematizing overall coverage (the error stuff will also make things a bit more systematic).

The changes here are:

  - Remove non-Try {Into,From}Val. 
  - Blanket-impl TryIntoVal to use TryFromVal, removing all manual TryIntoVal impls.
  - Switch TryFromVal to take &T everywhere, removing the T-vs-&T duplication.
 
It seems to hold together, so I'm going to start on the SDK changes to match. Feedback welcome.

## Discussion

In the resulting code, I think nobody should implement anything except TryFromVal<T>, UDT code or otherwise.

You may find it easier to review just by opening the finished files and eyeballing them for "this looks nice". The specific changes are all just the 3 above applied mechanically, plus type-inference-massaging to match in a few cases.

The removal of non-Try {Into,From}Val might seem a little aggressive, but if you look at what it's used for and the bodies of the impls, I think it makes sense: most of the projection paths have a guest-side fallibility path anyway (eg. when given an object handle of the wrong type) for the few remaining injection paths that are  logically infallible (eg. "you should always be able to inject a u64 to a host object") it's not a lot of extra work in the guest to call .unwrap() or ? as appropriate, and I think it's fairly likely we're actually going to re-parameterize all these over EnvBase or merge Env and CheckedEnv, in which case all host methods will return a Result anyways plumb it out to the user where they can do an infallible-unwrap whenever `E::Error=Infallible`. Either way, removing them cuts the set of impls in half and I think the reduction in clutter is a net win in comprehensibility, even for users.