### PR TITLE
Expose a list of all auths

### DIFF
--- a/soroban-env-host/src/auth.rs
+++ b/soroban-env-host/src/auth.rs
@@ -512,6 +512,21 @@ impl AuthorizationManager {
         }
     }
 
+    #[cfg(any(test, feature = "testutils"))]
+    // Builds a tuple containing the common details exposed from the
+    // AuthorizationManager about authenticated authorizations.
+    fn invocation_to_tuple(
+        address: &ScAddress,
+        authorized_invocation: &AuthorizedInvocation,
+    ) -> (ScAddress, Hash, ScSymbol, ScVec) {
+        (
+            address.clone(),
+            authorized_invocation.contract_id.clone(),
+            authorized_invocation.function_name.clone(),
+            authorized_invocation.args.clone(),
+        )
+    }
+
     // Returns the top-level authorizations that have been authenticated for the
     // last contract invocation.
     #[cfg(any(test, feature = "testutils"))]
@@ -529,14 +544,45 @@ impl AuthorizationManager {
                 // mostly care about at the benefit of making this list easier
                 // to use.
                 t.address.as_ref().map(|a| {
-                    (
-                        a.clone(),
-                        t.root_authorized_invocation.contract_id.clone(),
-                        t.root_authorized_invocation.function_name.clone(),
-                        t.root_authorized_invocation.args.clone(),
-                    )
+                    AuthorizationManager::invocation_to_tuple(a, &t.root_authorized_invocation)
                 })
             })
+            .collect()
+    }
+
+    // Returns all authorizations that have been authenticated for the
+    // last contract invocation.
+    #[cfg(any(test, feature = "testutils"))]
+    pub(crate) fn get_authenticated_authorizations(
+        &self,
+    ) -> Vec<(ScAddress, Hash, ScSymbol, ScVec)> {
+        self.trackers
+            .iter()
+            .filter(|t| t.authenticated)
+            .filter_map(|t| {
+                // Ignore authorizations without an address as they are implied,
+                // less useful as a test utility, and not succinctly capturable
+                // in the list of tuples. This is a tradeoff between offering up
+                // all authorizations vs the authorizations developers will
+                // mostly care about at the benefit of making this list easier
+                // to use.
+                t.address.as_ref().map(|a| {
+                    fn add_recursively_to_auths(
+                        a: &ScAddress,
+                        auths: &mut Vec<(ScAddress, Hash, ScSymbol, ScVec)>,
+                        i: &AuthorizedInvocation,
+                    ) {
+                        auths.push(AuthorizationManager::invocation_to_tuple(a, i));
+                        for sub in &i.sub_invocations {
+                            add_recursively_to_auths(a, auths, sub);
+                        }
+                    }
+                    let mut auths = vec![];
+                    add_recursively_to_auths(a, &mut auths, &t.root_authorized_invocation);
+                    auths
+                })
+            })
+            .flatten()
             .collect()
     }
 }

--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -1250,6 +1250,28 @@ impl Host {
             .get_authenticated_top_authorizations())
     }
 
+    // Returns the authorizations that have been authenticated for the last
+    // contract invocation.
+    //
+    // Authenticated means that either the authorization was authenticated using
+    // the actual authorization logic for that authorization in enforced mode,
+    // or that it was recorded in recording mode and authorization was assumed
+    // successful.
+    #[cfg(any(test, feature = "testutils"))]
+    pub fn get_authenticated_authorizations(
+        &self,
+    ) -> Result<Vec<(ScAddress, Hash, ScSymbol, ScVec)>, HostError> {
+        Ok(self
+            .0
+            .previous_authorization_manager
+            .borrow_mut()
+            .as_mut()
+            .ok_or_else(|| {
+                self.err_general("previous invocation is missing - no auth data to get")
+            })?
+            .get_authenticated_authorizations())
+    }
+
     #[cfg(any(test, feature = "testutils"))]
     pub fn reset_temp_storage(&self) {
         *self.0.temp_storage.borrow_mut() = Default::default();


### PR DESCRIPTION
### What
Expose a list of all auths in addition to the top-level auths.

### Why
The concept of top-level auths is pretty confusing when learning about how auth works. We have a longer term goal of building a tree-like structure for folks to interact with auth, but that is deferred as it is a lot of work. It would be simpler conceptually for people if when they are thinking about the auths that have occurred if it was just all auths rather than needing to learn about top-level auths.

This change exposes all auths as a flat list. This has limited utility as a developer cannot reason about the relationship that one auth has with another without the tree structure. So it is imperfect, but hopefully a little less confusing.