### PR TITLE
Change `Storage`, `Footprint`, `Snapshot` to return `dyn Error`

### DIFF
--- a/soroban-env-host/src/host/error.rs
+++ b/soroban-env-host/src/host/error.rs
@@ -151,6 +151,9 @@ impl<T> MapHostError<T> for Result<T, Box<dyn Error>> {
         self.map_err(|e| match e.downcast_ref::<HostError>() {
             Some(e) => e.clone(),
             None => {
+                // For now, the error is converted to a `Bytes` object so that it can be recorded
+                // as a `DebugEvent`. Once we have better alternatives for host string object type,
+                // we can use that instead.
                 let buf: Vec<u8> = Vec::from(e.to_string());
                 match host.add_host_object(buf) {
                     Ok(obj) => host.err_status_msg_with_args(

--- a/soroban-env-host/src/lib.rs
+++ b/soroban-env-host/src/lib.rs
@@ -49,5 +49,6 @@ pub mod cost_runner;
 pub use host::ContractFunctionSet;
 pub use host::{
     metered_map::MeteredOrdMap, metered_vector::MeteredVector, Host, HostError, LedgerInfo,
+    MapHostError,
 };
 pub use soroban_env_common::*;

--- a/soroban-env-host/src/native_contract/token/balance.rs
+++ b/soroban-env-host/src/native_contract/token/balance.rs
@@ -1,5 +1,5 @@
 use crate::budget::AsBudget;
-use crate::host::Host;
+use crate::host::{Host, MapHostError};
 use crate::native_contract::token::metadata::read_metadata;
 use crate::native_contract::token::public_types::{Identifier, Metadata};
 use crate::native_contract::token::storage_types::DataKey;
@@ -315,7 +315,7 @@ fn transfer_account_balance(e: &Host, account_id: AccountId, amount: i64) -> Res
         };
         if new_balance >= min_balance && new_balance <= max_balance {
             ae.balance = new_balance;
-            storage.put(&lk, &le, e.as_budget())
+            storage.put(&lk, &le, e.as_budget()).map_host_error(e)
         } else {
             Err(err!(
                 e,
@@ -358,7 +358,7 @@ fn transfer_trustline_balance(
         };
         if new_balance >= min_balance && new_balance <= max_balance {
             tl.balance = new_balance;
-            storage.put(&lk, &le, e.as_budget())
+            storage.put(&lk, &le, e.as_budget()).map_host_error(e)
         } else {
             Err(err!(
                 e,
@@ -600,7 +600,7 @@ fn set_trustline_authorization(
             tl.flags &= !(TrustLineFlags::AuthorizedFlag as u32);
             tl.flags |= TrustLineFlags::AuthorizedToMaintainLiabilitiesFlag as u32;
         }
-        storage.put(&lk, &le, e.as_budget())
+        storage.put(&lk, &le, e.as_budget()).map_host_error(e)
     })
 }
 

--- a/soroban-env-host/src/test/account.rs
+++ b/soroban-env-host/src/test/account.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use std::{error::Error, rc::Rc};
 
 use soroban_env_common::Env;
 
@@ -10,7 +10,7 @@ use crate::{
 };
 
 #[test]
-fn check_account_exists() -> Result<(), HostError> {
+fn check_account_exists() -> Result<(), Box<dyn Error>> {
     let acc_id0 = xdr::AccountId(xdr::PublicKey::PublicKeyTypeEd25519(xdr::Uint256([0; 32])));
     let acc_id1 = xdr::AccountId(xdr::PublicKey::PublicKeyTypeEd25519(xdr::Uint256([1; 32]))); // declared, but not in storage
     let acc_id2 = xdr::AccountId(xdr::PublicKey::PublicKeyTypeEd25519(xdr::Uint256([2; 32]))); // not declared

--- a/soroban-env-host/src/test/complex.rs
+++ b/soroban-env-host/src/test/complex.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use std::{error::Error, rc::Rc};
 
 use crate::{
     budget::Budget,
@@ -11,11 +11,11 @@ use soroban_test_wasms::COMPLEX;
 
 struct EmptySnap;
 impl SnapshotSource for EmptySnap {
-    fn get(&self, _key: &LedgerKey) -> Result<LedgerEntry, HostError> {
-        Err(ScHostStorageErrorCode::AccessToUnknownEntry.into())
+    fn get(&self, _key: &LedgerKey) -> Result<LedgerEntry, Box<dyn Error>> {
+        Err(HostError::from(ScHostStorageErrorCode::AccessToUnknownEntry).into())
     }
 
-    fn has(&self, _key: &LedgerKey) -> Result<bool, HostError> {
+    fn has(&self, _key: &LedgerKey) -> Result<bool, Box<dyn Error>> {
         Ok(false)
     }
 }


### PR DESCRIPTION
### What

Change `Storage`, `Footprint`, `Snapshot` to return `dyn Error`.
Add example of how to retrieve custom error. 
Add a new trait to convert from `dyn Error` -> `HostError`;

### Why

The `Storage` and `Footprint` depends on external `Snapshot` which may need to define its own errors (for example https://github.com/stellar/soroban-tools/pull/269/files#diff-a218fbb339f2a7838711dbd1e77eecb588242d37b1bad5f44df33cf5d11028a4R39-R58).  

This PR changes those types to work with generic errors and adds the functionality to convert them into a HostError (by logging the error string as a `DebugEvent`). 

cc @2opremio @leighmcculloch 

### Known limitations

[TODO or N/A]
