### PR TITLE
Don't allow invalid chars in Symbol objects.

### DIFF
--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -1602,6 +1602,9 @@ impl EnvBase for Host {
     }
 
     fn symbol_new_from_slice(&self, s: &str) -> Result<SymbolObject, HostError> {
+        for ch in s.chars() {
+            SymbolSmall::validate_char(ch)?;
+        }
         self.add_host_object(ScSymbol(s.as_bytes().to_vec().try_into()?))
     }
 

--- a/soroban-env-host/src/test.rs
+++ b/soroban-env-host/src/test.rs
@@ -14,6 +14,7 @@ mod num;
 #[cfg(all(feature = "testutils", feature = "vm"))]
 mod storage;
 mod str;
+mod symbol;
 mod vec;
 
 #[cfg(feature = "vm")]

--- a/soroban-env-host/src/test/symbol.rs
+++ b/soroban-env-host/src/test/symbol.rs
@@ -1,0 +1,50 @@
+use crate::{Host, HostError};
+use soroban_env_common::{Symbol, TryFromVal};
+
+#[test]
+fn invalid_chars() -> Result<(), HostError> {
+    let host = Host::default();
+
+    let s = "#";
+    let s = Symbol::try_from_val(&host, &s);
+
+    assert!(s.is_err());
+
+    Ok(())
+}
+
+#[test]
+fn overlong() -> Result<(), HostError> {
+    let host = Host::default();
+
+    let s = "123456789012345678901234567890___";
+    let s = Symbol::try_from_val(&host, &s);
+
+    assert!(s.is_err());
+
+    Ok(())
+}
+
+#[test]
+fn max_len() -> Result<(), HostError> {
+    let host = Host::default();
+
+    let s = "123456789012345678901234567890__";
+    let s = Symbol::try_from_val(&host, &s);
+
+    assert!(s.is_ok());
+
+    Ok(())
+}
+
+#[test]
+fn zero_len() -> Result<(), HostError> {
+    let host = Host::default();
+
+    let s = "";
+    let s = Symbol::try_from_val(&host, &s);
+
+    assert!(s.is_ok());
+
+    Ok(())
+}


### PR DESCRIPTION
### What

Validate that large Symbol values do not contain chars that are not allowed in Symbol types.

### Why

The conversion from str to Symbol falls back to the object path if a SymbolSmall cannot be created. The Host::symbol_new_from_slice function though does not do the required validation:

```rust
impl<E: Env> TryFromVal<E, &str> for Symbol {
    type Error = ConversionError;

    fn try_from_val(env: &E, v: &&str) -> Result<Self, Self::Error> {
        if let Ok(ss) = SymbolSmall::try_from_str(v) {
            Ok(Self(ss.0))
        } else if let Ok(so) = env.symbol_new_from_slice(v) {
            Ok(Self(so.0))
        } else {
            Err(ConversionError)
        }
    }
}
```

Symbol::new_from_slice creates an `ScSymbol` and puts it into the environment, but ScSymbol is (currently) allowed to contain invalid chars:

```rust
    fn symbol_new_from_slice(&self, s: &str) -> Result<SymbolObject, HostError> {
        self.add_host_object(ScSymbol(s.as_bytes().to_vec().try_into()?))
    }
```

This patch changes symbol_new_from_slice to prevent invalid ScSymbols from being injected into the environment.

This patch adds several test cases. Only the `invalid_chars` case was failing. The others I added because it wasn't obvious to me whether the cases were being checked or not; especially it was not obvious to me from the docs whether zero-length symbols are allowed (they are). The docs for Symbol should be updated to indicate zero-length symbols are ok, but that patch needs to live in the sdk.

### Known limitations

na