### PR TITLE
fix thinko in vec_new_from_linear_memory

### DIFF
--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -2163,7 +2163,7 @@ impl VmCallerEnv for Host {
         {
             let VmSlice { vm, pos, len } = self.decode_vmslice(vals_pos, len)?;
             self.charge_budget(CostType::VecNew, len as u64)?;
-            let mut vals: Vec<RawVal> = Vec::with_capacity(len as usize);
+            let mut vals: Vec<RawVal> = vec![RawVal::VOID.to_raw(); len as usize];
             self.metered_vm_read_vals_from_linear_memory::<8, RawVal>(
                 vmcaller,
                 &vm,


### PR DESCRIPTION
This just fixes a small mistake in vec_new_from_linear_memory that unfortunately turns it into a no-op. Cause of https://github.com/stellar/soroban-tools/pull/494#issuecomment-1466513951