### PR TITLE
Reform metering for value cloning and memory allocation

### DIFF
--- a/soroban-env-host/src/budget.rs
+++ b/soroban-env-host/src/budget.rs
@@ -95,6 +95,8 @@ pub enum CostType {
     // here for exploring calibration, not a long-term cost we surface
     // separately from signature verification.
     EdwardsPointCurve25519ScalarMul = 35,
+    HostMemAlloc = 36,
+    HostMemCpy = 37,
 }
 
 // TODO: add XDR support for iterating over all the elements of an enum
@@ -137,6 +139,8 @@ impl CostType {
             CostType::BytesCmp,
             CostType::ChargeBudget,
             CostType::EdwardsPointCurve25519ScalarMul,
+            CostType::HostMemAlloc,
+            CostType::HostMemCpy,
         ];
         VARIANTS.iter()
     }
@@ -497,6 +501,7 @@ impl Default for BudgetImpl {
                 CostType::BytesCmp => cpu.lin_param = 1,
                 CostType::ChargeBudget => cpu.const_param = 50,
                 CostType::EdwardsPointCurve25519ScalarMul => cpu.const_param = 10,
+                CostType::HostMemAlloc | CostType::HostMemCpy => cpu.lin_param = 1,
             }
 
             let mem = b.mem_bytes.get_cost_model_mut(*ct);
@@ -532,6 +537,7 @@ impl Default for BudgetImpl {
                 CostType::BytesCmp => (),
                 CostType::ChargeBudget => (),
                 CostType::EdwardsPointCurve25519ScalarMul => mem.const_param = 1,
+                CostType::HostMemAlloc | CostType::HostMemCpy => mem.lin_param = 1,
             }
         }
 

--- a/soroban-env-host/src/events/internal.rs
+++ b/soroban-env-host/src/events/internal.rs
@@ -1,7 +1,6 @@
 use super::{DebugEvent, Events, HostEvent};
 use crate::{
     budget::{AsBudget, Budget},
-    host::metered_clone::MeteredClone,
     xdr,
     xdr::ScObject,
     Host, HostError, MeteredVector, Object, RawVal,
@@ -48,8 +47,6 @@ pub(crate) enum InternalEvent {
     #[default]
     None,
 }
-
-impl MeteredClone for InternalEvent {}
 
 /// The events buffer. Stores `InternalEvent`s in the chronological order.
 #[derive(Clone, Default)]

--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -2292,7 +2292,7 @@ impl VmCallerEnv for Host {
                 #[cfg(any(test, feature = "testutils"))]
                 Frame::TestContract(tc) => get_host_val_tuple(&tc.id, &tc.func)?,
             };
-            let inner = MeteredVector::from_array(vals, self.as_budget())?;
+            let inner = MeteredVector::from_array(&vals, self.as_budget())?;
             outer.push(self.add_host_object(inner)?.into());
         }
         Ok(self.add_host_object(HostVec::from_vec(outer)?)?.into())

--- a/soroban-env-host/src/host/metered_clone.rs
+++ b/soroban-env-host/src/host/metered_clone.rs
@@ -1,31 +1,45 @@
-use std::rc::Rc;
+use std::{mem, rc::Rc};
 
 use soroban_env_common::{
-    xdr::{BytesM, LedgerEntry, LedgerKey, ScAddress, ScMap, ScObject, ScVal},
+    xdr::{
+        BytesM, ContractEvent, ContractEventBody, LedgerEntry, LedgerKey, ScAddress, ScMap,
+        ScMapEntry, ScObject, ScVal,
+    },
     RawVal,
 };
 
 use crate::{
     budget::{Budget, CostType},
+    events::{DebugArg, DebugEvent, HostEvent, InternalContractEvent, InternalEvent},
     host::Events,
     storage::AccessType,
     xdr::{AccountId, Hash, ScContractCode, ScVec, Uint256},
     HostError,
 };
 
-// Charge for an N-element "shallow copy" of some type, not cloning any
-// substructure. In a better world we would multiply this by size_of<Self> but
-// that's not guaranteed to be stable. Also this has a fairly serious level of
-// inaccuracy since we call the same charge for any shallow type, whether it's a
-// simple byte-copy or a sequence of Rc<>.clone calls (each of which bumps a
-// refcount -- shallow but not as cheap as memcpy).
-//
-// TODO: this is correct for CPU-cost but not memory-cost, since there's no heap
-// allocation implied by a shallow clone. We should (maybe) split BytesClone
-// into ByteCopy (the CPU byte-copying part) and HeapAlloc (the heap-allocating
-// part). See https://github.com/stellar/rs-soroban-env/issues/604.
-fn charge_shallow_copy(n_elts: usize, budget: &Budget) -> Result<(), HostError> {
-    budget.charge(CostType::BytesClone, n_elts as u64)
+extern crate static_assertions as sa;
+
+// Charge for an N-element "shallow copy" of some type, not cloning any substructure. The charge
+// unit is number of elements `n_elts` multiply by size of each element. In a better world we would
+// multiply by size_of<Self> instead but that's not guaranteed to be stable, which might cause
+// metering to differ across compilations, causing serious problems in concensus and replay.
+fn charge_shallow_copy<T: MeteredClone>(n_elts: u64, budget: &Budget) -> Result<(), HostError> {
+    // Ideally we would want a static assertion. However, it does not work due to rust restrictions
+    // (e.g. see https://github.com/rust-lang/rust/issues/57775). Here we make a runtime assertion
+    // that the type's size is below its promised element size for budget charging. This assertion
+    // only happens in debug build. In optimized build, not satisfying the asserted condition just
+    // means an underestimation of the cost.
+    debug_assert!(mem::size_of::<T>() as u64 <= T::ELT_SIZE);
+    budget.charge(CostType::HostMemCpy, n_elts * T::ELT_SIZE)
+}
+
+// Let it be a free function instead of a trait because charge heap alloc maybe called elsewhere,
+// not just metered clone, e.g. Box::<T>::new().
+fn charge_heap_alloc<T: MeteredClone>(n_elts: u64, budget: &Budget) -> Result<(), HostError> {
+    // Here we make a runtime assertion that the type's size is below its promised element size for
+    // budget charging.
+    debug_assert!(mem::size_of::<T>() as u64 <= T::ELT_SIZE);
+    budget.charge(CostType::HostMemAlloc, n_elts * T::ELT_SIZE)
 }
 
 pub trait MeteredClone: Clone {
@@ -35,6 +49,12 @@ pub trait MeteredClone: Clone {
     // `charge_for_clone` (correctly charging for cloning the substructure).
     const IS_SHALLOW: bool = true;
 
+    // Size (num of bytes) of a single element. This value determines the input for budget charging.
+    // It should be the upperbound (across various compilations and platforms) of the actual type's
+    // size. Implementer of the trait needs to decide this value based on Rust's guideline on type
+    // layout: https://doc.rust-lang.org/reference/type-layout.html
+    const ELT_SIZE: u64;
+
     // Called to clone a single element of type Self, a default implementation
     // that charges for a 1-unit memcpy and is _only_ appropriate when Self is
     // a shallow type (with no substructure). If you override Self::IS_SHALLOW
@@ -42,7 +62,7 @@ pub trait MeteredClone: Clone {
     // panic if you don't).
     fn charge_for_clone(&self, budget: &Budget) -> Result<(), HostError> {
         assert!(Self::IS_SHALLOW);
-        charge_shallow_copy(1, budget)
+        charge_shallow_copy::<Self>(1, budget)
     }
 
     // Called when cloning a slice of elements of type Self. Can be more
@@ -55,7 +75,7 @@ pub trait MeteredClone: Clone {
     fn charge_for_clones(clones: &[Self], budget: &Budget) -> Result<(), HostError> {
         if Self::IS_SHALLOW {
             // If we're shallow, we're allowed to batch our charges.
-            charge_shallow_copy(clones.len(), budget)
+            charge_shallow_copy::<Self>(clones.len() as u64, budget)
         } else {
             for elt in clones {
                 elt.charge_for_clone(budget)?;
@@ -63,36 +83,80 @@ pub trait MeteredClone: Clone {
             Ok(())
         }
     }
-    // Composite helper that just does a charge_for_clone followed by a clone. Some types
-    // might choose to do these two steps separately (eg. if they have a separate nontrivial and non-metered clone).
+
+    // Composite helper that just does a charge_for_clone followed by a clone.
+    // This should not need to be overriden since any non-trivial clone metering should be taken
+    // care of by `charge_for_clones` and this function just need to call the regular `clone()`.
     fn metered_clone(&self, budget: &Budget) -> Result<Self, HostError> {
         self.charge_for_clone(budget)?;
         Ok(self.clone())
     }
 }
 
-impl<T> MeteredClone for Rc<T> {}
-impl MeteredClone for Hash {}
-impl MeteredClone for RawVal {}
-impl MeteredClone for AccessType {}
-impl MeteredClone for AccountId {}
-impl MeteredClone for ScContractCode {}
-impl MeteredClone for Uint256 {}
-impl MeteredClone for ScAddress {}
-impl<const N: usize> MeteredClone for [u8; N] {}
+macro_rules! impl_metered_clone_for_shallow_types {
+    ($name:ident, $size:literal) => {
+        impl MeteredClone for $name {
+            const ELT_SIZE: u64 = $size;
+        }
+    };
+}
+
+// These are results from running mem::size_of::<T>()
+// TODO: we need some kind of automatic tests to validate those numbers
+// and automatically update them
+impl_metered_clone_for_shallow_types!(u8, 1);
+impl_metered_clone_for_shallow_types!(u32, 4);
+impl_metered_clone_for_shallow_types!(i32, 4);
+impl_metered_clone_for_shallow_types!(u64, 8);
+impl_metered_clone_for_shallow_types!(i64, 8);
+impl_metered_clone_for_shallow_types!(Hash, 32);
+impl_metered_clone_for_shallow_types!(RawVal, 8);
+impl_metered_clone_for_shallow_types!(AccessType, 1);
+impl_metered_clone_for_shallow_types!(AccountId, 32);
+impl_metered_clone_for_shallow_types!(ScContractCode, 33);
+impl_metered_clone_for_shallow_types!(Uint256, 32);
+impl_metered_clone_for_shallow_types!(ScAddress, 33);
+impl_metered_clone_for_shallow_types!(DebugArg, 16);
+impl_metered_clone_for_shallow_types!(InternalContractEvent, 40);
+
+// Rc is an exception, nothing is being cloned. We approximate ref counter bump with the cost of
+// cloning 16 bytes. Also it can't be below 16 since that's the size of an `Rc` structure.
+impl<T> MeteredClone for Rc<T> {
+    const ELT_SIZE: u64 = 16;
+}
+
+impl<const N: usize> MeteredClone for [u8; N] {
+    const ELT_SIZE: u64 = N as u64;
+}
+
+impl<K, V> MeteredClone for (K, V)
+where
+    K: MeteredClone,
+    V: MeteredClone,
+{
+    const ELT_SIZE: u64 = <K as MeteredClone>::ELT_SIZE + <V as MeteredClone>::ELT_SIZE;
+}
 
 // TODO: this isn't correct: these two have substructure to account for;
 // probably they should never be cloned in the middle of a contract at all (the
 // storage maps are Rc<> now) but changing that means changing the storage
 // interface. See https://github.com/stellar/rs-soroban-env/issues/603
-impl MeteredClone for LedgerKey {}
-impl MeteredClone for LedgerEntry {}
+impl MeteredClone for LedgerKey {
+    const ELT_SIZE: u64 = 80;
+}
+impl MeteredClone for LedgerEntry {
+    const ELT_SIZE: u64 = 264;
+}
 
 impl MeteredClone for ScVal {
     const IS_SHALLOW: bool = false;
 
+    const ELT_SIZE: u64 = 40;
+
     fn charge_for_clone(&self, budget: &Budget) -> Result<(), HostError> {
-        charge_shallow_copy(1, budget)?;
+        // first handle the shallow clone
+        charge_shallow_copy::<ScVal>(1, budget)?;
+        // then handle any substructures
         match self {
             ScVal::Object(Some(obj)) => {
                 match obj {
@@ -121,82 +185,256 @@ impl MeteredClone for ScVal {
     }
 }
 
+impl MeteredClone for ScMapEntry {
+    const IS_SHALLOW: bool = false;
+
+    const ELT_SIZE: u64 = 80;
+
+    fn charge_for_clone(&self, budget: &Budget) -> Result<(), HostError> {
+        self.key.charge_for_clone(budget)?;
+        self.val.charge_for_clone(budget)
+    }
+}
+
 impl MeteredClone for ScVec {
     const IS_SHALLOW: bool = false;
+
+    const ELT_SIZE: u64 = 24;
+
     fn charge_for_clone(&self, budget: &Budget) -> Result<(), HostError> {
-        for elt in self.0.iter() {
-            elt.charge_for_clone(budget)?
-        }
-        Ok(())
+        self.0.charge_for_clone(budget) // self.0 will be deref'ed into Vec
     }
 }
 
 impl MeteredClone for ScMap {
     const IS_SHALLOW: bool = false;
+
+    const ELT_SIZE: u64 = 24;
+
     fn charge_for_clone(&self, budget: &Budget) -> Result<(), HostError> {
-        for elt in self.0.iter() {
-            elt.key.charge_for_clone(budget)?;
-            elt.val.charge_for_clone(budget)?;
-        }
-        Ok(())
+        self.0.charge_for_clone(budget) // self.0 will be deref'ed into Vec
     }
 }
 
 impl<const C: u32> MeteredClone for BytesM<C> {
     const IS_SHALLOW: bool = false;
 
-    fn charge_for_clone(&self, budget: &Budget) -> Result<(), HostError> {
-        charge_shallow_copy(1, budget)?;
-        budget.charge(CostType::BytesClone, self.len() as u64)
-    }
-}
-
-impl MeteredClone for Vec<u8> {
-    const IS_SHALLOW: bool = false;
+    const ELT_SIZE: u64 = 24;
 
     fn charge_for_clone(&self, budget: &Budget) -> Result<(), HostError> {
-        charge_shallow_copy(1, budget)?;
-        budget.charge(CostType::BytesClone, self.len() as u64)
+        <Self as AsRef<Vec<u8>>>::as_ref(self).charge_for_clone(budget)
     }
 }
 
 impl<C: MeteredClone> MeteredClone for Vec<C> {
     const IS_SHALLOW: bool = false;
-    fn metered_clone(&self, budget: &Budget) -> Result<Self, HostError> {
-        if C::IS_SHALLOW {
-            // Shallow types we can batch-up our charging for.
-            budget.charge(CostType::BytesClone, self.len() as u64)?;
-            Ok(self.clone())
-        } else {
-            self.iter().map(|elt| elt.metered_clone(budget)).collect()
+
+    const ELT_SIZE: u64 = 24;
+
+    fn charge_for_clone(&self, budget: &Budget) -> Result<(), HostError> {
+        // first take care of Vec clone, which involves allocating memory, (shallowly) memcpy the
+        // underlying data into it, and copying the vec data structure.
+        charge_shallow_copy::<Vec<C>>(1, budget)?;
+        charge_heap_alloc::<C>(self.len() as u64, budget)?;
+        charge_shallow_copy::<C>(self.len() as u64, budget)?;
+        // then take care of any substructure clone (recursively)
+        for elt in self {
+            elt.charge_for_clone(budget)?;
         }
+        Ok(())
     }
 }
 
 impl<C: MeteredClone> MeteredClone for Box<C> {
     const IS_SHALLOW: bool = false;
 
-    fn metered_clone(&self, budget: &Budget) -> Result<Self, HostError> {
+    const ELT_SIZE: u64 = 8;
+
+    fn charge_for_clone(&self, budget: &Budget) -> Result<(), HostError> {
+        // first take care of the Box part
+        charge_shallow_copy::<Box<C>>(1, budget)?;
+        charge_heap_alloc::<C>(1, budget)?;
+        charge_shallow_copy::<C>(1, budget)?;
+        // then take care of any substructure clone (recursively)
         let inner: &C = &**self;
-        Ok(Box::new(inner.metered_clone(budget)?))
+        inner.charge_for_clone(budget)
     }
 }
 
 impl<C: MeteredClone> MeteredClone for Option<C> {
     const IS_SHALLOW: bool = C::IS_SHALLOW;
 
-    fn metered_clone(&self, budget: &Budget) -> Result<Self, HostError> {
+    // Size of C plus an 8 byte alignment overhead. If we need to handle types with larger
+    // alignment size, we need to increase the overhead.
+    const ELT_SIZE: u64 = C::ELT_SIZE + 8;
+
+    fn charge_for_clone(&self, budget: &Budget) -> Result<(), HostError> {
+        // first take care of the Option part, which is just a shallow copy
+        charge_shallow_copy::<Self>(1, budget)?;
+        // then take care of any substructure clone (recursively)
         match self {
-            Some(elt) => Ok(Some(elt.metered_clone(budget)?)),
-            None => Ok(None),
+            Some(elt) => elt.charge_for_clone(budget),
+            None => Ok(()),
+        }
+    }
+}
+
+impl MeteredClone for DebugEvent {
+    const IS_SHALLOW: bool = false;
+
+    const ELT_SIZE: u64 = 80;
+
+    fn charge_for_clone(&self, budget: &Budget) -> Result<(), HostError> {
+        charge_shallow_copy::<Self>(1, budget)?;
+        if self.args.is_heap() {
+            // equivalent to charging for a `Vec` clone.
+            charge_shallow_copy::<Vec<DebugArg>>(1, budget)?;
+            charge_heap_alloc::<Vec<DebugArg>>(self.args.len() as u64, budget)?;
+            charge_shallow_copy::<Vec<DebugArg>>(self.args.len() as u64, budget)
+        } else {
+            // equivalent to charging for a slice clone.
+            DebugArg::charge_for_clones(self.args.as_slice(), budget)
+        }
+    }
+}
+
+impl MeteredClone for ContractEvent {
+    const IS_SHALLOW: bool = false;
+
+    const ELT_SIZE: u64 = 104;
+
+    fn charge_for_clone(&self, budget: &Budget) -> Result<(), HostError> {
+        charge_shallow_copy::<Self>(1, budget)?;
+        let ContractEventBody::V0(event) = &self.body;
+        event.topics.charge_for_clone(budget)?;
+        event.data.charge_for_clone(budget)
+    }
+}
+
+impl MeteredClone for HostEvent {
+    const IS_SHALLOW: bool = false;
+
+    const ELT_SIZE: u64 = 112;
+
+    fn charge_for_clone(&self, budget: &Budget) -> Result<(), HostError> {
+        match self {
+            HostEvent::Contract(c) => c.charge_for_clone(budget),
+            HostEvent::Debug(d) => d.charge_for_clone(budget),
         }
     }
 }
 
 impl MeteredClone for Events {
     const IS_SHALLOW: bool = false;
-    fn metered_clone(&self, budget: &Budget) -> Result<Self, HostError> {
-        budget.charge(CostType::CloneEvents, self.0.len() as u64)?;
-        Ok(self.clone())
+
+    const ELT_SIZE: u64 = 24;
+
+    fn charge_for_clone(&self, budget: &Budget) -> Result<(), HostError> {
+        self.0.charge_for_clone(budget)
+    }
+}
+
+impl MeteredClone for InternalEvent {
+    const IS_SHALLOW: bool = false;
+
+    const ELT_SIZE: u64 = 80;
+
+    fn charge_for_clone(&self, budget: &Budget) -> Result<(), HostError> {
+        charge_shallow_copy::<Self>(1, budget)?;
+        match self {
+            InternalEvent::Contract(c) => c.charge_for_clone(budget),
+            InternalEvent::Debug(d) => d.charge_for_clone(budget),
+            InternalEvent::None => Ok(()),
+        }
+    }
+}
+
+mod test {
+    #[allow(unused)]
+    use super::*;
+
+    #[test]
+    fn test_elt_size() {
+        use expect_test::expect;
+        // This section is for outputting the actual size of types. They are for informational use.
+        // They might become outdated due to Rust type changes. Run `UPDATE_EXPECT=true cargo test`
+        // to update this.
+        expect!["32"].assert_eq(std::mem::size_of::<Hash>().to_string().as_str());
+        expect!["8"].assert_eq(std::mem::size_of::<RawVal>().to_string().as_str());
+        expect!["1"].assert_eq(std::mem::size_of::<AccessType>().to_string().as_str());
+        expect!["32"].assert_eq(std::mem::size_of::<AccountId>().to_string().as_str());
+        expect!["33"].assert_eq(std::mem::size_of::<ScContractCode>().to_string().as_str());
+        expect!["32"].assert_eq(std::mem::size_of::<Uint256>().to_string().as_str());
+        expect!["33"].assert_eq(std::mem::size_of::<ScAddress>().to_string().as_str());
+        expect!["80"].assert_eq(std::mem::size_of::<LedgerKey>().to_string().as_str());
+        expect!["264"].assert_eq(std::mem::size_of::<LedgerEntry>().to_string().as_str());
+        expect!["40"].assert_eq(std::mem::size_of::<ScVal>().to_string().as_str());
+        expect!["24"].assert_eq(std::mem::size_of::<ScVec>().to_string().as_str());
+        expect!["80"].assert_eq(std::mem::size_of::<ScMapEntry>().to_string().as_str());
+        expect!["24"].assert_eq(std::mem::size_of::<ScMap>().to_string().as_str());
+        expect!["24"].assert_eq(std::mem::size_of::<Vec<u8>>().to_string().as_str());
+        expect!["24"].assert_eq(std::mem::size_of::<Vec<ScVal>>().to_string().as_str());
+        expect!["24"].assert_eq(std::mem::size_of::<BytesM<10000>>().to_string().as_str());
+        expect!["8"].assert_eq(std::mem::size_of::<Box<u8>>().to_string().as_str());
+        expect!["8"].assert_eq(std::mem::size_of::<Box<ScVal>>().to_string().as_str());
+        expect!["80"].assert_eq(std::mem::size_of::<DebugEvent>().to_string().as_str());
+        expect!["104"].assert_eq(std::mem::size_of::<ContractEvent>().to_string().as_str());
+        expect!["112"].assert_eq(std::mem::size_of::<HostEvent>().to_string().as_str());
+        expect!["24"].assert_eq(std::mem::size_of::<Events>().to_string().as_str());
+        expect!["80"].assert_eq(std::mem::size_of::<InternalEvent>().to_string().as_str());
+        expect!["40"].assert_eq(
+            std::mem::size_of::<InternalContractEvent>()
+                .to_string()
+                .as_str(),
+        );
+
+        // These are the actual tests. We use a tighter condition (==) than the actual code (<=).
+        // For any new `MeteredClone` type, a new test case needs to be added below.
+        macro_rules! assert_mem_size_equals_elt_size {
+            ($name:ident) => {
+                assert_eq!(
+                    std::mem::size_of::<$name>() as u64,
+                    <$name as MeteredClone>::ELT_SIZE
+                );
+            };
+        }
+        assert_mem_size_equals_elt_size!(Hash);
+        assert_mem_size_equals_elt_size!(RawVal);
+        assert_mem_size_equals_elt_size!(AccessType);
+        assert_mem_size_equals_elt_size!(AccountId);
+        assert_mem_size_equals_elt_size!(ScContractCode);
+        assert_mem_size_equals_elt_size!(Uint256);
+        assert_mem_size_equals_elt_size!(ScAddress);
+        assert_mem_size_equals_elt_size!(LedgerKey);
+        assert_mem_size_equals_elt_size!(LedgerEntry);
+        assert_mem_size_equals_elt_size!(ScVal);
+        assert_mem_size_equals_elt_size!(ScVec);
+        assert_mem_size_equals_elt_size!(ScMapEntry);
+        assert_mem_size_equals_elt_size!(ScMap);
+        assert_mem_size_equals_elt_size!(DebugEvent);
+        assert_mem_size_equals_elt_size!(ContractEvent);
+        assert_mem_size_equals_elt_size!(HostEvent);
+        assert_mem_size_equals_elt_size!(Events);
+        assert_mem_size_equals_elt_size!(InternalEvent);
+        assert_eq!(
+            std::mem::size_of::<Vec<u8>>() as u64,
+            <Vec<u8> as MeteredClone>::ELT_SIZE
+        );
+        assert_eq!(
+            std::mem::size_of::<Vec<ScVal>>() as u64,
+            <Vec<ScVal> as MeteredClone>::ELT_SIZE
+        );
+        assert_eq!(
+            std::mem::size_of::<BytesM<10000>>() as u64,
+            <BytesM<10000> as MeteredClone>::ELT_SIZE
+        );
+        assert_eq!(
+            std::mem::size_of::<Box<u8>>() as u64,
+            <Box<u8> as MeteredClone>::ELT_SIZE
+        );
+        assert_eq!(
+            std::mem::size_of::<Box<ScVal>>() as u64,
+            <Box<ScVal> as MeteredClone>::ELT_SIZE
+        );
     }
 }

--- a/soroban-env-host/src/host/metered_clone.rs
+++ b/soroban-env-host/src/host/metered_clone.rs
@@ -106,9 +106,6 @@ macro_rules! impl_metered_clone_for_shallow_types {
     };
 }
 
-// These are results from running mem::size_of::<T>()
-// TODO: we need some kind of automatic tests to validate those numbers
-// and automatically update them
 impl_metered_clone_for_shallow_types!(u8, 1);
 impl_metered_clone_for_shallow_types!(u32, 4);
 impl_metered_clone_for_shallow_types!(i32, 4);

--- a/soroban-env-host/src/host/metered_map.rs
+++ b/soroban-env-host/src/host/metered_map.rs
@@ -128,7 +128,7 @@ where
             // possible object. In exchange we get to batch all charges associated with
             // the clone into one (when A::IS_SHALLOW==true).
             let map: Vec<(K, V)> = iter.collect();
-            map.charge_for_clone(ctx.as_budget())?;
+            map.charge_deep_clone(ctx.as_budget())?;
             Ok(Self {
                 map,
                 ctx: Default::default(),
@@ -329,9 +329,8 @@ where
 {
     const ELT_SIZE: u64 = <Vec<(K, V)> as MeteredClone>::ELT_SIZE;
 
-    fn metered_clone(&self, budget: &Budget) -> Result<Self, HostError> {
-        self.map.charge_for_clone(budget)?;
-        Ok(self.clone())
+    fn charge_for_substructure(&self, budget: &Budget) -> Result<(), HostError> {
+        self.map.charge_for_substructure(budget)
     }
 }
 

--- a/soroban-env-host/src/host/metered_vector.rs
+++ b/soroban-env-host/src/host/metered_vector.rs
@@ -20,8 +20,9 @@ impl<A> MeteredVector<A>
 where
     A: MeteredClone,
 {
-    fn charge_new(size: usize, budget: &Budget) -> Result<(), HostError> {
-        budget.charge(CostType::VecNew, size as u64)
+    /// Covers the cost of allocating a new Vec<A> with size in number of elements.
+    fn charge_new(n_elts: u64, budget: &Budget) -> Result<(), HostError> {
+        budget.charge(CostType::VecNew, n_elts * A::ELT_SIZE)
     }
 
     fn charge_access(&self, count: usize, budget: &Budget) -> Result<(), HostError> {
@@ -47,8 +48,10 @@ where
         Self::from_vec(Vec::new())
     }
 
-    pub fn from_array<const N: usize>(buf: [A; N], budget: &Budget) -> Result<Self, HostError> {
-        Self::charge_new(N, budget)?;
+    pub fn from_array(buf: &[A], budget: &Budget) -> Result<Self, HostError> {
+        // we may temporarily go over budget here.
+        let vec: Vec<A> = buf.into();
+        vec.charge_for_clone(budget)?;
         Self::from_vec(buf.into())
     }
 
@@ -66,14 +69,13 @@ where
         budget: &Budget,
     ) -> Result<Self, HostError> {
         if let (_, Some(sz)) = iter.size_hint() {
-            Self::charge_new(sz, budget)?;
             // It's possible we temporarily go over-budget here before charging, but
             // only by the cost of temporarily allocating twice the size of our largest
             // possible object. In exchange we get to batch all charges associated with
             // the clone into one (when A::IS_SHALLOW==true).
             let vec: Vec<A> = iter.collect();
-            A::charge_for_clones(vec.as_slice(), budget)?;
-            Ok(Self { vec })
+            vec.charge_for_clone(budget)?;
+            Self::from_vec(vec)
         } else {
             // TODO use a better error code for "unbounded input iterators"
             Err(ScHostFnErrorCode::UnknownError.into())
@@ -267,15 +269,16 @@ where
     where
         F: FnMut(usize, &mut A) -> Result<bool, HostError>,
     {
-        Self::charge_new(self.len(), budget)?;
+        // The closure evaluation is not metered here, it is assumed to be taken care of outside.
+        // Here just covers the cost of cloning a Vec.
         let mut vec = Vec::with_capacity(self.len());
         for (i, v) in self.vec.iter_mut().enumerate() {
             if f(i, v)? {
                 vec.push(v.clone());
             }
         }
-        A::charge_for_clones(vec.as_slice(), budget)?;
-        Ok(Self { vec })
+        vec.charge_for_clone(budget)?;
+        Self::from_vec(vec)
     }
 
     pub fn iter(&self) -> std::slice::Iter<'_, A> {
@@ -291,8 +294,10 @@ impl<A> MeteredClone for MeteredVector<A>
 where
     A: MeteredClone,
 {
+    const ELT_SIZE: u64 = <Vec<A> as MeteredClone>::ELT_SIZE;
+
     fn charge_for_clone(&self, budget: &Budget) -> Result<(), HostError> {
-        Self::charge_new(self.len(), budget)
+        self.vec.charge_for_clone(budget)
     }
 }
 

--- a/soroban-env-host/src/host/metered_vector.rs
+++ b/soroban-env-host/src/host/metered_vector.rs
@@ -51,7 +51,7 @@ where
     pub fn from_array(buf: &[A], budget: &Budget) -> Result<Self, HostError> {
         // we may temporarily go over budget here.
         let vec: Vec<A> = buf.into();
-        vec.charge_for_clone(budget)?;
+        vec.charge_deep_clone(budget)?;
         Self::from_vec(buf.into())
     }
 
@@ -74,7 +74,7 @@ where
             // possible object. In exchange we get to batch all charges associated with
             // the clone into one (when A::IS_SHALLOW==true).
             let vec: Vec<A> = iter.collect();
-            vec.charge_for_clone(budget)?;
+            vec.charge_deep_clone(budget)?;
             Self::from_vec(vec)
         } else {
             // TODO use a better error code for "unbounded input iterators"
@@ -277,7 +277,7 @@ where
                 vec.push(v.clone());
             }
         }
-        vec.charge_for_clone(budget)?;
+        vec.charge_deep_clone(budget)?;
         Self::from_vec(vec)
     }
 
@@ -296,8 +296,8 @@ where
 {
     const ELT_SIZE: u64 = <Vec<A> as MeteredClone>::ELT_SIZE;
 
-    fn charge_for_clone(&self, budget: &Budget) -> Result<(), HostError> {
-        self.vec.charge_for_clone(budget)
+    fn charge_for_substructure(&self, budget: &Budget) -> Result<(), HostError> {
+        self.vec.charge_for_substructure(budget)
     }
 }
 

--- a/soroban-env-host/src/test/event.rs
+++ b/soroban-env-host/src/test/event.rs
@@ -96,7 +96,7 @@ fn test_event_rollback() -> Result<(), HostError> {
         RawVal::from_void().get_payload()
     );
     host.0.events.borrow_mut().rollback(1, &host)?;
-
+    // run `UPDATE_EXPECT=true cargo test` to update this.
     let expected = expect![[
         r#"Events([Contract(ContractEvent { ext: V0, contract_id: Some(Hash(0000000000000000000000000000000000000000000000000000000000000000)), type_: Contract, body: V0(ContractEventV0 { topics: ScVec(VecM([I32(0), I32(1)])), data: U32(0) }) }), Debug(DebugEvent { msg: Some("debug event 0"), args: [] }), Debug(DebugEvent { msg: Some("rolled-back contract event: type {}, id {}, topics {}, data {}"), args: [Val(I32(0)), Val(Object(Bytes(#4))), Val(Object(Vec(#2))), Val(U32(0))] }), Debug(DebugEvent { msg: Some("{} contract events rolled back. Rollback start pos = {}"), args: [Val(U32(1)), Val(U32(1))] })])"#
     ]];


### PR DESCRIPTION
### What

Resolves https://github.com/stellar/rs-soroban-env/issues/604 and https://github.com/stellar/rs-soroban-env/issues/680.

This PR reforms `metered_clone`.
- Splits memory allocation from shallow copying
- Define the "shallow size" of `MeteredClone` types. 

A `metered_clone` consist of shallow copying of the type's memory footprint (for a `Vec` it's 24), plus recursively (deep) cloning any of the substructures. 
A `HostMemAlloc` charge occurs only when memory is allocated. I.e. types involving `alloc` -- `Box`, `Vec`, `Rc` etc.
The shallow copying of a type is charged the amount `ELT_SIZE` defined by the implementer, and there is a runtime check to ensure that amount is the upper bound of the actual memory size of the type `mem::size_of<T>`.
Adds a test in `budget_metering.rs` to demonstrate the metered cloning of a deep structure. 


### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
