### PR TITLE
Fix the cargo-deny matrix in rust.yml

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,8 @@ jobs:
     strategy:
       matrix:
         checks:
-          - advisories bans licenses sources
+          - advisories
+          - bans licenses sources
     # Prevent sudden announcement of a new advisory from failing ci:
     continue-on-error: ${{ matrix.checks == 'advisories' }}
     steps:


### PR DESCRIPTION
This just changes the matrix back to the way it was in the upstream example, running the advisories check (which is somewhat out of our control -- advisories come out asynchronously) separately from the other 3 checks which are in our control.
