### PR TITLE
Fix more clippy-isms, enable clippy in CI and Makefile

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,160 @@
+# paths = ["/path/to/override"] # path dependency overrides
+
+# [alias]     # command aliases
+# b = "build"
+# c = "check"
+# t = "test"
+# r = "run"
+# rr = "run --release"
+# recursive_example = "rr --example recursions"
+# space_example = ["run", "--release", "--", "\"command list\""]
+
+[build]
+# jobs = 1                      # number of parallel jobs, defaults to # of CPUs
+# rustc = "rustc"               # the rust compiler tool
+# rustc-wrapper = "…"           # run this wrapper instead of `rustc`
+# rustc-workspace-wrapper = "…" # run this wrapper instead of `rustc` for workspace members
+# rustdoc = "rustdoc"           # the doc generator tool
+# target = "triple"             # build for the target triple (ignored by `cargo install`)
+# target-dir = "target"         # path of where to place all generated artifacts
+rustflags = [
+     "-Dwarnings",
+     "-Aclippy::style",
+#    "-Dclippy::pedantic",
+#    "-Aclippy::module_name_repetitions",
+#    "-Aclippy::needless_pass_by_value",
+#    "-Aclippy::too_many_lines",
+#    "-Aclippy::must_use_candidate",
+#    "-Aclippy::missing_errors_doc",
+#    "-Aclippy::missing_safety_doc",
+#    "-Aclippy::inline_always",
+#    "-Aclippy::cast_possible_truncation",
+#    "-Aclippy::cast_sign_loss",
+#    "-Aclippy::cast_possible_wrap",
+#    "-Aclippy::similar_names",
+#    "-Aclippy::doc_markdown",
+#    "-Aclippy::default_trait_access",
+#    "-Aclippy::missing_safety_doc",
+#    "-Aclippy::struct_excessive_bools",
+#    "-Aclippy::missing_panics_doc",
+#    "-Aclippy::cast_lossless",
+#    "-Aclippy::trivially_copy_pass_by_ref",
+#    "-Aclippy::wrong_self_convention",
+#    "-Aclippy::unused_self",
+#    "-Aclippy::enum_glob_use",
+#    "-Aclippy::return_self_not_must_use",
+#    "-Aclippy::map_entry",
+#    "-Aclippy::match_same_arms",
+#    "-Aclippy::iter_not_returning_iterator",
+#    "-Aclippy::unnecessary_wraps",
+#    "-Aclippy::type_complexity",
+] # custom flags to pass to all compiler invocations
+# rustdocflags = ["…", "…"]     # custom flags to pass to rustdoc
+# incremental = true            # whether or not to enable incremental compilation
+# dep-info-basedir = "…"        # path for the base directory for targets in depfiles
+
+# [doc]
+# browser = "chromium"          # browser to use with `cargo doc --open`,
+#                               # overrides the `BROWSER` environment variable
+
+# [env]
+# # Set ENV_VAR_NAME=value for any process run by Cargo
+# ENV_VAR_NAME = "value"
+# # Set even if already present in environment
+# ENV_VAR_NAME_2 = { value = "value", force = true }
+# # Value is relative to .cargo directory containing `config.toml`, make absolute
+# ENV_VAR_NAME_3 = { value = "relative/path", relative = true }
+
+# [future-incompat-report]
+# frequency = 'always' # when to display a notification about a future incompat report
+
+# [cargo-new]
+# vcs = "none"              # VCS to use ('git', 'hg', 'pijul', 'fossil', 'none')
+
+# [http]
+# debug = false               # HTTP debugging
+# proxy = "host:port"         # HTTP proxy in libcurl format
+# ssl-version = "tlsv1.3"     # TLS version to use
+# ssl-version.max = "tlsv1.3" # maximum TLS version
+# ssl-version.min = "tlsv1.1" # minimum TLS version
+# timeout = 30                # timeout for each HTTP request, in seconds
+# low-speed-limit = 10        # network timeout threshold (bytes/sec)
+# cainfo = "cert.pem"         # path to Certificate Authority (CA) bundle
+# check-revoke = true         # check for SSL certificate revocation
+# multiplexing = true         # HTTP/2 multiplexing
+# user-agent = "…"            # the user-agent header
+
+# [install]
+# root = "/some/path"         # `cargo install` destination directory
+
+# [net]
+# retry = 2                   # network retries
+# git-fetch-with-cli = true   # use the `git` executable for git operations
+# offline = true              # do not access the network
+
+# [net.ssh]
+# known-hosts = ["..."]       # known SSH host keys
+
+# [patch.<registry>]
+# # Same keys as for [patch] in Cargo.toml
+
+# [profile.<name>]         # Modify profile settings via config.
+# inherits = "dev"         # Inherits settings from [profile.dev].
+# opt-level = 0            # Optimization level.
+# debug = true             # Include debug info.
+# split-debuginfo = '...'  # Debug info splitting behavior.
+# debug-assertions = true  # Enables debug assertions.
+# overflow-checks = true   # Enables runtime integer overflow checks.
+# lto = false              # Sets link-time optimization.
+# panic = 'unwind'         # The panic strategy.
+# incremental = true       # Incremental compilation.
+# codegen-units = 16       # Number of code generation units.
+# rpath = false            # Sets the rpath linking option.
+# [profile.<name>.build-override]  # Overrides build-script settings.
+# # Same keys for a normal profile.
+# [profile.<name>.package.<name>]  # Override profile for a package.
+# # Same keys for a normal profile (minus `panic`, `lto`, and `rpath`).
+
+# [registries.<name>]  # registries other than crates.io
+# index = "…"          # URL of the registry index
+# token = "…"          # authentication token for the registry
+
+# [registry]
+# default = "…"        # name of the default registry
+# token = "…"          # authentication token for crates.io
+
+# [source.<name>]      # source definition and replacement
+# replace-with = "…"   # replace this source with the given named source
+# directory = "…"      # path to a directory source
+# registry = "…"       # URL to a registry source
+# local-registry = "…" # path to a local registry source
+# git = "…"            # URL of a git repository source
+# branch = "…"         # branch name for the git repository
+# tag = "…"            # tag name for the git repository
+# rev = "…"            # revision for the git repository
+
+# [target.<triple>]
+# linker = "…"            # linker to use
+# runner = "…"            # wrapper to run executables
+# rustflags = ["…", "…"]  # custom flags for `rustc`
+
+# [target.<cfg>]
+# runner = "…"            # wrapper to run executables
+# rustflags = ["…", "…"]  # custom flags for `rustc`
+
+# [target.<triple>.<links>] # `links` build script override
+# rustc-link-lib = ["foo"]
+# rustc-link-search = ["/path/to/foo"]
+# rustc-flags = ["-L", "/some/path"]
+# rustc-cfg = ['key="value"']
+# rustc-env = {key = "value"}
+# rustc-cdylib-link-arg = ["…"]
+# metadata_key1 = "value"
+# metadata_key2 = "value"
+
+# [term]
+# quiet = false          # whether cargo output is quiet
+# verbose = false        # whether cargo provides verbose output
+# color = 'auto'         # whether cargo colorizes output
+# progress.when = 'auto' # whether cargo shows progress bar
+# progress.width = 80    # width of progress bar

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,9 +5,6 @@ on:
     branches: [main, release/**]
   pull_request:
 
-env:
-  RUSTFLAGS: -D warnings
-
 jobs:
 
   complete:
@@ -79,7 +76,7 @@ jobs:
       with:
         name: cargo-hack
         version: 0.5.16
-    - run: cargo hack --feature-powerset check --locked --target ${{ matrix.sys.target }}
+    - run: cargo hack --feature-powerset clippy --locked --target ${{ matrix.sys.target }}
     - if: matrix.sys.test
       run: cargo hack --feature-powerset test --locked --target ${{ matrix.sys.target }}
 

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,10 @@
 all: build test
 
-export RUSTFLAGS=-Dwarnings
-
 test:
 	cargo hack --feature-powerset test
 
 build:
-	cargo hack --feature-powerset check
+	cargo hack --feature-powerset clippy
 
 watch:
 	cargo watch --clear --watch-when-idle --shell '$(MAKE)'

--- a/soroban-env-common/src/compare.rs
+++ b/soroban-env-common/src/compare.rs
@@ -124,6 +124,7 @@ macro_rules! delegate_compare_to_wrapper {
     }};
 }
 
+#[allow(clippy::comparison_chain)]
 impl<E: Env> Compare<RawVal> for E {
     type Error = E::Error;
 

--- a/soroban-env-common/src/lib.rs
+++ b/soroban-env-common/src/lib.rs
@@ -100,7 +100,5 @@ pub use symbol::{Symbol, SymbolError, SymbolObject, SymbolSmall, SymbolSmallIter
 // that did panic! in a const context and rt::trap in a non-const
 // context but it's not clear how to actually do that.
 pub const fn require(b: bool) {
-    if !b {
-        panic!();
-    }
+    assert!(b,);
 }

--- a/soroban-env-common/src/raw_val.rs
+++ b/soroban-env-common/src/raw_val.rs
@@ -703,7 +703,7 @@ impl Debug for RawVal {
                 let ss: SymbolStr =
                     unsafe { <SymbolSmall as RawValConvertible>::unchecked_from_val(*self) }.into();
                 let s: &str = ss.as_ref();
-                write!(f, "Symbol({})", s)
+                write!(f, "Symbol({s})")
             }
             Tag::LedgerKeyContractExecutable => write!(f, "LedgerKeyContractCode"),
 
@@ -791,9 +791,9 @@ fn test_tag_from_u8() {
         let expected_tag = Tag::from_int(i);
         let actual_tag = Tag::from_u8(i);
         match expected_tag {
-            Ok(Tag::SmallCodeUpperBound)
-            | Ok(Tag::ObjectCodeLowerBound)
-            | Ok(Tag::ObjectCodeUpperBound) => {
+            Ok(
+                Tag::SmallCodeUpperBound | Tag::ObjectCodeLowerBound | Tag::ObjectCodeUpperBound,
+            ) => {
                 assert_eq!(actual_tag, Tag::Bad);
             }
             Ok(expected_tag) => {

--- a/soroban-env-common/src/status.rs
+++ b/soroban-env-common/src/status.rs
@@ -146,8 +146,8 @@ impl Debug for Status {
         };
         write!(f, "Status({}(", st.name())?;
         match st {
-            ScStatusType::Ok => write!(f, "{}", code),
-            ScStatusType::UnknownError => write!(f, "{}", code),
+            ScStatusType::Ok => write!(f, "{code}"),
+            ScStatusType::UnknownError => write!(f, "{code}"),
             ScStatusType::HostValueError => fmt_named_code::<ScHostValErrorCode>(code, f),
             ScStatusType::HostObjectError => fmt_named_code::<ScHostObjErrorCode>(code, f),
             ScStatusType::HostFunctionError => fmt_named_code::<ScHostFnErrorCode>(code, f),
@@ -155,7 +155,7 @@ impl Debug for Status {
             ScStatusType::HostContextError => fmt_named_code::<ScHostContextErrorCode>(code, f),
             ScStatusType::HostAuthError => fmt_named_code::<ScHostAuthErrorCode>(code, f),
             ScStatusType::VmError => fmt_named_code::<ScVmErrorCode>(code, f),
-            ScStatusType::ContractError => write!(f, "{}", code),
+            ScStatusType::ContractError => write!(f, "{code}"),
         }?;
         write!(f, "))")
     }
@@ -341,7 +341,11 @@ mod tests {
         // puts them all into a list, and sorts them with each comparison function,
         // then checks that both lists are sorted the same.
 
-        use crate::xdr::*;
+        use crate::xdr::{
+            ScHostAuthErrorCode, ScHostContextErrorCode, ScHostFnErrorCode, ScHostObjErrorCode,
+            ScHostStorageErrorCode, ScHostValErrorCode, ScStatus, ScUnknownErrorCode,
+            ScVmErrorCode,
+        };
 
         let xdr_vals = &[
             ScStatus::Ok,

--- a/soroban-env-common/src/string.rs
+++ b/soroban-env-common/src/string.rs
@@ -47,7 +47,7 @@ impl<E: Env> TryFromVal<E, &str> for RawVal {
 }
 
 #[cfg(feature = "std")]
-impl<'a, E: Env> TryFromVal<E, String> for StringObject {
+impl<E: Env> TryFromVal<E, String> for StringObject {
     type Error = ConversionError;
 
     fn try_from_val(env: &E, v: &String) -> Result<Self, Self::Error> {
@@ -56,7 +56,7 @@ impl<'a, E: Env> TryFromVal<E, String> for StringObject {
 }
 
 #[cfg(feature = "std")]
-impl<'a, E: Env> TryFromVal<E, String> for RawVal {
+impl<E: Env> TryFromVal<E, String> for RawVal {
     type Error = ConversionError;
 
     fn try_from_val(env: &E, v: &String) -> Result<Self, Self::Error> {

--- a/soroban-env-common/src/symbol.rs
+++ b/soroban-env-common/src/symbol.rs
@@ -21,12 +21,10 @@ impl core::fmt::Display for SymbolError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             SymbolError::TooLong(len) => f.write_fmt(format_args!(
-                "symbol too long: length {}, max {}",
-                len, MAX_SMALL_CHARS
+                "symbol too long: length {len}, max {MAX_SMALL_CHARS}"
             )),
             SymbolError::BadChar(char) => f.write_fmt(format_args!(
-                "symbol bad char: encountered {}, supported range [a-zA-Z0-9_]",
-                char
+                "symbol bad char: encountered {char}, supported range [a-zA-Z0-9_]"
             )),
         }
     }
@@ -359,11 +357,9 @@ impl Iterator for SymbolSmallIter {
 
 impl FromIterator<char> for SymbolSmall {
     fn from_iter<T: IntoIterator<Item = char>>(iter: T) -> Self {
-        let mut n = 0;
         let mut accum: u64 = 0;
-        for i in iter {
+        for (n, i) in iter.into_iter().enumerate() {
             require(n < MAX_SMALL_CHARS);
-            n += 1;
             accum <<= CODE_BITS;
             let v = match i {
                 '_' => 1,

--- a/soroban-env-host/benches/common/cost_types/val_xdr_conv.rs
+++ b/soroban-env-host/benches/common/cost_types/val_xdr_conv.rs
@@ -11,7 +11,7 @@ impl HostCostMeasurement for ValXdrConvMeasure {
     fn new_random_case(_host: &Host, rng: &mut StdRng, _input: u64) -> (Option<RawVal>, ScVal) {
         let v = rng.next_u32();
         let rv: RawVal = v.into();
-        let scv: ScVal = ScVal::U32(v as u32);
+        let scv: ScVal = ScVal::U32(v);
         (Some(rv), scv)
     }
 }

--- a/soroban-env-host/benches/common/cost_types/verify_ed25519_sig.rs
+++ b/soroban-env-host/benches/common/cost_types/verify_ed25519_sig.rs
@@ -19,7 +19,7 @@ impl HostCostMeasurement for VerifyEd25519SigMeasure {
     fn new_random_case(_host: &Host, rng: &mut StdRng, input: u64) -> VerifyEd25519SigSample {
         let size = 1 + input * Self::STEP_SIZE;
         let keypair: Keypair = Keypair::generate(rng);
-        let key: PublicKey = keypair.public.clone();
+        let key: PublicKey = keypair.public;
         let msg: Vec<u8> = (0..size).map(|x| x as u8).collect();
         let sig: Signature = keypair.sign(msg.as_slice());
         VerifyEd25519SigSample { key, msg, sig }

--- a/soroban-env-host/benches/common/cost_types/vm_ops.rs
+++ b/soroban-env-host/benches/common/cost_types/vm_ops.rs
@@ -18,21 +18,21 @@ impl HostCostMeasurement for VmInstantiationMeasure {
 
     fn new_best_case(_host: &Host, _rng: &mut StdRng) -> VmInstantiationSample {
         let id: xdr::Hash = [0; 32].into();
-        let wasm: Vec<u8> = soroban_test_wasms::ADD_I32.clone().into();
+        let wasm: Vec<u8> = soroban_test_wasms::ADD_I32.into();
         VmInstantiationSample { id: Some(id), wasm }
     }
 
     fn new_worst_case(_host: &Host, _rng: &mut StdRng, input: u64) -> VmInstantiationSample {
         let id: xdr::Hash = [0; 32].into();
         let idx = input as usize % util::TEST_WASMS.len();
-        let wasm = util::TEST_WASMS[idx].clone().into();
+        let wasm = util::TEST_WASMS[idx].into();
         VmInstantiationSample { id: Some(id), wasm }
     }
 
     fn new_random_case(_host: &Host, rng: &mut StdRng, _input: u64) -> VmInstantiationSample {
         let id: xdr::Hash = [0; 32].into();
         let idx = rng.gen_range(0, 10) % util::TEST_WASMS.len();
-        let wasm = util::TEST_WASMS[idx].clone().into();
+        let wasm = util::TEST_WASMS[idx].into();
         VmInstantiationSample { id: Some(id), wasm }
     }
 }

--- a/soroban-env-host/benches/common/mod.rs
+++ b/soroban-env-host/benches/common/mod.rs
@@ -20,7 +20,7 @@ pub(crate) trait Benchmark {
 }
 
 fn get_explicit_bench_names() -> Option<Vec<String>> {
-    let bare_args: Vec<_> = std::env::args().filter(|x| !x.starts_with("-")).collect();
+    let bare_args: Vec<_> = std::env::args().filter(|x| !x.starts_with('-')).collect();
     match bare_args.len() {
         0 | 1 => None,
         _ => Some(bare_args[1..].into()),

--- a/soroban-env-host/src/cost_runner/mod.rs
+++ b/soroban-env-host/src/cost_runner/mod.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unit_arg)]
 mod cost_types;
 mod runner;
 

--- a/soroban-env-host/src/fees.rs
+++ b/soroban-env-host/src/fees.rs
@@ -115,11 +115,11 @@ pub fn compute_transaction_resource_fee(
         .saturating_add(ledger_write_bytes_fee)
         .saturating_add(historical_fee)
         .saturating_add(bandwidth_fee);
-    let res = (
+
+    (
         refundable_fee.saturating_add(non_refundable_fee),
         refundable_fee,
-    );
-    res
+    )
 }
 
 fn compute_fee_per_increment(resource_value: u32, fee_rate: i64, increment: i64) -> i64 {

--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -1065,7 +1065,7 @@ impl Host {
             // maintains a borrow of self.0.contracts, which can cause borrow errors.
             let cfs_option = self.0.contracts.borrow().get(&id).cloned();
             if let Some(cfs) = cfs_option {
-                let frame = TestContractFrame::new(id.clone(), func.clone(), args.to_vec());
+                let frame = TestContractFrame::new(id.clone(), func, args.to_vec());
                 let panic = frame.panic.clone();
                 return self.with_frame(Frame::TestContract(frame), || {
                     use std::any::Any;
@@ -2159,7 +2159,7 @@ impl VmCallerEnv for Host {
                 &vm,
                 vals_pos,
                 vals.as_mut_slice(),
-                |buf| RawVal::from_payload(u64::from_le_bytes(buf.clone())),
+                |buf| RawVal::from_payload(u64::from_le_bytes(*buf)),
             )?;
 
             // Step 3: turn pairs into a map.
@@ -2444,7 +2444,7 @@ impl VmCallerEnv for Host {
                 &vm,
                 pos,
                 vals.as_mut_slice(),
-                |buf| RawVal::from_payload(u64::from_le_bytes(buf.clone())),
+                |buf| RawVal::from_payload(u64::from_le_bytes(*buf)),
             )?;
             self.add_host_object(HostVec::from_vec(vals)?)
         }

--- a/soroban-env-host/src/host/diagnostics_helper.rs
+++ b/soroban-env-host/src/host/diagnostics_helper.rs
@@ -76,8 +76,7 @@ impl Host {
             self.record_system_debug_contract_event(
                 ContractEventType::Diagnostic,
                 calling_contract,
-                self.add_host_object(HostVec::from_vec(topics)?)?
-                    .try_into()?,
+                self.add_host_object(HostVec::from_vec(topics)?)?,
                 self.vec_new_from_slice(args)?.into(),
             )
         })
@@ -102,8 +101,7 @@ impl Host {
             self.record_system_debug_contract_event(
                 ContractEventType::Diagnostic,
                 Some(self.hash_to_bytesobj(contract_id)?),
-                self.add_host_object(HostVec::from_vec(topics)?)?
-                    .try_into()?,
+                self.add_host_object(HostVec::from_vec(topics)?)?,
                 *res,
             )
         })

--- a/soroban-env-host/src/host/mem_helper.rs
+++ b/soroban-env-host/src/host/mem_helper.rs
@@ -87,7 +87,7 @@ impl Host {
         let mem_slice = mem_data.get_mut(mem_range).ok_or(ScVmErrorCode::Memory)?;
 
         self.charge_budget(ContractCostType::VmMemWrite, Some(byte_len as u64))?;
-        for (src, dst) in buf.iter().zip(mem_slice.chunks_mut(VAL_SZ as usize)) {
+        for (src, dst) in buf.iter().zip(mem_slice.chunks_mut(VAL_SZ)) {
             if dst.len() != VAL_SZ {
                 // This should be impossible unless there's an error above, but just in case.
                 return Err(ScHostObjErrorCode::VecIndexOutOfBound.into());
@@ -125,7 +125,7 @@ impl Host {
 
         self.charge_budget(ContractCostType::VmMemRead, Some(byte_len as u64))?;
         let mut tmp: [u8; VAL_SZ] = [0u8; VAL_SZ];
-        for (dst, src) in buf.iter_mut().zip(mem_slice.chunks(VAL_SZ as usize)) {
+        for (dst, src) in buf.iter_mut().zip(mem_slice.chunks(VAL_SZ)) {
             if let Ok(src) = TryInto::<&[u8; VAL_SZ]>::try_into(src) {
                 tmp.copy_from_slice(src);
                 *dst = from_le_bytes(&tmp);
@@ -361,6 +361,7 @@ impl Host {
         dest: &mut [T],
     ) -> Result<(), HostError> {
         self.charge_budget(ContractCostType::HostMemCpy, Some(src.len() as u64))?;
-        Ok(dest.copy_from_slice(src))
+        dest.copy_from_slice(src);
+        Ok(())
     }
 }

--- a/soroban-env-host/src/host/metered_vector.rs
+++ b/soroban-env-host/src/host/metered_vector.rs
@@ -211,14 +211,12 @@ where
         F: Fn(&A) -> Result<Ordering, HostError>,
     {
         self.charge_scan(budget)?;
-        let mut i = 0;
         let iter = self.vec.iter();
         // this is similar logic to `iter.position(f)` but is fallible
-        for val in iter {
+        for (i, val) in iter.enumerate() {
             if f(val)? == Ordering::Equal {
                 return Ok(Some(i));
             }
-            i += 1;
         }
         Ok(None)
     }

--- a/soroban-env-host/src/native_contract/base_types.rs
+++ b/soroban-env-host/src/native_contract/base_types.rs
@@ -68,15 +68,12 @@ impl<const N: usize> From<BytesN<N>> for Bytes {
 impl Bytes {
     pub fn push(&mut self, x: u8) -> Result<(), HostError> {
         let x32: u32 = x.into();
-        self.object = self.host.bytes_push(self.object, x32.into())?.try_into()?;
+        self.object = self.host.bytes_push(self.object, x32.into())?;
         Ok(())
     }
 
     pub fn append(&mut self, other: Bytes) -> Result<(), HostError> {
-        self.object = self
-            .host
-            .bytes_append(self.object, other.object)?
-            .try_into()?;
+        self.object = self.host.bytes_append(self.object, other.object)?;
         Ok(())
     }
 
@@ -238,7 +235,7 @@ impl From<Map> for MapObject {
 
 impl Map {
     pub fn new(env: &Host) -> Result<Self, HostError> {
-        let map = env.map_new()?.try_into()?;
+        let map = env.map_new()?;
         Ok(Self {
             host: env.clone(),
             object: map,
@@ -266,7 +263,7 @@ impl Map {
     {
         let k_rv = RawVal::try_from_val(&self.host, k)?;
         let v_rv = RawVal::try_from_val(&self.host, v)?;
-        self.object = self.host.map_put(self.object, k_rv, v_rv)?.try_into()?;
+        self.object = self.host.map_put(self.object, k_rv, v_rv)?;
         Ok(())
     }
 }

--- a/soroban-env-host/src/native_contract/testutils.rs
+++ b/soroban-env-host/src/native_contract/testutils.rs
@@ -67,6 +67,7 @@ pub(crate) enum TestSigner<'a> {
 
 pub(crate) struct AccountContractSigner<'a> {
     pub(crate) id: Hash,
+    #[allow(clippy::type_complexity)]
     pub(crate) sign: Box<dyn Fn(&[u8]) -> HostVec + 'a>,
 }
 
@@ -147,7 +148,7 @@ pub(crate) fn authorize_single_invocation_with_nonce(
     let address_with_nonce = match signer {
         TestSigner::AccountInvoker(_) => None,
         TestSigner::Account(_) | TestSigner::AccountContract(_) => Some(AddressWithNonce {
-            address: sc_address.clone(),
+            address: sc_address,
             nonce: nonce.unwrap(),
         }),
         TestSigner::ContractInvoker(_) => {
@@ -166,7 +167,7 @@ pub(crate) fn authorize_single_invocation_with_nonce(
     let signature_payload = if let Some(addr_with_nonce) = &address_with_nonce {
         let signature_payload_preimage = HashIdPreimage::ContractAuth(HashIdPreimageContractAuth {
             network_id: host
-                .with_ledger_info(|li: &LedgerInfo| Ok(li.network_id.clone()))
+                .with_ledger_info(|li: &LedgerInfo| Ok(li.network_id))
                 .unwrap()
                 .try_into()
                 .unwrap(),
@@ -199,7 +200,7 @@ pub(crate) fn authorize_single_invocation(
         TestSigner::AccountInvoker(_) => None,
         TestSigner::Account(_) | TestSigner::AccountContract(_) => Some(
             host.read_nonce(
-                &Hash(contract_id.to_vec().clone().try_into().unwrap()),
+                &Hash(contract_id.to_vec().try_into().unwrap()),
                 &signer.address(host).to_sc_address().unwrap(),
             )
             .unwrap(),
@@ -249,6 +250,7 @@ pub(crate) fn sign_payload_for_ed25519(
     .unwrap()
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn create_account(
     host: &Host,
     account_id: &AccountId,
@@ -262,7 +264,7 @@ pub(crate) fn create_account(
     sponsorships: Option<(u32, u32)>,
     flags: u32,
 ) {
-    let key = host.to_account_key(account_id.clone().into());
+    let key = host.to_account_key(account_id.clone());
     let account_id = match key.as_ref() {
         LedgerKey::Account(acc) => acc.account_id.clone(),
         _ => unreachable!(),

--- a/soroban-env-host/src/native_contract/token/balance.rs
+++ b/soroban-env-host/src/native_contract/token/balance.rs
@@ -351,11 +351,7 @@ fn transfer_account_balance(e: &Host, account_id: AccountId, amount: i64) -> Res
 
         let (min_balance, max_balance) = get_min_max_account_balance(e, &ae)?;
 
-        let new_balance = if amount <= 0 {
-            ae.balance + amount
-        } else if ae.balance <= i64::MAX - amount {
-            ae.balance + amount
-        } else {
+        let Some(new_balance) = ae.balance.checked_add(amount) else {
             return Err(e.err_status_msg(ContractError::BalanceError, "resulting balance overflow"));
         };
         if new_balance >= min_balance && new_balance <= max_balance {
@@ -395,11 +391,7 @@ fn transfer_trustline_balance(
 
         let (min_balance, max_balance) = get_min_max_trustline_balance(e, &tl)?;
 
-        let new_balance = if amount <= 0 {
-            tl.balance + amount
-        } else if tl.balance <= i64::MAX - amount {
-            tl.balance + amount
-        } else {
+        let Some(new_balance) = tl.balance.checked_add(amount) else {
             return Err(e.err_status_msg(ContractError::BalanceError, "resulting balance overflow"));
         };
         if new_balance >= min_balance && new_balance <= max_balance {

--- a/soroban-env-host/src/native_contract/token/test_token.rs
+++ b/soroban-env-host/src/native_contract/token/test_token.rs
@@ -226,24 +226,22 @@ impl<'a> TestToken<'a> {
     }
 
     pub(crate) fn name(&self) -> Result<Bytes, HostError> {
-        Ok(self
-            .host
+        self.host
             .call(
                 self.id.clone().into(),
                 Symbol::try_from_val(self.host, &"name")?,
                 host_vec![self.host].into(),
             )?
-            .try_into_val(self.host)?)
+            .try_into_val(self.host)
     }
 
     pub(crate) fn symbol(&self) -> Result<Bytes, HostError> {
-        Ok(self
-            .host
+        self.host
             .call(
                 self.id.clone().into(),
                 Symbol::try_from_val(self.host, &"symbol")?,
                 host_vec![self.host].into(),
             )?
-            .try_into_val(self.host)?)
+            .try_into_val(self.host)
     }
 }

--- a/soroban-env-host/src/test/address.rs
+++ b/soroban-env-host/src/test/address.rs
@@ -16,7 +16,7 @@ fn test_account_address_conversions() {
         host.visit_obj(address_obj, |addr: &ScAddress| { Ok(addr.clone()) })
             .unwrap(),
         ScAddress::Account(AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(
-            account_pk.clone()
+            account_pk
         ))))
     );
     let restored_pk_obj = host
@@ -50,7 +50,7 @@ fn test_contract_address_conversions() {
     assert_eq!(
         host.visit_obj(address_obj, |addr: &ScAddress| { Ok(addr.clone()) })
             .unwrap(),
-        ScAddress::Contract(Hash(contract_id.clone()))
+        ScAddress::Contract(Hash(contract_id))
     );
     let restored_contract_id_obj = host
         .address_to_contract_id(address_obj)

--- a/soroban-env-host/src/test/auth.rs
+++ b/soroban-env-host/src/test/auth.rs
@@ -140,8 +140,7 @@ impl AuthTest {
                 &self.host,
                 self.get_addresses(),
                 self.convert_setup_tree(&root)
-            ]
-            .into(),
+            ],
             sign_payloads,
             success,
         );
@@ -188,7 +187,7 @@ impl AuthTest {
                 let payload_preimage = HashIdPreimage::ContractAuth(HashIdPreimageContractAuth {
                     network_id: self
                         .host
-                        .with_ledger_info(|li: &LedgerInfo| Ok(li.network_id.clone()))
+                        .with_ledger_info(|li: &LedgerInfo| Ok(li.network_id))
                         .unwrap()
                         .try_into()
                         .unwrap(),
@@ -217,7 +216,7 @@ impl AuthTest {
         self.host.set_authorization_entries(contract_auth).unwrap();
         assert_eq!(
             self.host
-                .call(contract_id.clone().into(), fn_name, args.into(),)
+                .call(contract_id.into(), fn_name, args.into(),)
                 .is_ok(),
             success
         );

--- a/soroban-env-host/src/test/budget_metering.rs
+++ b/soroban-env-host/src/test/budget_metering.rs
@@ -55,7 +55,7 @@ fn vm_hostfn_invocation() -> Result<(), HostError> {
     let args = host.test_vec_obj::<u32>(&[1])?;
 
     // try_call
-    host.try_call(id_obj, sym.into(), args.clone().into())?;
+    host.try_call(id_obj, sym, args)?;
     host.with_budget(|budget| {
         assert_eq!(budget.get_tracker(ContractCostType::InvokeVmFunction).0, 1);
         assert_eq!(
@@ -181,7 +181,7 @@ fn test_recursive_type_clone() -> Result<(), HostError> {
     let v: Vec<Box<ScMap>> = vec![
         Box::new(scmap.clone()),
         Box::new(scmap.clone()),
-        Box::new(scmap.clone()),
+        Box::new(scmap),
     ];
 
     v.metered_clone(host.as_budget())?;

--- a/soroban-env-host/src/test/bytes.rs
+++ b/soroban-env-host/src/test/bytes.rs
@@ -99,8 +99,8 @@ fn bytes_slice_start_greater_than_len() -> Result<(), HostError> {
 fn bytes_xdr_roundtrip() -> Result<(), HostError> {
     let host = Host::default();
     let roundtrip = |v: ScVal| -> Result<(), HostError> {
-        let rv: RawVal = host.to_host_val(&v)?.into();
-        let bo = host.serialize_to_bytes(rv.clone())?;
+        let rv: RawVal = host.to_host_val(&v)?;
+        let bo = host.serialize_to_bytes(rv)?;
         let rv_back = host.deserialize_from_bytes(bo)?;
         assert_eq!(host.compare(&rv, &rv_back)?, core::cmp::Ordering::Equal);
         Ok(())
@@ -145,8 +145,8 @@ fn linear_memory_operations() -> Result<(), HostError> {
         let obj: BytesObject = host
             .call(
                 id_obj,
-                Symbol::try_from_small_str("bin_word").unwrap().into(),
-                args.into(),
+                Symbol::try_from_small_str("bin_word").unwrap(),
+                args,
             )?
             .try_into()?;
         let obj_ref: BytesObject = host.test_bin_obj(&[0xaa, 0xbb, 0xcc, 0xdd])?;
@@ -161,11 +161,7 @@ fn linear_memory_operations() -> Result<(), HostError> {
         let mut args = host.vec_new(RawVal::from_void().into())?;
         args = host.vec_push_back(args, obj0.to_raw())?;
         let obj: BytesObject = host
-            .call(
-                id_obj,
-                Symbol::try_from_small_str("bin_inc").unwrap().into(),
-                args.into(),
-            )?
+            .call(id_obj, Symbol::try_from_small_str("bin_inc").unwrap(), args)?
             .try_into()?;
         let obj_ref = host.test_bin_obj(&[2, 3, 4, 5])?;
         assert_eq!(

--- a/soroban-env-host/src/test/event.rs
+++ b/soroban-env-host/src/test/event.rs
@@ -33,7 +33,7 @@ fn contract_event() -> Result<(), HostError> {
     let args = host.test_vec_obj::<i32>(&[1, 2])?;
     host.register_test_contract(id, test_contract)?;
     assert_eq!(
-        host.call(id, sym.into(), args.into())?.get_payload(),
+        host.call(id, sym, args)?.get_payload(),
         RawVal::from_void().to_raw().get_payload()
     );
 
@@ -98,7 +98,7 @@ fn test_event_rollback() -> Result<(), HostError> {
     let args = host.test_vec_obj::<i32>(&[1, 2])?;
     host.register_test_contract(id, test_contract)?;
     assert_eq!(
-        host.call(id, sym.into(), args.into())?.get_payload(),
+        host.call(id, sym, args)?.get_payload(),
         RawVal::from_void().to_raw().get_payload()
     );
     host.0.events.borrow_mut().rollback(1)?;

--- a/soroban-env-host/src/test/ledger.rs
+++ b/soroban-env-host/src/test/ledger.rs
@@ -12,7 +12,7 @@ fn ledger_network_id() -> Result<(), HostError> {
     let storage =
         Storage::with_enforcing_footprint_and_map(Footprint::default(), StorageMap::new()?);
 
-    let host = Host::with_storage_and_budget(storage, budget.clone());
+    let host = Host::with_storage_and_budget(storage, budget);
     host.set_ledger_info(LedgerInfo {
         protocol_version: 0,
         sequence_number: 0,

--- a/soroban-env-host/src/test/lifecycle.rs
+++ b/soroban-env-host/src/test/lifecycle.rs
@@ -59,7 +59,7 @@ fn test_host() -> Host {
     let budget = Budget::default();
     let storage =
         Storage::with_enforcing_footprint_and_map(Footprint::default(), StorageMap::new().unwrap());
-    let host = Host::with_storage_and_budget(storage, budget.clone());
+    let host = Host::with_storage_and_budget(storage, budget);
     host.set_ledger_info(LedgerInfo {
         network_id: generate_bytes_array(),
         ..Default::default()
@@ -113,7 +113,7 @@ fn test_create_contract_from_source_account(host: &Host, code: &[u8]) -> Hash {
     let res = host
         .invoke_functions(vec![
             HostFunction {
-                args: HostFunctionArgs::UploadContractWasm(upload_args.clone()),
+                args: HostFunctionArgs::UploadContractWasm(upload_args),
                 auth: Default::default(),
             },
             HostFunction {
@@ -154,7 +154,7 @@ fn create_contract_using_parent_id_test() {
     let salt = generate_bytes_array();
     let child_pre_image = HashIdPreimage::ContractIdFromContract(HashIdPreimageContractId {
         contract_id: parent_contract_id.clone(),
-        salt: Uint256(salt.clone()),
+        salt: Uint256(salt),
         network_id: host
             .hash_from_bytesobj_input("network_id", host.get_ledger_network_id().unwrap())
             .unwrap(),
@@ -167,7 +167,7 @@ fn create_contract_using_parent_id_test() {
     };
 
     // Install the code for the child contract.
-    let wasm_hash = sha256_hash_id_preimage(upload_args.clone());
+    let wasm_hash = sha256_hash_id_preimage(upload_args);
     // Add the contract code and code reference access to the footprint.
     host.with_mut_storage(|s: &mut Storage| {
         s.footprint
@@ -203,12 +203,9 @@ fn create_contract_using_parent_id_test() {
     // Can't create the contract yet, as the code hasn't been installed yet.
     assert!(host
         .call(
-            host.test_bin_obj(&parent_contract_id.0)
-                .unwrap()
-                .try_into()
-                .unwrap(),
-            Symbol::try_from_small_str("create").unwrap().into(),
-            args.clone().into(),
+            host.test_bin_obj(&parent_contract_id.0).unwrap(),
+            Symbol::try_from_small_str("create").unwrap(),
+            args,
         )
         .is_err());
 
@@ -230,12 +227,9 @@ fn create_contract_using_parent_id_test() {
 
     // Now successfully create the child contract itself.
     host.call(
-        host.test_bin_obj(&parent_contract_id.0)
-            .unwrap()
-            .try_into()
-            .unwrap(),
-        Symbol::try_from_small_str("create").unwrap().into(),
-        args.into(),
+        host.test_bin_obj(&parent_contract_id.0).unwrap(),
+        Symbol::try_from_small_str("create").unwrap(),
+        args,
     )
     .unwrap();
 
@@ -269,7 +263,7 @@ fn test_contract_wasm_update() {
     };
     let old_wasm_hash_obj: RawVal = host
         .invoke_functions(vec![HostFunction {
-            args: HostFunctionArgs::UploadContractWasm(old_upload_args.clone()),
+            args: HostFunctionArgs::UploadContractWasm(old_upload_args),
             auth: Default::default(),
         }])
         .unwrap()[0]
@@ -289,7 +283,7 @@ fn test_contract_wasm_update() {
 
     let updated_wasm_hash_obj: RawVal = host
         .invoke_functions(vec![HostFunction {
-            args: HostFunctionArgs::UploadContractWasm(upload_args.clone()),
+            args: HostFunctionArgs::UploadContractWasm(upload_args),
             auth: Default::default(),
         }])
         .unwrap()[0]

--- a/soroban-env-host/src/test/map.rs
+++ b/soroban-env-host/src/test/map.rs
@@ -185,9 +185,9 @@ fn map_prev_and_next_heterogeneous() -> Result<(), HostError> {
 
     let mut test_map = host.map_new()?;
     test_map = host.map_put(test_map, 2u32.into(), 4u32.into())?;
-    test_map = host.map_put(test_map, obj_map.clone().into(), 4u32.into())?;
-    test_map = host.map_put(test_map, obj_vec.clone().into(), 4u32.into())?;
-    test_map = host.map_put(test_map, sym.clone().into(), 4u32.into())?;
+    test_map = host.map_put(test_map, obj_map, 4u32.into())?;
+    test_map = host.map_put(test_map, obj_vec, 4u32.into())?;
+    test_map = host.map_put(test_map, sym.into(), 4u32.into())?;
     // The key ordering should be [u32, symbol, vec, map]
     // prev
     {
@@ -200,18 +200,15 @@ fn map_prev_and_next_heterogeneous() -> Result<(), HostError> {
             RawVal::from_u32(2).to_raw().get_payload()
         );
         assert_eq!(
-            host.map_prev_key(test_map, sym.clone().into())?
-                .get_payload(),
+            host.map_prev_key(test_map, sym.into())?.get_payload(),
             RawVal::from_u32(2).to_raw().get_payload()
         );
         assert_eq!(
-            host.map_prev_key(test_map, obj_vec.clone().into())?
-                .get_payload(),
+            host.map_prev_key(test_map, obj_vec)?.get_payload(),
             sym.as_raw().get_payload()
         );
         assert_eq!(
-            host.map_prev_key(test_map, obj_map.clone().into())?
-                .get_payload(),
+            host.map_prev_key(test_map, obj_map)?.get_payload(),
             obj_vec.get_payload()
         );
     }
@@ -226,18 +223,15 @@ fn map_prev_and_next_heterogeneous() -> Result<(), HostError> {
             sym.as_raw().get_payload()
         );
         assert_eq!(
-            host.map_next_key(test_map, sym.clone().into())?
-                .get_payload(),
+            host.map_next_key(test_map, sym.into())?.get_payload(),
             obj_vec.get_payload()
         );
         assert_eq!(
-            host.map_next_key(test_map, obj_vec.clone().into())?
-                .get_payload(),
+            host.map_next_key(test_map, obj_vec)?.get_payload(),
             obj_map.get_payload()
         );
         assert_eq!(
-            host.map_next_key(test_map, obj_map.clone().into())?
-                .get_payload(),
+            host.map_next_key(test_map, obj_map)?.get_payload(),
             Status::UNKNOWN_ERROR.to_raw().get_payload()
         );
     }

--- a/soroban-env-host/src/test/storage.rs
+++ b/soroban-env-host/src/test/storage.rs
@@ -15,7 +15,7 @@ fn test_peristent_storage() {
             &host,
             &host
                 .call(
-                    contract_id.clone(),
+                    contract_id,
                     Symbol::from_small_str("has"),
                     host_vec![&host, key_1].into(),
                 )
@@ -26,7 +26,7 @@ fn test_peristent_storage() {
     );
     // Put a key to storage and verify it's there
     host.call(
-        contract_id.clone(),
+        contract_id,
         Symbol::from_small_str("put"),
         host_vec![&host, key_1, 1234_u64].into(),
     )
@@ -37,7 +37,7 @@ fn test_peristent_storage() {
             &host,
             &host
                 .call(
-                    contract_id.clone(),
+                    contract_id,
                     Symbol::from_small_str("has"),
                     host_vec![&host, key_1].into(),
                 )
@@ -49,7 +49,7 @@ fn test_peristent_storage() {
 
     // Put anothrer key and verify it's there
     host.call(
-        contract_id.clone(),
+        contract_id,
         Symbol::from_small_str("put"),
         host_vec![&host, key_2, u64::MAX].into(),
     )
@@ -59,7 +59,7 @@ fn test_peristent_storage() {
             &host,
             &host
                 .call(
-                    contract_id.clone(),
+                    contract_id,
                     Symbol::from_small_str("has"),
                     host_vec![
                         &host,
@@ -82,7 +82,7 @@ fn test_peristent_storage() {
             &host,
             &host
                 .call(
-                    contract_id.clone(),
+                    contract_id,
                     Symbol::from_small_str("get"),
                     host_vec![&host, key_1].into(),
                 )
@@ -96,7 +96,7 @@ fn test_peristent_storage() {
             &host,
             &host
                 .call(
-                    contract_id.clone(),
+                    contract_id,
                     Symbol::from_small_str("get"),
                     host_vec![&host, key_2].into(),
                 )
@@ -108,7 +108,7 @@ fn test_peristent_storage() {
 
     // Update value for key 2 and check it
     host.call(
-        contract_id.clone(),
+        contract_id,
         Symbol::from_small_str("put"),
         host_vec![&host, key_2, 4321_u64].into(),
     )
@@ -118,7 +118,7 @@ fn test_peristent_storage() {
             &host,
             &host
                 .call(
-                    contract_id.clone(),
+                    contract_id,
                     Symbol::from_small_str("get"),
                     host_vec![&host, key_2].into(),
                 )
@@ -130,7 +130,7 @@ fn test_peristent_storage() {
 
     // Delete entry for key 1
     host.call(
-        contract_id.clone(),
+        contract_id,
         Symbol::from_small_str("del"),
         host_vec![&host, key_1].into(),
     )
@@ -141,7 +141,7 @@ fn test_peristent_storage() {
             &host,
             &host
                 .call(
-                    contract_id.clone(),
+                    contract_id,
                     Symbol::from_small_str("has"),
                     host_vec![&host, key_1].into(),
                 )
@@ -155,7 +155,7 @@ fn test_peristent_storage() {
             &host,
             &host
                 .call(
-                    contract_id.clone(),
+                    contract_id,
                     Symbol::from_small_str("has"),
                     host_vec![&host, key_2].into(),
                 )
@@ -178,7 +178,7 @@ fn test_temp_storage() {
             &host,
             &host
                 .call(
-                    contract_id.clone(),
+                    contract_id,
                     Symbol::from_small_str("has_tmp"),
                     host_vec![&host, key_1].into(),
                 )
@@ -189,7 +189,7 @@ fn test_temp_storage() {
     );
     // Put a key to storage and verify it's there
     host.call(
-        contract_id.clone(),
+        contract_id,
         Symbol::from_small_str("put_tmp"),
         host_vec![&host, key_1, Symbol::from_small_str("val_1")].into(),
     )
@@ -200,7 +200,7 @@ fn test_temp_storage() {
             &host,
             &host
                 .call(
-                    contract_id.clone(),
+                    contract_id,
                     Symbol::from_small_str("has_tmp"),
                     // Use a new object to sanity-check that comparison
                     // happens based on value.
@@ -214,7 +214,7 @@ fn test_temp_storage() {
 
     // Put anothrer key and verify it's there
     host.call(
-        contract_id.clone(),
+        contract_id,
         Symbol::from_small_str("put_tmp"),
         host_vec![&host, key_2, Symbol::from_small_str("val_2")].into(),
     )
@@ -224,7 +224,7 @@ fn test_temp_storage() {
             &host,
             &host
                 .call(
-                    contract_id.clone(),
+                    contract_id,
                     Symbol::from_small_str("has_tmp"),
                     host_vec![&host, key_2].into(),
                 )
@@ -241,7 +241,7 @@ fn test_temp_storage() {
             &host,
             &host
                 .call(
-                    contract_id.clone(),
+                    contract_id,
                     Symbol::from_small_str("get_tmp"),
                     host_vec![&host, key_1].into(),
                 )
@@ -256,7 +256,7 @@ fn test_temp_storage() {
             &host,
             &host
                 .call(
-                    contract_id.clone(),
+                    contract_id,
                     Symbol::from_small_str("get_tmp"),
                     host_vec![&host, 1000_i128].into(),
                 )
@@ -269,7 +269,7 @@ fn test_temp_storage() {
 
     // Update value for key 2 and check it
     host.call(
-        contract_id.clone(),
+        contract_id,
         Symbol::from_small_str("put_tmp"),
         host_vec![&host, key_2, Symbol::from_small_str("new_val")].into(),
     )
@@ -279,7 +279,7 @@ fn test_temp_storage() {
             &host,
             &host
                 .call(
-                    contract_id.clone(),
+                    contract_id,
                     Symbol::from_small_str("get_tmp"),
                     host_vec![&host, key_2].into(),
                 )
@@ -292,7 +292,7 @@ fn test_temp_storage() {
 
     // Delete entry for key 1
     host.call(
-        contract_id.clone(),
+        contract_id,
         Symbol::from_small_str("del_tmp"),
         host_vec![&host, key_1].into(),
     )
@@ -303,7 +303,7 @@ fn test_temp_storage() {
             &host,
             &host
                 .call(
-                    contract_id.clone(),
+                    contract_id,
                     Symbol::from_small_str("has_tmp"),
                     host_vec![&host, key_1].into(),
                 )
@@ -317,7 +317,7 @@ fn test_temp_storage() {
             &host,
             &host
                 .call(
-                    contract_id.clone(),
+                    contract_id,
                     Symbol::from_small_str("has_tmp"),
                     host_vec![&host, key_2].into(),
                 )
@@ -335,7 +335,7 @@ fn test_temp_storage() {
             &host,
             &host
                 .call(
-                    contract_id.clone(),
+                    contract_id,
                     Symbol::from_small_str("has_tmp"),
                     host_vec![&host, key_2].into(),
                 )

--- a/soroban-env-host/src/test/tuple.rs
+++ b/soroban-env-host/src/test/tuple.rs
@@ -12,7 +12,7 @@ fn tuple_conversions() -> Result<(), HostError> {
     obj = host.vec_push_back(obj, (1u32).into())?;
     obj = host.vec_push_back(obj, (1i32).into())?;
 
-    assert_eq!(host.obj_cmp(raw.try_into()?, obj.into())?, 0);
+    assert_eq!(host.obj_cmp(raw, obj.into())?, 0);
 
     let roundtrip: (u32, i32) = raw.try_into_val(&host)?;
     assert_eq!(roundtrip, (1u32, 1i32));
@@ -25,8 +25,7 @@ fn tuple_array_conversions() -> Result<(), HostError> {
     let host = Host::default();
 
     let raw: [RawVal; 0] = ().try_into_val(&host)?;
-    let unit: () = raw.try_into_val(&host)?;
-    assert_eq!(unit, ());
+    let _unit: () = raw.try_into_val(&host)?;
 
     let raw: [RawVal; 2] = (1u32, 1i32).try_into_val(&host)?;
     let roundtrip: (u32, i32) = raw.try_into_val(&host)?;

--- a/soroban-env-host/src/vm.rs
+++ b/soroban-env-host/src/vm.rs
@@ -291,7 +291,7 @@ impl Vm {
             raw_args.push(host.to_host_val(scv)?);
         }
         let raw_res = self.invoke_function_raw(host, &func_sym, raw_args.as_slice())?;
-        Ok(host.from_host_val(raw_res)?)
+        host.from_host_val(raw_res)
     }
 
     /// Returns a list of functions in the WASM module loaded into the [Vm].
@@ -332,7 +332,7 @@ impl Vm {
     where
         F: FnOnce(&mut VmCaller<Host>) -> T,
     {
-        let store: &mut Store<Host> = &mut *self.store.borrow_mut();
+        let store: &mut Store<Host> = &mut self.store.borrow_mut();
         let mut ctx: StoreContextMut<Host> = store.into();
         let caller: Caller<Host> = Caller::new(&mut ctx, Some(self.instance));
         let mut vmcaller: VmCaller<Host> = VmCaller(Some(caller));

--- a/soroban-env-host/tests/fees.rs
+++ b/soroban-env-host/tests/fees.rs
@@ -82,7 +82,7 @@ fn resource_fee_computation() {
                 fee_per_propagate_1kb: 900,
             },
         ),
-        (1304913, 62824)
+        (1_304_913, 62824)
     );
 
     // Integer limits
@@ -112,6 +112,6 @@ fn resource_fee_computation() {
         // after multiplication and hence it's i64::MAX / 1024.
         // Hitting the integer size limits shouldn't be an issue in practice;
         // we need to just make sure there are no overflows.
-        (i64::MAX, 9007199254740992)
+        (i64::MAX, 9_007_199_254_740_992)
     );
 }

--- a/soroban-env-host/tests/integration.rs
+++ b/soroban-env-host/tests/integration.rs
@@ -52,7 +52,7 @@ fn debug_fmt() {
     match &events.last().unwrap().event {
         Event::Debug(de) => {
             assert_eq!(
-                format!("{}", de),
+                format!("{de}"),
                 "can't convert I32(1) to alloc::vec::Vec<u8>"
             )
         }

--- a/soroban-env-macros/src/call_macro_with_all_host_functions.rs
+++ b/soroban-env-macros/src/call_macro_with_all_host_functions.rs
@@ -14,14 +14,14 @@ pub fn generate(file_lit: LitStr) -> Result<TokenStream, Error> {
     let file = File::open(&file_path).map_err(|e| {
         Error::new(
             file_lit.span(),
-            format!("error reading file '{}': {}", file_str, e),
+            format!("error reading file '{file_str}': {e}"),
         )
     })?;
 
     let root: Root = serde_json::from_reader(file).map_err(|e| {
         Error::new(
             file_lit.span(),
-            format!("error parsing file '{}': {}", file_str, e),
+            format!("error parsing file '{file_str}': {e}"),
         )
     })?;
 

--- a/soroban-native-sdk-macros/src/derive_fn.rs
+++ b/soroban-native-sdk-macros/src/derive_fn.rs
@@ -4,7 +4,7 @@ use quote::{format_ident, quote};
 use syn::{spanned::Spanned, Error, FnArg, Type};
 
 pub fn derive_contract_function_set<'a>(
-    ty: &Box<Type>,
+    ty: &Type,
     methods: impl Iterator<Item = &'a syn::ImplItemFn>,
 ) -> TokenStream2 {
     let mut errors = Vec::<Error>::new();

--- a/soroban-synth-wasm/src/func_emitter.rs
+++ b/soroban-synth-wasm/src/func_emitter.rs
@@ -94,8 +94,8 @@ impl FuncEmitter {
     /// directly to get the corresponding [`LocalRef`]s.
     pub fn new(mod_emit: ModEmitter, arity: Arity, n_locals: u32) -> Self {
         let func = Function::new([(n_locals, ValType::I64)]);
-        let args = (0..arity.0).map(|n| LocalRef(n)).collect();
-        let locals = (arity.0..arity.0 + n_locals).map(|n| LocalRef(n)).collect();
+        let args = (0..arity.0).map(LocalRef).collect();
+        let locals = (arity.0..arity.0 + n_locals).map(LocalRef).collect();
         Self {
             mod_emit,
             arity,
@@ -134,9 +134,7 @@ impl FuncEmitter {
         *is_first_arg = false;
         let insn = match op.into() {
             Operand::StackTop => {
-                if !first {
-                    panic!("can only use Operand::StackTop as first arg");
-                }
+                assert!(first, "can only use Operand::StackTop as first arg");
                 return self;
             }
             Operand::Local(loc) => Instruction::LocalGet(loc.0),

--- a/soroban-synth-wasm/src/mod_emitter.rs
+++ b/soroban-synth-wasm/src/mod_emitter.rs
@@ -121,6 +121,7 @@ impl ModEmitter {
     /// Return the unique [`TypeRef`] for a function with a given [`Arity`],
     /// creating such a type in the `type` section of the module if such a type
     /// does not already exist.
+    #[allow(clippy::map_entry)]
     pub fn get_fn_type(&mut self, arity: Arity) -> TypeRef {
         if self.type_refs.contains_key(&arity) {
             self.type_refs[&arity]
@@ -138,10 +139,12 @@ impl ModEmitter {
     /// Return the unique [`FuncRef`] for a function import with a given module
     /// name, function name, and arity, creating such an import in the `import`
     /// section of the module if it does not already exist.
+    #[allow(clippy::map_entry)]
     pub fn import_func(&mut self, module: &str, fname: &str, arity: Arity) -> FuncRef {
-        if self.funcs.len() != 0 {
-            panic!("must import all functions before defining any exports");
-        }
+        assert!(
+            self.funcs.is_empty(),
+            "must import all functions before defining any exports"
+        );
         let key = (module.to_owned(), fname.to_owned(), arity);
         if self.import_refs.contains_key(&key) {
             self.import_refs[&key]


### PR DESCRIPTION
This extends https://github.com/stellar/rs-soroban-env/pull/790 and a bit of https://github.com/stellar/rs-soroban-env/pull/728, enabling the default set of clippy warnings and then disabling all the `style` ones, and adding clippy to CI and Makefile.

We can enable more checks as we have time, in groups, without having to do them all at once (and risk the PR bitrotting while waiting on review).