### PR TITLE
Anti features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ rev = "862b32f5"
 
 # [patch."https://github.com/stellar/rs-stellar-xdr"]
 # stellar-xdr = { path = "../rs-stellar-xdr/" }
+
 # [patch."https://github.com/stellar/wasmi"]
 # soroban-wasmi = { path = "../wasmi/wasmi_v1/" }
 # soroban-wasmi_core = { path = "../wasmi/core/" }

--- a/soroban-env-common/Cargo.toml
+++ b/soroban-env-common/Cargo.toml
@@ -28,7 +28,7 @@ int-enum = "0.5.0"
 [features]
 std = ["stellar-xdr/std", "stellar-xdr/base64"]
 serde = ["dep:serde", "stellar-xdr/serde"]
-vm = ["wasmi"]
+wasmi = ["dep:wasmi"]
 testutils = ["dep:arbitrary", "stellar-xdr/arbitrary"]
 
 [package.metadata.docs.rs]

--- a/soroban-env-common/src/raw_val.rs
+++ b/soroban-env-common/src/raw_val.rs
@@ -382,7 +382,7 @@ impl_tryfroms_and_tryfromvals_delegating_to_rawvalconvertible!(u32);
 impl_tryfroms_and_tryfromvals_delegating_to_rawvalconvertible!(i32);
 impl_tryfroms_and_tryfromvals_delegating_to_rawvalconvertible!(Status);
 
-#[cfg(feature = "vm")]
+#[cfg(feature = "wasmi")]
 impl wasmi::core::FromValue for RawVal {
     fn from_value(val: wasmi::core::Value) -> Option<Self> {
         if let wasmi::core::Value::I64(i) = val {
@@ -393,7 +393,7 @@ impl wasmi::core::FromValue for RawVal {
     }
 }
 
-#[cfg(feature = "vm")]
+#[cfg(feature = "wasmi")]
 impl From<RawVal> for wasmi::core::Value {
     fn from(v: RawVal) -> Self {
         wasmi::core::Value::I64(v.get_payload() as i64)

--- a/soroban-env-common/src/vmcaller_env.rs
+++ b/soroban-env-common/src/vmcaller_env.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "vm")]
+#[cfg(feature = "wasmi")]
 use crate::xdr::ScHostContextErrorCode;
 
 use super::{
@@ -8,7 +8,7 @@ use super::{
 };
 use crate::call_macro_with_all_host_functions;
 use crate::{EnvBase, Symbol};
-#[cfg(not(feature = "vm"))]
+#[cfg(not(feature = "wasmi"))]
 use core::marker::PhantomData;
 
 /// The VmCallerEnv trait is similar to the Env trait -- it
@@ -25,9 +25,9 @@ use core::marker::PhantomData;
 /// contract) to call host methods without having to write `VmCaller::none()`
 /// everywhere.
 
-#[cfg(feature = "vm")]
+#[cfg(feature = "wasmi")]
 pub struct VmCaller<'a, T>(pub Option<wasmi::Caller<'a, T>>);
-#[cfg(feature = "vm")]
+#[cfg(feature = "wasmi")]
 impl<'a, T> VmCaller<'a, T> {
     pub fn none() -> Self {
         VmCaller(None)
@@ -46,11 +46,11 @@ impl<'a, T> VmCaller<'a, T> {
     }
 }
 
-#[cfg(not(feature = "vm"))]
+#[cfg(not(feature = "wasmi"))]
 pub struct VmCaller<'a, T> {
     _nothing: PhantomData<&'a T>,
 }
-#[cfg(not(feature = "vm"))]
+#[cfg(not(feature = "wasmi"))]
 impl<'a, T> VmCaller<'a, T> {
     pub fn none() -> Self {
         VmCaller {

--- a/soroban-env-common/src/wrapper_macros.rs
+++ b/soroban-env-common/src/wrapper_macros.rs
@@ -83,7 +83,7 @@ macro_rules! impl_tryfroms_and_tryfromvals_delegating_to_rawvalconvertible {
 macro_rules! impl_wrapper_wasmi_conversions {
     ($wrapper:ty) => {
         // wasmi / VM argument support
-        #[cfg(feature = "vm")]
+        #[cfg(feature = "wasmi")]
         impl wasmi::core::FromValue for $wrapper {
             fn from_value(val: wasmi::core::Value) -> Option<Self> {
                 let maybe: Option<u64> = <u64 as wasmi::core::FromValue>::from_value(val);
@@ -102,7 +102,7 @@ macro_rules! impl_wrapper_wasmi_conversions {
                 }
             }
         }
-        #[cfg(feature = "vm")]
+        #[cfg(feature = "wasmi")]
         impl From<$wrapper> for wasmi::core::Value {
             fn from(v: $wrapper) -> Self {
                 wasmi::core::Value::I64(v.as_raw().get_payload() as i64)

--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.69"
 
 [dependencies]
 soroban-native-sdk-macros = { workspace = true }
-soroban-env-common = { workspace = true, features = ["std", "vm"] }
+soroban-env-common = { workspace = true, features = ["std", "wasmi"] }
 wasmi = { workspace = true }
 static_assertions = "1.1.0"
 sha2 = "0.9.0"

--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -12,8 +12,8 @@ rust-version = "1.69"
 
 [dependencies]
 soroban-native-sdk-macros = { workspace = true }
-soroban-env-common = { workspace = true, features = ["std"] }
-wasmi = { workspace = true, optional = true }
+soroban-env-common = { workspace = true, features = ["std", "vm"] }
+wasmi = { workspace = true }
 static_assertions = "1.1.0"
 sha2 = "0.9.0"
 ed25519-dalek = "1.0.1"
@@ -47,23 +47,21 @@ more-asserts = "0.3.1"
 linregress = "0.5.1"
 
 [features]
-vm = ["wasmi", "soroban-env-common/vm"]
 hostfn_log_fmt_values = []
-serde = ["soroban-env-common/serde"]
 testutils = ["soroban-env-common/testutils"]
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 perf-event = "0.4.7"
 
 [[bench]]
-required-features = ["vm", "testutils"]
+required-features = ["testutils"]
 harness = false
 bench = true
 name = "worst_case_linear_models"
 path = "benches/worst_case_linear_models.rs"
 
 [[bench]]
-required-features = ["vm", "testutils"]
+required-features = ["testutils"]
 harness = false
 bench = true
 name = "variation_histograms"

--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -47,7 +47,6 @@ more-asserts = "0.3.1"
 linregress = "0.5.1"
 
 [features]
-hostfn_log_fmt_values = []
 testutils = ["soroban-env-common/testutils"]
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]

--- a/soroban-env-host/src/auth.rs
+++ b/soroban-env-host/src/auth.rs
@@ -425,7 +425,6 @@ impl AuthorizationManager {
     // This should be called for every `Host` `push_frame`.
     pub(crate) fn push_frame(&mut self, host: &Host, frame: &Frame) -> Result<(), HostError> {
         let (contract_id, function_name) = match frame {
-            #[cfg(feature = "vm")]
             Frame::ContractVM(vm, fn_name, _) => {
                 (vm.contract_id.metered_clone(&self.budget)?, *fn_name)
             }

--- a/soroban-env-host/src/cost_runner/cost_types/mod.rs
+++ b/soroban-env-host/src/cost_runner/cost_types/mod.rs
@@ -5,7 +5,6 @@ mod guard_frame;
 mod host_mem_alloc;
 mod host_mem_cmp;
 mod host_mem_cpy;
-#[cfg(feature = "vm")]
 mod invoke;
 mod map_ops;
 mod val_deser;
@@ -14,9 +13,7 @@ mod val_xdr_conv;
 mod vec_ops;
 mod verify_ed25519_sig;
 mod visit_object;
-#[cfg(feature = "vm")]
 mod vm_ops;
-#[cfg(feature = "vm")]
 mod wasm_insn_exec;
 
 pub use charge_budget::*;
@@ -26,7 +23,6 @@ pub use guard_frame::*;
 pub use host_mem_alloc::*;
 pub use host_mem_cmp::*;
 pub use host_mem_cpy::*;
-#[cfg(feature = "vm")]
 pub use invoke::*;
 pub use map_ops::*;
 pub use val_deser::*;
@@ -35,7 +31,5 @@ pub use val_xdr_conv::*;
 pub use vec_ops::*;
 pub use verify_ed25519_sig::*;
 pub use visit_object::*;
-#[cfg(feature = "vm")]
 pub use vm_ops::*;
-#[cfg(feature = "vm")]
 pub use wasm_insn_exec::*;

--- a/soroban-env-host/src/events/debug.rs
+++ b/soroban-env-host/src/events/debug.rs
@@ -1,7 +1,6 @@
 use std::{borrow::Cow, fmt::Display};
 
 use crate::{xdr, RawVal, Status};
-#[cfg(feature = "vm")]
 use crate::{
     xdr::{ScUnknownErrorCode, ScVmErrorCode},
     HostError,
@@ -161,7 +160,6 @@ impl From<xdr::Error> for DebugError {
     }
 }
 
-#[cfg(feature = "vm")]
 impl From<wasmi::Error> for DebugError {
     fn from(err: wasmi::Error) -> Self {
         // At the moment we have a status code for each of the wasmi error types,

--- a/soroban-env-host/src/events/diagnostic.rs
+++ b/soroban-env-host/src/events/diagnostic.rs
@@ -57,7 +57,6 @@ impl Host {
     // Will not return error if frame is missing
     pub(crate) fn get_current_contract_id_unmetered(&self) -> Result<Option<Hash>, HostError> {
         self.with_current_frame_opt(|frame| match frame {
-            #[cfg(feature = "vm")]
             Some(Frame::ContractVM(vm, _, _)) => Ok(Some(vm.contract_id.clone())),
             Some(Frame::HostFunction(_)) => Ok(None),
             Some(Frame::Token(id, _, _)) => Ok(Some(id.clone())),

--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -24,7 +24,6 @@ use crate::{
     U64Object, U64Val, VecObject, VmCaller, VmCallerEnv, Void, I256, U256,
 };
 
-#[cfg(feature = "vm")]
 use crate::Vm;
 use crate::{EnvBase, Object, RawVal, Symbol};
 
@@ -54,7 +53,6 @@ pub use frame::{ContractFunctionSet, TestContractFrame};
 
 /// Temporary helper for denoting a slice of guest memory, as formed by
 /// various bytes operations.
-#[cfg(feature = "vm")]
 pub(crate) struct VmSlice {
     vm: Rc<Vm>,
     pos: u32,
@@ -547,7 +545,6 @@ impl Host {
         let st = match frames.as_slice() {
             // There are always two frames when WASM is executed in the VM.
             [.., f2, _] => match f2 {
-                #[cfg(feature = "vm")]
                 Frame::ContractVM(_, _, _) => Ok(InvokerType::Contract),
                 Frame::HostFunction(_) => Ok(InvokerType::Account),
                 Frame::Token(id, _, _) => Ok(InvokerType::Contract),
@@ -1243,59 +1240,54 @@ impl VmCallerEnv for Host {
         vals_pos: U32Val,
         len: U32Val,
     ) -> Result<MapObject, HostError> {
-        #[cfg(not(feature = "vm"))]
-        unimplemented!();
-        #[cfg(feature = "vm")]
-        {
-            // Step 1: extract all key symbols.
-            let VmSlice {
-                vm,
-                pos: keys_pos,
-                len,
-            } = self.decode_vmslice(keys_pos, len)?;
-            // covers `Vec::with_capacity` and `len` pushes
-            metered_clone::charge_container_bulk_init_with_elts::<Vec<Symbol>, Symbol>(
-                len as u64,
-                self.as_budget(),
-            )?;
-            let mut key_syms: Vec<Symbol> = Vec::with_capacity(len as usize);
-            self.metered_vm_scan_slices_in_linear_memory(
-                vmcaller,
-                &vm,
-                keys_pos,
-                len as usize,
-                |n, slice| {
-                    self.charge_budget(ContractCostType::VmMemRead, Some(slice.len() as u64))?;
-                    let scsym = ScSymbol(slice.try_into()?);
-                    let sym = Symbol::try_from(self.to_host_val(&ScVal::Symbol(scsym))?)?;
-                    key_syms.push(sym);
-                    Ok(())
-                },
-            )?;
+        // Step 1: extract all key symbols.
+        let VmSlice {
+            vm,
+            pos: keys_pos,
+            len,
+        } = self.decode_vmslice(keys_pos, len)?;
+        // covers `Vec::with_capacity` and `len` pushes
+        metered_clone::charge_container_bulk_init_with_elts::<Vec<Symbol>, Symbol>(
+            len as u64,
+            self.as_budget(),
+        )?;
+        let mut key_syms: Vec<Symbol> = Vec::with_capacity(len as usize);
+        self.metered_vm_scan_slices_in_linear_memory(
+            vmcaller,
+            &vm,
+            keys_pos,
+            len as usize,
+            |n, slice| {
+                self.charge_budget(ContractCostType::VmMemRead, Some(slice.len() as u64))?;
+                let scsym = ScSymbol(slice.try_into()?);
+                let sym = Symbol::try_from(self.to_host_val(&ScVal::Symbol(scsym))?)?;
+                key_syms.push(sym);
+                Ok(())
+            },
+        )?;
 
-            // Step 2: extract all val RawVals.
-            let vals_pos: u32 = vals_pos.into();
-            metered_clone::charge_container_bulk_init_with_elts::<Vec<Symbol>, Symbol>(
-                len as u64,
-                self.as_budget(),
-            )?;
-            let mut vals: Vec<RawVal> = vec![RawVal::VOID.into(); len as usize];
-            self.metered_vm_read_vals_from_linear_memory::<8, RawVal>(
-                vmcaller,
-                &vm,
-                vals_pos,
-                vals.as_mut_slice(),
-                |buf| RawVal::from_payload(u64::from_le_bytes(*buf)),
-            )?;
+        // Step 2: extract all val RawVals.
+        let vals_pos: u32 = vals_pos.into();
+        metered_clone::charge_container_bulk_init_with_elts::<Vec<Symbol>, Symbol>(
+            len as u64,
+            self.as_budget(),
+        )?;
+        let mut vals: Vec<RawVal> = vec![RawVal::VOID.into(); len as usize];
+        self.metered_vm_read_vals_from_linear_memory::<8, RawVal>(
+            vmcaller,
+            &vm,
+            vals_pos,
+            vals.as_mut_slice(),
+            |buf| RawVal::from_payload(u64::from_le_bytes(*buf)),
+        )?;
 
-            // Step 3: turn pairs into a map.
-            let pair_iter = key_syms
-                .iter()
-                .map(|s| s.to_raw())
-                .zip(vals.iter().cloned());
-            let map = HostMap::from_exact_iter(pair_iter, self)?;
-            self.add_host_object(map)
-        }
+        // Step 3: turn pairs into a map.
+        let pair_iter = key_syms
+            .iter()
+            .map(|s| s.to_raw())
+            .zip(vals.iter().cloned());
+        let map = HostMap::from_exact_iter(pair_iter, self)?;
+        self.add_host_object(map)
     }
 
     fn map_unpack_to_linear_memory(
@@ -1306,48 +1298,43 @@ impl VmCallerEnv for Host {
         vals_pos: U32Val,
         len: U32Val,
     ) -> Result<Void, HostError> {
-        #[cfg(not(feature = "vm"))]
-        unimplemented!();
-        #[cfg(feature = "vm")]
-        {
-            let VmSlice {
-                vm,
-                pos: keys_pos,
-                len,
-            } = self.decode_vmslice(keys_pos, len)?;
-            self.visit_obj(map, |mapobj: &HostMap| {
-                // Step 1: check all key symbols.
-                self.metered_vm_scan_slices_in_linear_memory(
-                    vmcaller,
-                    &vm,
-                    keys_pos,
-                    len as usize,
-                    |n, slice| {
-                        let sym = Symbol::try_from(
-                            mapobj
-                                .map
-                                .get(n)
-                                .ok_or(ScHostObjErrorCode::VecIndexOutOfBound)?
-                                .0,
-                        )?;
-                        self.check_symbol_matches(slice, sym)?;
-                        Ok(())
-                    },
-                )?;
+        let VmSlice {
+            vm,
+            pos: keys_pos,
+            len,
+        } = self.decode_vmslice(keys_pos, len)?;
+        self.visit_obj(map, |mapobj: &HostMap| {
+            // Step 1: check all key symbols.
+            self.metered_vm_scan_slices_in_linear_memory(
+                vmcaller,
+                &vm,
+                keys_pos,
+                len as usize,
+                |n, slice| {
+                    let sym = Symbol::try_from(
+                        mapobj
+                            .map
+                            .get(n)
+                            .ok_or(ScHostObjErrorCode::VecIndexOutOfBound)?
+                            .0,
+                    )?;
+                    self.check_symbol_matches(slice, sym)?;
+                    Ok(())
+                },
+            )?;
 
-                // Step 2: write all vals.
-                self.metered_vm_write_vals_to_linear_memory(
-                    vmcaller,
-                    &vm,
-                    vals_pos.into(),
-                    mapobj.map.as_slice(),
-                    |pair| u64::to_le_bytes(pair.1.get_payload()),
-                )?;
-                Ok(())
-            })?;
+            // Step 2: write all vals.
+            self.metered_vm_write_vals_to_linear_memory(
+                vmcaller,
+                &vm,
+                vals_pos.into(),
+                mapobj.map.as_slice(),
+                |pair| u64::to_le_bytes(pair.1.get_payload()),
+            )?;
+            Ok(())
+        })?;
 
-            Ok(RawVal::VOID)
-        }
+        Ok(RawVal::VOID)
     }
 
     fn vec_new(&self, _vmcaller: &mut VmCaller<Host>, c: RawVal) -> Result<VecObject, HostError> {
@@ -1555,25 +1542,20 @@ impl VmCallerEnv for Host {
         vals_pos: U32Val,
         len: U32Val,
     ) -> Result<VecObject, HostError> {
-        #[cfg(not(feature = "vm"))]
-        unimplemented!();
-        #[cfg(feature = "vm")]
-        {
-            let VmSlice { vm, pos, len } = self.decode_vmslice(vals_pos, len)?;
-            metered_clone::charge_container_bulk_init_with_elts::<Vec<Symbol>, Symbol>(
-                len as u64,
-                self.as_budget(),
-            )?;
-            let mut vals: Vec<RawVal> = vec![RawVal::VOID.to_raw(); len as usize];
-            self.metered_vm_read_vals_from_linear_memory::<8, RawVal>(
-                vmcaller,
-                &vm,
-                pos,
-                vals.as_mut_slice(),
-                |buf| RawVal::from_payload(u64::from_le_bytes(*buf)),
-            )?;
-            self.add_host_object(HostVec::from_vec(vals)?)
-        }
+        let VmSlice { vm, pos, len } = self.decode_vmslice(vals_pos, len)?;
+        metered_clone::charge_container_bulk_init_with_elts::<Vec<Symbol>, Symbol>(
+            len as u64,
+            self.as_budget(),
+        )?;
+        let mut vals: Vec<RawVal> = vec![RawVal::VOID.to_raw(); len as usize];
+        self.metered_vm_read_vals_from_linear_memory::<8, RawVal>(
+            vmcaller,
+            &vm,
+            pos,
+            vals.as_mut_slice(),
+            |buf| RawVal::from_payload(u64::from_le_bytes(*buf)),
+        )?;
+        self.add_host_object(HostVec::from_vec(vals)?)
     }
 
     fn vec_unpack_to_linear_memory(
@@ -1583,22 +1565,17 @@ impl VmCallerEnv for Host {
         vals_pos: U32Val,
         len: U32Val,
     ) -> Result<Void, HostError> {
-        #[cfg(not(feature = "vm"))]
-        unimplemented!();
-        #[cfg(feature = "vm")]
-        {
-            let VmSlice { vm, pos, len } = self.decode_vmslice(vals_pos, len)?;
-            self.visit_obj(vec, |vecobj: &HostVec| {
-                self.metered_vm_write_vals_to_linear_memory(
-                    vmcaller,
-                    &vm,
-                    vals_pos.into(),
-                    vecobj.as_slice(),
-                    |x| u64::to_le_bytes(x.get_payload()),
-                )
-            })?;
-            Ok(RawVal::VOID)
-        }
+        let VmSlice { vm, pos, len } = self.decode_vmslice(vals_pos, len)?;
+        self.visit_obj(vec, |vecobj: &HostVec| {
+            self.metered_vm_write_vals_to_linear_memory(
+                vmcaller,
+                &vm,
+                vals_pos.into(),
+                vecobj.as_slice(),
+                |x| u64::to_le_bytes(x.get_payload()),
+            )
+        })?;
+        Ok(RawVal::VOID)
     }
 
     // Notes on metering: covered by components
@@ -1789,13 +1766,8 @@ impl VmCallerEnv for Host {
         lm_pos: U32Val,
         len: U32Val,
     ) -> Result<Void, HostError> {
-        #[cfg(not(feature = "vm"))]
-        unimplemented!();
-        #[cfg(feature = "vm")]
-        {
-            self.memobj_copy_to_linear_memory::<ScString>(vmcaller, s, s_pos, lm_pos, len)?;
-            Ok(RawVal::VOID)
-        }
+        self.memobj_copy_to_linear_memory::<ScString>(vmcaller, s, s_pos, lm_pos, len)?;
+        Ok(RawVal::VOID)
     }
 
     fn symbol_copy_to_linear_memory(
@@ -1806,13 +1778,8 @@ impl VmCallerEnv for Host {
         lm_pos: U32Val,
         len: U32Val,
     ) -> Result<Void, HostError> {
-        #[cfg(not(feature = "vm"))]
-        unimplemented!();
-        #[cfg(feature = "vm")]
-        {
-            self.memobj_copy_to_linear_memory::<ScSymbol>(vmcaller, s, s_pos, lm_pos, len)?;
-            Ok(RawVal::VOID)
-        }
+        self.memobj_copy_to_linear_memory::<ScSymbol>(vmcaller, s, s_pos, lm_pos, len)?;
+        Ok(RawVal::VOID)
     }
 
     fn bytes_copy_to_linear_memory(
@@ -1823,13 +1790,8 @@ impl VmCallerEnv for Host {
         lm_pos: U32Val,
         len: U32Val,
     ) -> Result<Void, HostError> {
-        #[cfg(not(feature = "vm"))]
-        unimplemented!();
-        #[cfg(feature = "vm")]
-        {
-            self.memobj_copy_to_linear_memory::<ScBytes>(vmcaller, b, b_pos, lm_pos, len)?;
-            Ok(RawVal::VOID)
-        }
+        self.memobj_copy_to_linear_memory::<ScBytes>(vmcaller, b, b_pos, lm_pos, len)?;
+        Ok(RawVal::VOID)
     }
 
     fn bytes_copy_from_linear_memory(
@@ -1840,12 +1802,7 @@ impl VmCallerEnv for Host {
         lm_pos: U32Val,
         len: U32Val,
     ) -> Result<BytesObject, HostError> {
-        #[cfg(not(feature = "vm"))]
-        unimplemented!();
-        #[cfg(feature = "vm")]
-        {
-            self.memobj_copy_from_linear_memory::<ScBytes>(vmcaller, b, b_pos, lm_pos, len)
-        }
+        self.memobj_copy_from_linear_memory::<ScBytes>(vmcaller, b, b_pos, lm_pos, len)
     }
 
     fn bytes_new_from_linear_memory(
@@ -1854,9 +1811,6 @@ impl VmCallerEnv for Host {
         lm_pos: U32Val,
         len: U32Val,
     ) -> Result<BytesObject, HostError> {
-        #[cfg(not(feature = "vm"))]
-        unimplemented!();
-        #[cfg(feature = "vm")]
         self.memobj_new_from_linear_memory::<ScBytes>(vmcaller, lm_pos, len)
     }
 
@@ -1866,9 +1820,6 @@ impl VmCallerEnv for Host {
         lm_pos: U32Val,
         len: U32Val,
     ) -> Result<StringObject, HostError> {
-        #[cfg(not(feature = "vm"))]
-        unimplemented!();
-        #[cfg(feature = "vm")]
         self.memobj_new_from_linear_memory::<ScString>(vmcaller, lm_pos, len)
     }
 
@@ -1878,9 +1829,6 @@ impl VmCallerEnv for Host {
         lm_pos: U32Val,
         len: U32Val,
     ) -> Result<SymbolObject, HostError> {
-        #[cfg(not(feature = "vm"))]
-        unimplemented!();
-        #[cfg(feature = "vm")]
         self.memobj_new_from_linear_memory::<ScSymbol>(vmcaller, lm_pos, len)
     }
 
@@ -1891,30 +1839,25 @@ impl VmCallerEnv for Host {
         lm_pos: U32Val,
         len: U32Val,
     ) -> Result<U32Val, HostError> {
-        #[cfg(not(feature = "vm"))]
-        unimplemented!();
-        #[cfg(feature = "vm")]
-        {
-            let VmSlice { vm, pos, len } = self.decode_vmslice(lm_pos, len)?;
-            let mut found = None;
-            self.metered_vm_scan_slices_in_linear_memory(
-                vmcaller,
-                &vm,
-                pos,
-                len as usize,
-                |i, slice| {
-                    if self.symbol_matches(slice, sym)? {
-                        if found.is_none() {
-                            found = Some(self.usize_to_u32(i)?)
-                        }
+        let VmSlice { vm, pos, len } = self.decode_vmslice(lm_pos, len)?;
+        let mut found = None;
+        self.metered_vm_scan_slices_in_linear_memory(
+            vmcaller,
+            &vm,
+            pos,
+            len as usize,
+            |i, slice| {
+                if self.symbol_matches(slice, sym)? {
+                    if found.is_none() {
+                        found = Some(self.usize_to_u32(i)?)
                     }
-                    Ok(())
-                },
-            )?;
-            match found {
-                None => Err(self.err_status(ScHostFnErrorCode::InputArgsInvalid)),
-                Some(idx) => Ok(U32Val::from(idx)),
-            }
+                }
+                Ok(())
+            },
+        )?;
+        match found {
+            None => Err(self.err_status(ScHostFnErrorCode::InputArgsInvalid)),
+            Some(idx) => Ok(U32Val::from(idx)),
         }
     }
 
@@ -2213,7 +2156,6 @@ impl VmCallerEnv for Host {
         let mut outer = Vec::with_capacity(frames.len());
         for frame in frames.iter() {
             let vals = match frame {
-                #[cfg(feature = "vm")]
                 Frame::ContractVM(vm, function, _) => {
                     get_host_val_tuple(&vm.contract_id, &function)?
                 }
@@ -2276,7 +2218,6 @@ impl VmCallerEnv for Host {
         let addr = self.visit_obj(address, |addr: &ScAddress| Ok(addr.clone()))?;
         let args = self.with_current_frame(|f| {
             let args = match f {
-                #[cfg(feature = "vm")]
                 Frame::ContractVM(_, _, args) => args,
                 Frame::HostFunction(_) => {
                     return Err(self.err_general("require_auth is not suppported for host fns"))

--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -817,7 +817,7 @@ impl VmCallerEnv for Host {
         fmt: StringObject,
         args: VecObject,
     ) -> Result<Void, HostError> {
-        if cfg!(feature = "hostfn_log_fmt_values") {
+        if self.is_debug() {
             let fmt: String = self
                 .visit_obj(fmt, move |hv: &ScString| {
                     Ok(String::from_utf8(hv.clone().into()))

--- a/soroban-env-host/src/host/frame.rs
+++ b/soroban-env-host/src/host/frame.rs
@@ -441,10 +441,10 @@ impl Host {
                                 status = st;
                                 event = DebugEvent::new().msg("caught panic from contract function '{}', propagating escalated error '{}'").arg(func).arg(st.to_raw());
                             }
-                            // If we're allowed to record dynamic strings (which happens in
-                            // native test configurations), also log the panic payload into
-                            // the .
-                            else if cfg!(feature = "hostfn_log_fmt_values") {
+                            // If we're allowed to record dynamic strings (which happens 
+                            // when diagnostics are active), also log the panic payload into
+                            // the Debug buffer.
+                            else if self.is_debug() {
                                 if let Some(str) = panic_payload.downcast_ref::<&str>() {
                                     let msg: String = format!("caught panic '{}' from contract function '{:?}'", str, func);
                                     event = DebugEvent::new().msg(msg);

--- a/soroban-env-host/src/lib.rs
+++ b/soroban-env-host/src/lib.rs
@@ -6,11 +6,6 @@
 //! crate for use by host (or contract local-testing) code. Most of the type and
 //! module definitions visible here are actually defined in the common crate.
 //!
-//! The `Host` can be configured with or without support for a [vm::Vm],
-//! depending on the `"vm"` cargo feature. When enabled, the VM is currently a
-//! thin wrapper around the [wasmi](https://github.com/paritytech/wasmi)
-//! interpreter, though other VMs might be supported in the future.
-//!
 //! It may seem unusual to configure a contract host _without_ a VM, but this
 //! configuration makes more sense when considering that Soroban supports a
 //! "local testing" configuration where host and guest code are _both compiled
@@ -37,9 +32,7 @@ pub(crate) mod host_object;
 mod native_contract;
 
 pub mod auth;
-#[cfg(feature = "vm")]
 pub mod vm;
-#[cfg(feature = "vm")]
 pub use vm::Vm;
 #[cfg(any(test, feature = "testutils"))]
 pub mod cost_runner;

--- a/soroban-env-host/src/test.rs
+++ b/soroban-env-host/src/test.rs
@@ -7,28 +7,17 @@ mod crypto;
 mod ledger;
 mod map;
 mod num;
-// In theory, this test module should run fine without testutils. However,
-// currently it won't compile without 'testutils' feature as the compiler
-// doesn't see `escalate_error_to_panic` implementation, even though
-// everything seems correct from the build configuration standpoint.
-#[cfg(all(feature = "testutils", feature = "vm"))]
 mod storage;
 mod str;
 mod symbol;
 mod vec;
 
-#[cfg(feature = "vm")]
 mod auth;
-#[cfg(feature = "vm")]
 mod budget_metering;
-#[cfg(feature = "vm")]
 mod complex;
 mod event;
-#[cfg(feature = "vm")]
 mod hostile;
-#[cfg(feature = "vm")]
 mod invocation;
-#[cfg(feature = "vm")]
 mod lifecycle;
 mod token;
 mod tuple;

--- a/soroban-env-host/src/test/bytes.rs
+++ b/soroban-env-host/src/test/bytes.rs
@@ -5,9 +5,7 @@ use crate::{
 };
 use soroban_env_common::{Compare, EnvBase};
 
-#[cfg(feature = "vm")]
 use crate::Symbol;
-#[cfg(feature = "vm")]
 use soroban_test_wasms::LINEAR_MEMORY;
 
 #[test]
@@ -132,7 +130,6 @@ fn bytes_xdr_roundtrip() -> Result<(), HostError> {
     Ok(())
 }
 
-#[cfg(feature = "vm")]
 #[test]
 fn linear_memory_operations() -> Result<(), HostError> {
     use soroban_env_common::BytesObject;

--- a/soroban-env-host/src/test/storage.rs
+++ b/soroban-env-host/src/test/storage.rs
@@ -7,7 +7,7 @@ use soroban_test_wasms::CONTRACT_STORAGE;
 fn test_peristent_storage() {
     let host = Host::test_host_with_recording_footprint();
     let contract_id = host.register_test_contract_wasm(CONTRACT_STORAGE).unwrap();
-    let key_1 = Symbol::from_small_str("key_1");
+    let key_1 = Symbol::try_from_small_str("key_1").unwrap();
     let key_2 = Symbol::try_from_val(&host, &"this_is_key_2").unwrap();
     // Check that the key is not in the storage yet
     assert_eq!(
@@ -16,7 +16,7 @@ fn test_peristent_storage() {
             &host
                 .call(
                     contract_id,
-                    Symbol::from_small_str("has"),
+                    Symbol::try_from_small_str("has").unwrap(),
                     host_vec![&host, key_1].into(),
                 )
                 .unwrap()
@@ -27,7 +27,7 @@ fn test_peristent_storage() {
     // Put a key to storage and verify it's there
     host.call(
         contract_id,
-        Symbol::from_small_str("put"),
+        Symbol::try_from_small_str("put").unwrap(),
         host_vec![&host, key_1, 1234_u64].into(),
     )
     .unwrap();
@@ -38,7 +38,7 @@ fn test_peristent_storage() {
             &host
                 .call(
                     contract_id,
-                    Symbol::from_small_str("has"),
+                    Symbol::try_from_small_str("has").unwrap(),
                     host_vec![&host, key_1].into(),
                 )
                 .unwrap()
@@ -50,7 +50,7 @@ fn test_peristent_storage() {
     // Put anothrer key and verify it's there
     host.call(
         contract_id,
-        Symbol::from_small_str("put"),
+        Symbol::try_from_small_str("put").unwrap(),
         host_vec![&host, key_2, u64::MAX].into(),
     )
     .unwrap();
@@ -60,7 +60,7 @@ fn test_peristent_storage() {
             &host
                 .call(
                     contract_id,
-                    Symbol::from_small_str("has"),
+                    Symbol::try_from_small_str("has").unwrap(),
                     host_vec![
                         &host,
                         // Use a new object to sanity-check that comparison
@@ -83,7 +83,7 @@ fn test_peristent_storage() {
             &host
                 .call(
                     contract_id,
-                    Symbol::from_small_str("get"),
+                    Symbol::try_from_small_str("get").unwrap(),
                     host_vec![&host, key_1].into(),
                 )
                 .unwrap()
@@ -97,7 +97,7 @@ fn test_peristent_storage() {
             &host
                 .call(
                     contract_id,
-                    Symbol::from_small_str("get"),
+                    Symbol::try_from_small_str("get").unwrap(),
                     host_vec![&host, key_2].into(),
                 )
                 .unwrap()
@@ -109,7 +109,7 @@ fn test_peristent_storage() {
     // Update value for key 2 and check it
     host.call(
         contract_id,
-        Symbol::from_small_str("put"),
+        Symbol::try_from_small_str("put").unwrap(),
         host_vec![&host, key_2, 4321_u64].into(),
     )
     .unwrap();
@@ -119,7 +119,7 @@ fn test_peristent_storage() {
             &host
                 .call(
                     contract_id,
-                    Symbol::from_small_str("get"),
+                    Symbol::try_from_small_str("get").unwrap(),
                     host_vec![&host, key_2].into(),
                 )
                 .unwrap()
@@ -131,7 +131,7 @@ fn test_peristent_storage() {
     // Delete entry for key 1
     host.call(
         contract_id,
-        Symbol::from_small_str("del"),
+        Symbol::try_from_small_str("del").unwrap(),
         host_vec![&host, key_1].into(),
     )
     .unwrap();
@@ -142,7 +142,7 @@ fn test_peristent_storage() {
             &host
                 .call(
                     contract_id,
-                    Symbol::from_small_str("has"),
+                    Symbol::try_from_small_str("has").unwrap(),
                     host_vec![&host, key_1].into(),
                 )
                 .unwrap()
@@ -156,7 +156,7 @@ fn test_peristent_storage() {
             &host
                 .call(
                     contract_id,
-                    Symbol::from_small_str("has"),
+                    Symbol::try_from_small_str("has").unwrap(),
                     host_vec![&host, key_2].into(),
                 )
                 .unwrap()

--- a/soroban-env-host/src/test/token.rs
+++ b/soroban-env-host/src/test/token.rs
@@ -2489,7 +2489,6 @@ fn test_classic_transfers_not_possible_for_unauthorized_asset() {
     assert_eq!(test.get_trustline_balance(&trustline_key), 100_000_000);
 }
 
-#[cfg(feature = "vm")]
 #[allow(clippy::type_complexity)]
 fn simple_account_sign_fn<'a>(
     host: &'a Host,
@@ -2502,7 +2501,6 @@ fn simple_account_sign_fn<'a>(
     })
 }
 
-#[cfg(feature = "vm")]
 #[test]
 fn test_custom_account_auth() {
     use crate::native_contract::testutils::AccountContractSigner;


### PR DESCRIPTION
This removes all features from the host besides `testutils`

- The `"serde"` feature was unused
- The `"hostfn_log_fmt_values"` feature was an over-conservative setting that didn't need to be static; we already have a dynamic flag `is_debug()` that uses the dynamic diagnostic level to enable expensive logging, we should just use that
- The `"vm"` feature was there to theoretically support building a native testing config of the host without any VM -- for testing purely native contracts -- but in practice testing always builds with `"vm"` enabled and users test a mix of native and wasm contracts, so there's just no use for it.

There's no functional change here, just simplification of the codebase (and speeding-up of test cycles).