### PR TITLE
Include token name in all token events

### DIFF
--- a/soroban-env-host/src/native_contract/token/contract.rs
+++ b/soroban-env-host/src/native_contract/token/contract.rs
@@ -185,7 +185,7 @@ impl TokenTrait for Token {
             .checked_add(amount)
             .ok_or_else(|| e.err_status(ContractError::OverflowError))?;
         write_allowance(&e, from.clone(), spender.clone(), new_allowance)?;
-        event::incr_allow(e, from, spender, amount)?;
+        event::incr_allow(e, from, spender, amount, read_name(&e)?)?;
         Ok(())
     }
 
@@ -203,7 +203,7 @@ impl TokenTrait for Token {
         } else {
             write_allowance(&e, from.clone(), spender.clone(), allowance - amount)?;
         }
-        event::decr_allow(e, from, spender, amount)?;
+        event::decr_allow(e, from, spender, amount, read_name(&e)?)?;
         Ok(())
     }
 
@@ -227,7 +227,7 @@ impl TokenTrait for Token {
         from.require_auth()?;
         spend_balance(e, from.clone(), amount)?;
         receive_balance(e, to.clone(), amount)?;
-        event::transfer(e, from, to, amount)?;
+        event::transfer(e, from, to, amount, read_name(&e)?)?;
         Ok(())
     }
 
@@ -244,7 +244,7 @@ impl TokenTrait for Token {
         spend_allowance(e, from.clone(), spender, amount)?;
         spend_balance(e, from.clone(), amount)?;
         receive_balance(e, to.clone(), amount)?;
-        event::transfer(e, from, to, amount)?;
+        event::transfer(e, from, to, amount, read_name(&e)?)?;
         Ok(())
     }
 
@@ -254,7 +254,7 @@ impl TokenTrait for Token {
         check_non_native(e)?;
         from.require_auth()?;
         spend_balance(&e, from.clone(), amount)?;
-        event::burn(e, from, amount)?;
+        event::burn(e, from, amount, read_name(&e)?)?;
         Ok(())
     }
 
@@ -265,7 +265,7 @@ impl TokenTrait for Token {
         spender.require_auth()?;
         spend_allowance(&e, from.clone(), spender, amount)?;
         spend_balance(&e, from.clone(), amount)?;
-        event::burn(e, from, amount)?;
+        event::burn(e, from, amount, read_name(&e)?)?;
         Ok(())
     }
 
@@ -276,7 +276,7 @@ impl TokenTrait for Token {
         check_clawbackable(&e, from.clone())?;
         admin.require_auth()?;
         spend_balance_no_authorization_check(e, from.clone(), amount.clone())?;
-        event::clawback(e, admin, from, amount)?;
+        event::clawback(e, admin, from, amount, read_name(&e)?)?;
         Ok(())
     }
 
@@ -285,7 +285,7 @@ impl TokenTrait for Token {
         check_admin(e, &admin)?;
         admin.require_auth()?;
         write_authorization(e, addr.clone(), authorize)?;
-        event::set_auth(e, admin, addr, authorize)?;
+        event::set_auth(e, admin, addr, authorize, read_name(&e)?)?;
         Ok(())
     }
 
@@ -295,7 +295,7 @@ impl TokenTrait for Token {
         check_admin(e, &admin)?;
         admin.require_auth()?;
         receive_balance(e, to.clone(), amount)?;
-        event::mint(e, admin, to, amount)?;
+        event::mint(e, admin, to, amount, read_name(&e)?)?;
         Ok(())
     }
 
@@ -304,7 +304,7 @@ impl TokenTrait for Token {
         check_admin(e, &admin)?;
         admin.require_auth()?;
         write_administrator(e, new_admin.clone())?;
-        event::set_admin(e, admin, new_admin)?;
+        event::set_admin(e, admin, new_admin, read_name(&e)?)?;
         Ok(())
     }
 

--- a/soroban-env-host/src/native_contract/token/event.rs
+++ b/soroban-env-host/src/native_contract/token/event.rs
@@ -1,19 +1,23 @@
-use crate::native_contract::base_types::Vec;
+use crate::native_contract::base_types::{Bytes, Vec};
 use crate::HostError;
 use crate::{host::Host, native_contract::base_types::Address};
-use soroban_env_common::{Env, Symbol, TryIntoVal};
+use soroban_env_common::{Env, Symbol};
 
 pub(crate) fn incr_allow(
     e: &Host,
     from: Address,
     to: Address,
     amount: i128,
+    name: Bytes,
 ) -> Result<(), HostError> {
     let mut topics = Vec::new(e)?;
     topics.push(&Symbol::from_str("incr_allow"))?;
     topics.push(&from)?;
     topics.push(&to)?;
-    e.contract_event(topics.into(), amount.try_into_val(e)?)?;
+    let mut data = Vec::new(e)?;
+    data.push(&amount)?;
+    data.push(&name)?;
+    e.contract_event(topics.into(), data.into())?;
     Ok(())
 }
 
@@ -22,12 +26,16 @@ pub(crate) fn decr_allow(
     from: Address,
     to: Address,
     amount: i128,
+    name: Bytes,
 ) -> Result<(), HostError> {
     let mut topics = Vec::new(e)?;
     topics.push(&Symbol::from_str("decr_allow"))?;
     topics.push(&from)?;
     topics.push(&to)?;
-    e.contract_event(topics.into(), amount.try_into_val(e)?)?;
+    let mut data = Vec::new(e)?;
+    data.push(&amount)?;
+    data.push(&name)?;
+    e.contract_event(topics.into(), data.into())?;
     Ok(())
 }
 
@@ -36,21 +44,34 @@ pub(crate) fn transfer(
     from: Address,
     to: Address,
     amount: i128,
+    name: Bytes,
 ) -> Result<(), HostError> {
     let mut topics = Vec::new(e)?;
     topics.push(&Symbol::from_str("transfer"))?;
     topics.push(&from)?;
     topics.push(&to)?;
-    e.contract_event(topics.into(), amount.try_into_val(e)?)?;
+    let mut data = Vec::new(e)?;
+    data.push(&amount)?;
+    data.push(&name)?;
+    e.contract_event(topics.into(), data.into())?;
     Ok(())
 }
 
-pub(crate) fn mint(e: &Host, admin: Address, to: Address, amount: i128) -> Result<(), HostError> {
+pub(crate) fn mint(
+    e: &Host,
+    admin: Address,
+    to: Address,
+    amount: i128,
+    name: Bytes,
+) -> Result<(), HostError> {
     let mut topics = Vec::new(e)?;
     topics.push(&Symbol::from_str("mint"))?;
     topics.push(&admin)?;
     topics.push(&to)?;
-    e.contract_event(topics.into(), amount.try_into_val(e)?)?;
+    let mut data = Vec::new(e)?;
+    data.push(&amount)?;
+    data.push(&name)?;
+    e.contract_event(topics.into(), data.into())?;
     Ok(())
 }
 
@@ -59,12 +80,16 @@ pub(crate) fn clawback(
     admin: Address,
     from: Address,
     amount: i128,
+    name: Bytes,
 ) -> Result<(), HostError> {
     let mut topics = Vec::new(e)?;
     topics.push(&Symbol::from_str("clawback"))?;
     topics.push(&admin)?;
     topics.push(&from)?;
-    e.contract_event(topics.into(), amount.try_into_val(e)?)?;
+    let mut data = Vec::new(e)?;
+    data.push(&amount)?;
+    data.push(&name)?;
+    e.contract_event(topics.into(), data.into())?;
     Ok(())
 }
 
@@ -73,27 +98,42 @@ pub(crate) fn set_auth(
     admin: Address,
     id: Address,
     authorize: bool,
+    name: Bytes,
 ) -> Result<(), HostError> {
     let mut topics = Vec::new(e)?;
     topics.push(&Symbol::from_str("set_auth"))?;
     topics.push(&admin)?;
     topics.push(&id)?;
-    e.contract_event(topics.into(), authorize.try_into_val(e)?)?;
+    let mut data = Vec::new(e)?;
+    data.push(&authorize)?;
+    data.push(&name)?;
+    e.contract_event(topics.into(), data.into())?;
     Ok(())
 }
 
-pub(crate) fn set_admin(e: &Host, admin: Address, new_admin: Address) -> Result<(), HostError> {
+pub(crate) fn set_admin(
+    e: &Host,
+    admin: Address,
+    new_admin: Address,
+    name: Bytes,
+) -> Result<(), HostError> {
     let mut topics = Vec::new(e)?;
     topics.push(&Symbol::from_str("set_admin"))?;
     topics.push(&admin)?;
-    e.contract_event(topics.into(), new_admin.try_into_val(e)?)?;
+    let mut data = Vec::new(e)?;
+    data.push(&new_admin)?;
+    data.push(&name)?;
+    e.contract_event(topics.into(), data.into())?;
     Ok(())
 }
 
-pub(crate) fn burn(e: &Host, from: Address, amount: i128) -> Result<(), HostError> {
+pub(crate) fn burn(e: &Host, from: Address, amount: i128, name: Bytes) -> Result<(), HostError> {
     let mut topics = Vec::new(e)?;
     topics.push(&Symbol::from_str("burn"))?;
     topics.push(&from)?;
-    e.contract_event(topics.into(), amount.try_into_val(e)?)?;
+    let mut data = Vec::new(e)?;
+    data.push(&amount)?;
+    data.push(&name)?;
+    e.contract_event(topics.into(), data.into())?;
     Ok(())
 }


### PR DESCRIPTION
### What

Include the token name in the data scval for all events emitted by the native asset contract

### Why

In https://github.com/stellar/go/issues/4722#issuecomment-1363317232 I had a discussion with @sisuresh about how it would be useful for horizon ingestion to be able to identify if a contract id corresponds the stellar asset contract. We need this information so that we can identify transfers of Stellar assets that were initiated via a smart contract invocation as opposed to a stellar classic payment operation.

@sisuresh was understandably reluctant to add an extra flag in the xdr definitions so that we could identify that a contract id corresponds to a stellar asset. So after some brainstorming we determined that if the events emitted by a stellar asset contract included the asset issuer and symbol we would be able to determine whether the event originated from a stellar asset contract because we can hash the asset symbol and issuer from the contract event and check that the hash matches the contract's id.  

### Known limitations

[N/A]
