### PR TITLE
Undo pub(crate)ing of fn in host

### DIFF
--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -364,7 +364,7 @@ impl Host {
             AuthorizationManager::new_recording(self.budget_cloned());
     }
 
-    pub(crate) fn set_authorization_entries(
+    pub fn set_authorization_entries(
         &self,
         auth_entries: Vec<soroban_env_common::xdr::ContractAuth>,
     ) -> Result<(), HostError> {


### PR DESCRIPTION
### What
Undo pub(crate)ing of set_authorization_entries function in host.

### Why
I'm using it in the SDK in a PR I'm working on. It was just marked as pub crate in https://github.com/stellar/rs-soroban-env/commit/dab3fd1a813e2bf5c6b23cd828d46de11f40b442 today, but it doesn't appear to be critical to that change. I'd like to keep it public for use in the SDK. The SDK needs to be able to set authorization entries independent of invoking a host function since the SDK does invocations via the Env call interface.