### PR TITLE
Structured diagnostic events

### DIFF
--- a/soroban-env-host/src/budget.rs
+++ b/soroban-env-host/src/budget.rs
@@ -369,9 +369,9 @@ impl Budget {
         })
     }
 
-    pub fn with_free_budget<F>(&self, f: F) -> Result<(), HostError>
+    pub fn with_free_budget<F, T>(&self, f: F) -> Result<T, HostError>
     where
-        F: FnOnce() -> Result<(), HostError>,
+        F: FnOnce() -> Result<T, HostError>,
     {
         self.mut_budget(|mut b| {
             b.enabled = false;

--- a/soroban-env-host/src/budget.rs
+++ b/soroban-env-host/src/budget.rs
@@ -317,6 +317,7 @@ pub(crate) struct BudgetImpl {
     /// Tracks the sums of _input_ values to the cost models, for purposes of
     /// calibration and reporting; not used for budget-limiting per se.
     inputs: Vec<u64>,
+    enabled: bool,
 }
 
 #[derive(Default, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -348,6 +349,10 @@ impl Budget {
     }
 
     pub fn charge(&self, ty: CostType, input: u64) -> Result<(), HostError> {
+        if !self.0.borrow().enabled {
+            return Ok(());
+        }
+
         // println!("charging {} of {:?} (cpu budget: {}, mem budget: {})",
         // input, ty, self.get_cpu_insns_count(), self.get_mem_bytes_count());
         //
@@ -362,6 +367,24 @@ impl Budget {
             b.cpu_insns.charge(ty, input)?;
             b.mem_bytes.charge(ty, input)
         })
+    }
+
+    pub fn with_free_budget<F>(&self, f: F) -> Result<(), HostError>
+    where
+        F: FnOnce() -> Result<(), HostError>,
+    {
+        self.mut_budget(|mut b| {
+            b.enabled = false;
+            Ok(())
+        })?;
+
+        let res = f();
+
+        self.mut_budget(|mut b| {
+            b.enabled = true;
+            Ok(())
+        })?;
+        res
     }
 
     pub fn get_input(&self, ty: CostType) -> u64 {
@@ -444,6 +467,7 @@ impl Default for BudgetImpl {
             cpu_insns: BudgetDimension::new(ScVmErrorCode::TrapCpuLimitExceeded),
             mem_bytes: BudgetDimension::new(ScVmErrorCode::TrapMemLimitExceeded),
             inputs: Default::default(),
+            enabled: true,
         };
 
         for ct in CostType::variants() {

--- a/soroban-env-host/src/events/internal.rs
+++ b/soroban-env-host/src/events/internal.rs
@@ -114,9 +114,8 @@ impl InternalEventsBuffer {
         if rollback_count > 0 {
             self.vec.push(InternalEvent::Debug(
                 DebugEvent::new()
-                    .msg("{} contract events rolled back. Rollback start pos = {}")
-                    .arg(RawVal::from(rollback_count))
-                    .arg(host.usize_to_rawval_u32(events)?),
+                    .msg("{} contract events rolled back.")
+                    .arg(RawVal::from(rollback_count)),
             ));
         }
         Ok(())

--- a/soroban-env-host/src/events/internal.rs
+++ b/soroban-env-host/src/events/internal.rs
@@ -4,7 +4,7 @@ use crate::{
     host::metered_clone::MeteredClone,
     xdr,
     xdr::ScObject,
-    Host, HostError, MeteredVector, Object, RawVal,
+    Host, HostError, Object, RawVal,
 };
 
 /// The internal representation of a `ContractEvent` that is stored in the events buffer
@@ -55,14 +55,14 @@ impl MeteredClone for InternalEvent {}
 /// The events buffer. Stores `InternalEvent`s in the chronological order.
 #[derive(Clone, Default)]
 pub(crate) struct InternalEventsBuffer {
-    pub(crate) vec: MeteredVector<InternalEvent>,
+    pub(crate) vec: Vec<InternalEvent>,
 }
 
 impl InternalEventsBuffer {
     // Records an InternalEvent
-    // Metering covered by the `MeteredVec`.
-    pub fn record(&mut self, e: InternalEvent, budget: &Budget) -> Result<(), HostError> {
-        self.vec = self.vec.push_back(e, budget)?;
+    pub fn record(&mut self, e: InternalEvent, _budget: &Budget) -> Result<(), HostError> {
+        //TODO:Add metering for non-diagnostic events
+        self.vec.push(e);
         Ok(())
     }
 
@@ -81,38 +81,30 @@ impl InternalEventsBuffer {
     /// Rolls back the event buffer starting at `events`. Any `ContractEvent` will be converted
     /// to a `DebugEvent` indicating the event has been rolled back. An additional `DebugEvent`
     /// will be pushed at the end indicating the rollback happened.
-    // Metering covered by the `MeteredVec`
     pub fn rollback(&mut self, events: usize, host: &Host) -> Result<(), HostError> {
+        //TODO: Metering for non-diagnostic events?
+
         let mut rollback_count = 0u32;
-        self.vec = self.vec.retain_mut(
-            |i, e| {
-                if i < events {
-                    Ok(true)
-                } else {
-                    match e {
-                        InternalEvent::Contract(c) | InternalEvent::StructuredDebug(c) => {
-                            *e = Self::defunct_contract_event(c);
-                            rollback_count += 1;
-                            Ok(true)
-                        }
-                        InternalEvent::Debug(_) | InternalEvent::None => Ok(true),
-                    }
+        // note that we first skip the events that are not being rolled back
+        for e in self.vec.iter_mut().skip(events) {
+            match e {
+                InternalEvent::Contract(c) | InternalEvent::StructuredDebug(c) => {
+                    *e = Self::defunct_contract_event(c);
+                    rollback_count += 1;
                 }
-            },
-            host.as_budget(),
-        )?;
+                InternalEvent::Debug(_) | InternalEvent::None => {}
+            }
+        }
+
         // If any events were rolled back, we push one more debug event at the end to
         // let the user know.
         if rollback_count > 0 {
-            self.vec = self.vec.push_back(
-                InternalEvent::Debug(
-                    DebugEvent::new()
-                        .msg("{} contract events rolled back. Rollback start pos = {}")
-                        .arg(RawVal::from(rollback_count))
-                        .arg(host.usize_to_rawval_u32(events)?),
-                ),
-                host.as_budget(),
-            )?;
+            self.vec.push(InternalEvent::Debug(
+                DebugEvent::new()
+                    .msg("{} contract events rolled back. Rollback start pos = {}")
+                    .arg(RawVal::from(rollback_count))
+                    .arg(host.usize_to_rawval_u32(events)?),
+            ));
         }
         Ok(())
     }
@@ -134,7 +126,7 @@ impl InternalEventsBuffer {
 
     /// Converts the internal events into their external representation. This should only be called
     /// either when the host is finished (via `try_finish`), or when an error occurs.
-    // Metering: the new vec allocation is not charged, but that should be fine.
+    // TODO: Metering for non-diagnostic events?
     pub fn externalize(&self, host: &Host) -> Result<Events, HostError> {
         let vec: Result<Vec<HostEvent>, HostError> = self
             .vec
@@ -142,9 +134,9 @@ impl InternalEventsBuffer {
             .map(|e| match e {
                 InternalEvent::Contract(c) => Ok(HostEvent::Contract(c.clone().to_xdr(host)?)),
                 InternalEvent::Debug(d) => Ok(HostEvent::Debug(d.clone())),
-                InternalEvent::StructuredDebug(c) => {
-                    Ok(HostEvent::StructuredDebug(c.clone().to_xdr(host)?))
-                }
+                InternalEvent::StructuredDebug(c) => host
+                    .as_budget()
+                    .with_free_budget(|| Ok(HostEvent::StructuredDebug(c.clone().to_xdr(host)?))),
                 InternalEvent::None => Err(host.err_general("Unexpected event type")),
             })
             .collect();

--- a/soroban-env-host/src/events/mod.rs
+++ b/soroban-env-host/src/events/mod.rs
@@ -10,6 +10,7 @@ pub(crate) use internal::{InternalContractEvent, InternalEvent, InternalEventsBu
 pub enum HostEvent {
     Contract(crate::xdr::ContractEvent),
     Debug(DebugEvent),
+    StructuredDebug(crate::xdr::ContractEvent),
 }
 
 /// The external representation of events in the chronological order.

--- a/soroban-env-host/src/events/mod.rs
+++ b/soroban-env-host/src/events/mod.rs
@@ -17,6 +17,9 @@ pub enum HostEvent {
 #[derive(Clone, Debug, Default)]
 pub struct Events(pub Vec<HostEvent>);
 
+#[derive(Clone, Default)]
+pub struct RolledbackDiagnosticEvents(pub Vec<crate::xdr::ContractEvent>);
+
 // Maximum number of topics in a `ContractEvent`. This applies to both
 // `Contract` and `System` types of contract events.
 pub(crate) const CONTRACT_EVENT_TOPICS_LIMIT: usize = 4;

--- a/soroban-env-host/src/host/diagnostics_helper.rs
+++ b/soroban-env-host/src/host/diagnostics_helper.rs
@@ -19,10 +19,6 @@ impl Host {
         topics: Object,
         data: RawVal,
     ) -> Result<(), HostError> {
-        if !self.is_debug() {
-            return Ok(());
-        }
-
         let ce = InternalContractEvent {
             type_,
             contract_id: None,

--- a/soroban-env-host/src/host/diagnostics_helper.rs
+++ b/soroban-env-host/src/host/diagnostics_helper.rs
@@ -1,0 +1,106 @@
+use soroban_env_common::{
+    xdr::{ContractEventType, Hash, ScObject, ScVal, ScVec},
+    ConversionError, Object, Symbol, TryFromVal,
+};
+
+use crate::events::{InternalContractEvent, InternalEvent};
+use crate::{budget::AsBudget, Host, HostError, RawVal};
+
+/// None of these functions are metered, which is why they're behind the is_debug check
+impl Host {
+    fn hash_to_scval(&self, hash: Hash) -> Result<ScVal, HostError> {
+        let id_obj = self.add_host_object(hash.0.to_vec())?;
+        Ok(ScVal::Object(Some(self.from_host_obj(id_obj.into())?)))
+    }
+
+    fn record_system_debug_contract_event(
+        &self,
+        type_: ContractEventType,
+        topics: Object,
+        data: RawVal,
+    ) -> Result<(), HostError> {
+        if !self.is_debug() {
+            return Ok(());
+        }
+
+        let ce = InternalContractEvent {
+            type_,
+            contract_id: None,
+            topics,
+            data,
+        };
+        self.get_events_mut(|events| {
+            Ok(events.record(InternalEvent::StructuredDebug(ce), self.as_budget()))
+        })?
+    }
+
+    // Emits an event with topic = ["fn_call", contract_id, function_name] and
+    // data = [arg1, args2, ...]
+    pub fn fn_call_diagnostics(
+        &self,
+        contract_id: &Hash,
+        func: &Symbol,
+        args: &[RawVal],
+    ) -> Result<(), HostError> {
+        if !self.is_debug() {
+            return Ok(());
+        }
+
+        self.as_budget().with_free_budget(|| {
+            let mut topics: Vec<ScVal> = Vec::new();
+            topics.push(ScVal::Symbol(
+                self.map_err("fn_call".as_bytes().try_into())?,
+            ));
+
+            topics.push(self.hash_to_scval(contract_id.clone())?);
+            topics.push(func.try_into()?);
+
+            let scval_topics: ScVec = self.map_err(topics.try_into())?;
+
+            let data: Result<Vec<ScVal>, ConversionError> = args
+                .into_iter()
+                .map(|i| ScVal::try_from_val(self, i))
+                .collect();
+            let data_vec: ScVec = self.map_err(data?.try_into())?;
+
+            self.record_system_debug_contract_event(
+                ContractEventType::System,
+                self.to_host_obj(&ScObject::Vec(scval_topics))?,
+                self.to_host_val(&ScVal::Object(Some(ScObject::Vec(data_vec))))?,
+            )
+        })
+    }
+
+    // Emits an event with topic = ["fn_return", contract_id, function_name] and
+    // data = [return_val]
+    pub fn fn_return_diagnostics(
+        &self,
+        contract_id: &Hash,
+        func: &Symbol,
+        res: &RawVal,
+    ) -> Result<(), HostError> {
+        if !self.is_debug() {
+            return Ok(());
+        }
+
+        self.as_budget().with_free_budget(|| {
+            let mut topics: Vec<ScVal> = Vec::new();
+            topics.push(ScVal::Symbol(
+                self.map_err("fn_return".as_bytes().try_into())?,
+            ));
+
+            topics.push(self.hash_to_scval(contract_id.clone())?);
+            topics.push(func.try_into()?);
+
+            let scval_topics: ScVec = self.map_err(topics.try_into())?;
+
+            let return_val = ScVal::try_from_val(self, &res)?;
+
+            self.record_system_debug_contract_event(
+                ContractEventType::System,
+                self.to_host_obj(&ScObject::Vec(scval_topics))?,
+                self.to_host_val(&return_val)?,
+            )
+        })
+    }
+}

--- a/soroban-env-host/src/host/err_helper.rs
+++ b/soroban-env-host/src/host/err_helper.rs
@@ -17,7 +17,7 @@ impl Host {
         } else {
             let mut he: HostError = ds.status.into();
             // If `get_events` causes an out-of-budget err, the events will not be recorded.
-            he.events = self.get_events().ok();
+            he.events = self.get_events().ok().unzip().0;
             he
         }
     }

--- a/soroban-env-host/src/host/error.rs
+++ b/soroban-env-host/src/host/error.rs
@@ -67,6 +67,7 @@ impl Debug for HostError {
                         .rev()
                         .filter_map(|ev| match ev {
                             HostEvent::Debug(e) => Some(format!("{:}", e)),
+                            HostEvent::StructuredDebug(e) => Some(format!("{:?}", e)),
                             _ => None,
                         })
                         .take(MAX_DEBUG_EVENTS)

--- a/soroban-env-host/src/lib.rs
+++ b/soroban-env-host/src/lib.rs
@@ -49,6 +49,7 @@ pub mod cost_runner;
 #[cfg(any(test, feature = "testutils"))]
 pub use host::ContractFunctionSet;
 pub use host::{
-    metered_map::MeteredOrdMap, metered_vector::MeteredVector, Host, HostError, LedgerInfo,
+    metered_map::MeteredOrdMap, metered_vector::MeteredVector, DiagnosticLevel, Host, HostError,
+    LedgerInfo,
 };
 pub use soroban_env_common::*;

--- a/soroban-env-host/src/test/complex.rs
+++ b/soroban-env-host/src/test/complex.rs
@@ -41,7 +41,7 @@ fn run_complex() -> Result<(), HostError> {
             let args: ScVec = host.test_scvec::<i32>(&[])?;
             vm.invoke_function(&host, "go", &args)?;
         }
-        let (store, _, _) = host.try_finish().unwrap();
+        let (store, _, _, _) = host.try_finish().unwrap();
         store.footprint
     };
 

--- a/soroban-env-host/src/test/event.rs
+++ b/soroban-env-host/src/test/event.rs
@@ -54,7 +54,7 @@ fn contract_event() -> Result<(), HostError> {
 
     // Fish out the last contract event and check that it is
     // correct, and formats as expected.
-    let events = host.get_events()?;
+    let events = host.get_events()?.0;
     match events.0.last() {
         Some(HostEvent::Contract(ce)) => {
             assert_eq!(*ce, event_ref)
@@ -98,9 +98,9 @@ fn test_event_rollback() -> Result<(), HostError> {
     host.0.events.borrow_mut().rollback(1, &host)?;
 
     let expected = expect![[
-        r#"Events([Contract(ContractEvent { ext: V0, contract_id: Some(Hash(0000000000000000000000000000000000000000000000000000000000000000)), type_: Contract, body: V0(ContractEventV0 { topics: ScVec(VecM([I32(0), I32(1)])), data: U32(0) }) }), Debug(DebugEvent { msg: Some("debug event 0"), args: [] }), Debug(DebugEvent { msg: Some("rolled-back contract event: type {}, id {}, topics {}, data {}"), args: [Val(I32(0)), Val(Object(Bytes(#4))), Val(Object(Vec(#2))), Val(U32(0))] }), Debug(DebugEvent { msg: Some("{} contract events rolled back. Rollback start pos = {}"), args: [Val(U32(1)), Val(U32(1))] })])"#
+        r#"Events([Contract(ContractEvent { ext: V0, contract_id: Some(Hash(0000000000000000000000000000000000000000000000000000000000000000)), type_: Contract, body: V0(ContractEventV0 { topics: ScVec(VecM([I32(0), I32(1)])), data: U32(0) }) }), Debug(DebugEvent { msg: Some("debug event 0"), args: [] }), Debug(DebugEvent { msg: Some("rolled-back contract event: type {}, id {}, topics {}, data {}"), args: [Val(I32(0)), Val(Object(Bytes(#4))), Val(Object(Vec(#2))), Val(U32(0))] }), Debug(DebugEvent { msg: Some("{} contract events rolled back."), args: [Val(U32(1))] })])"#
     ]];
-    let actual = format!("{:?}", host.0.events.borrow().externalize(&host)?);
+    let actual = format!("{:?}", host.0.events.borrow().externalize(&host)?.0);
     expected.assert_eq(&actual);
     Ok(())
 }

--- a/soroban-env-host/src/test/invocation.rs
+++ b/soroban-env-host/src/test/invocation.rs
@@ -77,7 +77,7 @@ fn invoke_cross_contract_with_err() -> Result<(), HostError> {
     let exp_st: Status = code.into();
     assert_eq!(sv.get_payload(), exp_st.to_raw().get_payload());
 
-    let events = host.get_events()?;
+    let events = host.get_events()?.0;
     assert_eq!(events.0.len(), 4);
     let last_event = events.0.last();
     match last_event {
@@ -109,7 +109,7 @@ fn invoke_cross_contract_with_err() -> Result<(), HostError> {
     let res = host.call(id_obj, sym.into(), args.into());
     assert!(HostError::result_matches_err_status(res, code));
 
-    let events = host.get_events()?;
+    let events = host.get_events()?.0;
     assert_eq!(events.0.len(), 8);
     let last_event = events.0.last();
     match last_event {
@@ -171,7 +171,7 @@ fn invoke_cross_contract_indirect_err() -> Result<(), HostError> {
     let exp: Status = code.into();
     assert_eq!(status.get_payload(), exp.to_raw().get_payload());
 
-    let events = host.get_events()?;
+    let events = host.get_events()?.0;
     assert_eq!(events.0.len(), 9);
     let last_event = events.0.last();
     match last_event {
@@ -203,7 +203,7 @@ fn invoke_cross_contract_indirect_err() -> Result<(), HostError> {
     let res = host.call(id0_obj, sym.into(), args.clone().into());
     assert!(HostError::result_matches_err_status(res, code));
 
-    let events = host.get_events()?;
+    let events = host.get_events()?.0;
     assert_eq!(events.0.len(), 18);
     let last_event = events.0.last();
     match last_event {

--- a/soroban-env-host/src/test/invocation.rs
+++ b/soroban-env-host/src/test/invocation.rs
@@ -35,9 +35,12 @@ fn invoke_single_contract_function() -> Result<(), HostError> {
     Ok(())
 }
 
-#[test]
-fn invoke_cross_contract() -> Result<(), HostError> {
+fn invoke_cross_contract(diagnostics: bool) -> Result<(), HostError> {
     let host = Host::test_host_with_recording_footprint();
+    if diagnostics {
+        host.set_diagnostic_level(crate::DiagnosticLevel::Debug);
+    }
+
     let id_obj = host.register_test_contract_wasm(ADD_I32)?;
     // prepare arguments
     let sym = Symbol::from_str("add");
@@ -48,6 +51,16 @@ fn invoke_cross_contract() -> Result<(), HostError> {
     let i: i32 = res.try_into()?;
     assert_eq!(i, 3);
     Ok(())
+}
+
+#[test]
+fn invoke_cross_contract_without_diagnostics() -> Result<(), HostError> {
+    invoke_cross_contract(false)
+}
+
+#[test]
+fn invoke_cross_contract_with_diagnostics() -> Result<(), HostError> {
+    invoke_cross_contract(true)
 }
 
 #[test]

--- a/soroban-env-host/src/vm.rs
+++ b/soroban-env-host/src/vm.rs
@@ -236,6 +236,10 @@ impl Vm {
         host.with_frame(
             Frame::ContractVM(self.clone(), Symbol::from_str(func), args.to_vec()),
             || {
+                if host.is_debug() {
+                    host.fn_call_diagnostics(&self.contract_id, &Symbol::from_str(func), args)?;
+                }
+
                 let wasm_args: Vec<Value> = args
                     .iter()
                     .map(|i| Value::I64(i.get_payload() as i64))

--- a/soroban-env-host/tests/integration.rs
+++ b/soroban-env-host/tests/integration.rs
@@ -50,7 +50,7 @@ fn debug_fmt() {
 
     // Fish out the last debug event and check that it is
     // correct, and formats as expected.
-    let events = host.get_events().unwrap();
+    let events = host.get_events().unwrap().0;
     match events.0.last() {
         Some(HostEvent::Debug(de)) => {
             assert_eq!(


### PR DESCRIPTION
Related to https://github.com/stellar/rs-soroban-env/issues/587.

### Diagnostic events

Add diagnostic `ContractEvents` that are not metered. I used `ContractEvents` because they are structured, allowing downstream consumers to parse a format they should already be familiar with if they consume regular events. These are not the same as the existing `DebugEvents`, which are non structured messages returned by the host. These diagnostic events are also returned by the host, but should be included in a non hashed portion of tx meta.

There are currently no explicit limits on the number of diagnostics events because they are only created for contract calls and return values, not directly by users. I suspect the amount of data created per contract call (2 events) is not enough to DOS the host without getting killed by other metering limits (@jayz22 let me know if this is incorrect). This may change as we iterate, so consider adding a first N or last N buffer for diagnostic events in the future (cc. @MonsieurNicolas).

### Debug events
I considered turning the existing debug events into structured diagnostic events, but held off on this because debug events are metered, can be called by users in a contract, and are just output as strings.


