### PR TITLE
Bump xdr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1177,7 +1177,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "stellar-xdr"
 version = "0.0.15"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=4655b635c698bb3bbc628bdba456df627c42ee3a#4655b635c698bb3bbc628bdba456df627c42ee3a"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=bcf6f4c3a9dd32822a20af89880650a421d10e7f#bcf6f4c3a9dd32822a20af89880650a421d10e7f"
 dependencies = [
  "arbitrary",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ soroban-native-sdk-macros = { version = "0.0.15", path = "soroban-native-sdk-mac
 [workspace.dependencies.stellar-xdr]
 version = "0.0.15"
 git = "https://github.com/stellar/rs-stellar-xdr"
-rev = "4655b635c698bb3bbc628bdba456df627c42ee3a"
+rev = "bcf6f4c3a9dd32822a20af89880650a421d10e7f"
 default-features = false
 
 [workspace.dependencies.wasmi]


### PR DESCRIPTION
Bump xdr to include https://github.com/stellar/rs-stellar-xdr/pull/242. This change is mainly for stellar-core, and should not affect other consumers at the moment.
