### PR TITLE
Remove the unnecessary error events that appeared in non-error scenarios

### DIFF
--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -231,12 +231,8 @@ impl Host {
         *self.0.source_account.borrow_mut() = None;
     }
 
-    pub fn source_account(&self) -> Result<AccountId, HostError> {
-        if let Some(account_id) = self.0.source_account.borrow().as_ref() {
-            Ok(account_id.clone())
-        } else {
-            Err(self.err_general("invoker account is not configured"))
-        }
+    pub fn source_account(&self) -> Option<AccountId> {
+        self.0.source_account.borrow().clone()
     }
 
     pub fn switch_to_recording_auth(&self) {
@@ -1077,7 +1073,9 @@ impl Host {
             .previous_authorization_manager
             .borrow_mut()
             .as_mut()
-            .ok_or(self.err_general("previous invocation is missing - no auth data to get"))?
+            .ok_or_else(|| {
+                self.err_general("previous invocation is missing - no auth data to get")
+            })?
             .get_recorded_top_authorizations())
     }
 

--- a/soroban-env-host/src/host/data_helper.rs
+++ b/soroban-env-host/src/host/data_helper.rs
@@ -137,7 +137,9 @@ impl Host {
             return Err(self.err_general("invoker is not an account"));
         }
 
-        let source_account = self.source_account()?;
+        let source_account = self
+            .source_account()
+            .ok_or_else(|| self.err_general("unexpected missing invoker in id preimage"))?;
         Ok(HashIdPreimage::ContractIdFromSourceAccount(
             HashIdPreimageSourceAccountContractId {
                 network_id: self

--- a/soroban-env-host/src/test/invocation.rs
+++ b/soroban-env-host/src/test/invocation.rs
@@ -65,6 +65,7 @@ fn invoke_cross_contract_with_err() -> Result<(), HostError> {
     assert_eq!(sv.get_payload(), exp_st.to_raw().get_payload());
 
     let events = host.get_events()?;
+    println!("{:#?}", events);
     assert_eq!(events.0.len(), 4);
     let last_event = events.0.last();
     match last_event {

--- a/soroban-env-host/src/test/invocation.rs
+++ b/soroban-env-host/src/test/invocation.rs
@@ -65,7 +65,6 @@ fn invoke_cross_contract_with_err() -> Result<(), HostError> {
     assert_eq!(sv.get_payload(), exp_st.to_raw().get_payload());
 
     let events = host.get_events()?;
-    println!("{:#?}", events);
     assert_eq!(events.0.len(), 4);
     let last_event = events.0.last();
     match last_event {


### PR DESCRIPTION
### What

- The account now returns an option and it's up to the client to return an error.
- Use `ok_or_else` instead of `ok_or`

### Why

Remove confusing error messages that don't mean anything.

### Known limitations

N/A
