### PR TITLE
Remove `admin` argument from the token admin interface.

### DIFF
--- a/soroban-env-host/src/native_contract/token/admin.rs
+++ b/soroban-env-host/src/native_contract/token/admin.rs
@@ -1,12 +1,11 @@
 use crate::host::Host;
 use crate::native_contract::base_types::Address;
-use crate::native_contract::contract_error::ContractError;
 use crate::native_contract::token::storage_types::DataKey;
-use crate::{err, HostError};
-use soroban_env_common::{Compare, Env, TryIntoVal};
+use crate::HostError;
+use soroban_env_common::{Env, TryIntoVal};
 
 // Metering: covered by components
-fn read_administrator(e: &Host) -> Result<Address, HostError> {
+pub fn read_administrator(e: &Host) -> Result<Address, HostError> {
     let key = DataKey::Admin;
     let rv = e.get_contract_data(key.try_into_val(e)?)?;
     Ok(rv.try_into_val(e)?)
@@ -17,20 +16,4 @@ pub fn write_administrator(e: &Host, id: Address) -> Result<(), HostError> {
     let key = DataKey::Admin;
     e.put_contract_data(key.try_into_val(e)?, id.try_into_val(e)?)?;
     Ok(())
-}
-
-// Metering: *mostly* covered by components.
-pub fn check_admin(e: &Host, addr: &Address) -> Result<(), HostError> {
-    let admin = read_administrator(e)?;
-    if e.compare(&admin, addr)? != core::cmp::Ordering::Equal {
-        Err(err!(
-            e,
-            ContractError::UnauthorizedError,
-            "address '{}' is not an admin ('{}')",
-            addr.clone(),
-            admin
-        ))
-    } else {
-        Ok(())
-    }
 }

--- a/soroban-env-host/src/native_contract/token/test_token.rs
+++ b/soroban-env-host/src/native_contract/token/test_token.rs
@@ -176,11 +176,7 @@ impl<'a> TestToken<'a> {
         addr: Address,
         authorize: bool,
     ) -> Result<(), HostError> {
-        self.call_with_single_signer(
-            admin,
-            "set_auth",
-            host_vec![self.host, admin.address(self.host), addr, authorize],
-        )
+        self.call_with_single_signer(admin, "set_auth", host_vec![self.host, addr, authorize])
     }
 
     pub(crate) fn mint(
@@ -189,11 +185,7 @@ impl<'a> TestToken<'a> {
         to: Address,
         amount: i128,
     ) -> Result<(), HostError> {
-        self.call_with_single_signer(
-            admin,
-            "mint",
-            host_vec![self.host, admin.address(self.host), to, amount],
-        )
+        self.call_with_single_signer(admin, "mint", host_vec![self.host, to, amount])
     }
 
     pub(crate) fn clawback(
@@ -202,11 +194,7 @@ impl<'a> TestToken<'a> {
         from: Address,
         amount: i128,
     ) -> Result<(), HostError> {
-        self.call_with_single_signer(
-            admin,
-            "clawback",
-            host_vec![self.host, admin.address(self.host), from, amount],
-        )
+        self.call_with_single_signer(admin, "clawback", host_vec![self.host, from, amount])
     }
 
     pub(crate) fn set_admin(
@@ -214,11 +202,7 @@ impl<'a> TestToken<'a> {
         admin: &TestSigner,
         new_admin: Address,
     ) -> Result<(), HostError> {
-        self.call_with_single_signer(
-            admin,
-            "set_admin",
-            host_vec![self.host, admin.address(self.host), new_admin],
-        )
+        self.call_with_single_signer(admin, "set_admin", host_vec![self.host, new_admin])
     }
 
     pub(crate) fn decimals(&self) -> Result<u32, HostError> {


### PR DESCRIPTION
### What

Remove `admin` argument from the token admin interface.

Instead simply require auth for the stored admin address.

### Why

Simplify/reduce the interface.

### Known limitations

N/A
