### PR TITLE
Allow for a custom budget outside tests

### DIFF
--- a/soroban-env-host/src/budget.rs
+++ b/soroban-env-host/src/budget.rs
@@ -416,7 +416,6 @@ impl Budget {
         }
     }
 
-    #[cfg(test)]
     pub fn reset_limits(&self, cpu: u64, mem: u64) {
         self.mut_budget(|mut b| {
             b.cpu_insns.reset(cpu);


### PR DESCRIPTION
### What

This PR removes the `#[cfg(test)]` guard before the `reset_limits` function for the budget implementation.

This PR will close #666 

### Why

This change allows the definition of a custom budget outside of the already given "unlimited" and "standard" variants.

### Known limitations

In the current state this change should not have any downsides. On the long run this will most likely need to change when coming to a consent about production level budgeting.
