### PR TITLE
Some further cleanups to diagnostic events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,12 +379,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dyn-fmt"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a0836c9bd73a9d3ca55b0effc5b1eedf96dd13ef994389bcac6d4d33c46188"
-
-[[package]]
 name = "ed25519"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1138,7 +1132,6 @@ dependencies = [
  "backtrace",
  "bytes-lit",
  "curve25519-dalek",
- "dyn-fmt",
  "ed25519-dalek",
  "env_logger",
  "expect-test",
@@ -1162,7 +1155,6 @@ dependencies = [
  "tabwriter",
  "textplots",
  "thousands",
- "tinyvec",
  "tracking-allocator",
  "wasmprinter",
 ]
@@ -1429,21 +1421,6 @@ checksum = "65bb801831d812c562ae7d2bfb531f26e66e4e1f6b17307ba4149c5064710e5b"
 dependencies = [
  "time-core",
 ]
-
-[[package]]
-name = "tinyvec"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "toml_datetime"

--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -23,8 +23,6 @@ hex = "0.4.3"
 num-traits = "0.2.15"
 num-integer = "0.1.45"
 num-derive = "0.3.3"
-tinyvec = { version = "1.6.0", features = ["alloc"] }
-dyn-fmt = "0.3.0"
 log = "0.4.17"
 backtrace = "0.3"
 

--- a/soroban-env-host/src/host/error.rs
+++ b/soroban-env-host/src/host/error.rs
@@ -78,10 +78,10 @@ impl Debug for HostError {
                     writeln!(f, "Event log (newest first):")?;
                     wrote_heading = true;
                 }
-                writeln!(f, "   {:?}: {}", i, e.event)?;
+                writeln!(f, "   {}: {}", i, e)?;
             }
             if info.events.0.len() > MAX_EVENTS {
-                writeln!(f, "   {:?}: ... elided ...", MAX_EVENTS)?;
+                writeln!(f, "   {}: ... elided ...", MAX_EVENTS)?;
             }
             writeln!(f)?;
             writeln!(f, "Backtrace (newest first):")?;

--- a/soroban-env-host/src/host/frame.rs
+++ b/soroban-env-host/src/host/frame.rs
@@ -471,13 +471,13 @@ impl Host {
                                         "caught panic '{}' from contract function '{:?}'",
                                         str, func
                                     );
-                                    let _ = self.debug_diagnostics(&msg, args);
+                                    let _ = self.log_diagnostics(&msg, args);
                                 } else if let Some(str) = panic_payload.downcast_ref::<String>() {
                                     let msg: String = format!(
                                         "caught panic '{}' from contract function '{:?}'",
                                         str, func
                                     );
-                                    let _ = self.debug_diagnostics(&msg, args);
+                                    let _ = self.log_diagnostics(&msg, args);
                                 }
                             }
                             Err(self.error(error, "caught error from function", &[]))

--- a/soroban-env-host/src/test/invocation.rs
+++ b/soroban-env-host/src/test/invocation.rs
@@ -80,9 +80,9 @@ fn invoke_cross_contract_with_err() -> Result<(), HostError> {
     let last_event: &HostEvent = events.last().unwrap();
     // run `UPDATE_EXPECT=true cargo test` to update this.
     let expected = expect![[
-        r#"[Diagnostic Event] topics:[debug], data:["contract try_call resulted in error", vec_err, [1], Error(Object,IndexBounds)]"#
+        r#"[Diagnostic Event] topics:[error, Error(Object, IndexBounds)], data:["contract try_call failed", vec_err, [1]]"#
     ]];
-    let actual = format!("{}", last_event.event);
+    let actual = format!("{}", last_event);
     expected.assert_eq(&actual);
 
     // call
@@ -94,9 +94,9 @@ fn invoke_cross_contract_with_err() -> Result<(), HostError> {
     let last_event = events.last().unwrap();
     // run `UPDATE_EXPECT=true cargo test` to update this.
     let expected = expect![[
-        r#"[Diagnostic Event] topics:[debug], data:["contract call resulted in error", vec_err, [1], Error(Object,IndexBounds)]"#
+        r#"[Diagnostic Event] topics:[error, Error(Object, IndexBounds)], data:["contract call failed", vec_err, [1]]"#
     ]];
-    let actual = format!("{}", last_event.event);
+    let actual = format!("{}", last_event);
     expected.assert_eq(&actual);
 
     Ok(())
@@ -138,9 +138,9 @@ fn invoke_cross_contract_indirect_err() -> Result<(), HostError> {
     let last_event = events.last().unwrap();
     // run `UPDATE_EXPECT=true cargo test` to update this.
     let expected = expect![[
-        r#"[Diagnostic Event] topics:[debug], data:["contract try_call resulted in error", add_with, [2147483647, 1, Bytes()], Error(WasmVm,InternalError)]"#
+        r#"[Diagnostic Event] topics:[error, Error(WasmVm, InternalError)], data:["contract try_call failed", add_with, [2147483647, 1, Bytes()]]"#
     ]];
-    let actual = format!("{}", last_event.event);
+    let actual = format!("{}", last_event);
     expected.assert_eq(&actual);
 
     // call
@@ -152,9 +152,9 @@ fn invoke_cross_contract_indirect_err() -> Result<(), HostError> {
     let last_event = events.last().unwrap();
     // run `UPDATE_EXPECT=true cargo test` to update this.
     let expected = expect![[
-        r#"[Diagnostic Event] topics:[debug], data:["contract call resulted in error", add_with, [2147483647, 1, Bytes()], Error(WasmVm,InternalError)]"#
+        r#"[Diagnostic Event] topics:[error, Error(WasmVm, InternalError)], data:["contract call failed", add_with, [2147483647, 1, Bytes()]]"#
     ]];
-    let actual = format!("{}", last_event.event);
+    let actual = format!("{}", last_event);
     expected.assert_eq(&actual);
 
     Ok(())

--- a/soroban-env-host/src/test/lifecycle.rs
+++ b/soroban-env-host/src/test/lifecycle.rs
@@ -1,4 +1,3 @@
-use crate::events::{Event, HostEvent};
 use crate::native_contract::testutils::HostVec;
 use crate::{
     budget::{AsBudget, Budget},
@@ -314,13 +313,10 @@ fn test_contract_wasm_update() {
         )
         .unwrap();
     match events.last() {
-        Some(HostEvent {
-            event: Event::Contract(ce),
-            failed_call: _,
-        }) => {
+        Some(he) => {
             assert_eq!(
-                ce,
-                &ContractEvent {
+                he.event,
+                ContractEvent {
                     ext: ExtensionPoint::V0,
                     contract_id: Some(contract_id),
                     type_: ContractEventType::System,

--- a/soroban-env-host/src/vm.rs
+++ b/soroban-env-host/src/vm.rs
@@ -293,7 +293,7 @@ impl Vm {
                         wasmi::Error::Trap(trap) if trap.is_host() => {
                             if let Some(he) = trap.into_host() {
                                 if let Ok(he) = he.downcast::<HostError>() {
-                                    host.debug_diagnostics(
+                                    host.log_diagnostics(
                                         "VM call trapped with HostError",
                                         &[func_sym.to_raw(), he.error.to_raw()],
                                     )?;

--- a/soroban-env-host/tests/integration.rs
+++ b/soroban-env-host/tests/integration.rs
@@ -49,8 +49,7 @@ fn debug_log() {
     let events = host.get_events().unwrap().0;
     let last_event = &events.last().unwrap();
     // run `UPDATE_EXPECT=true cargo test` to update this.
-    let expected =
-        expect![[r#"[Diagnostic Event] topics:[debug], data:["can't convert value", 1]"#]];
-    let actual = format!("{}", last_event.event);
+    let expected = expect![[r#"[Diagnostic Event] topics:[log], data:["can't convert value", 1]"#]];
+    let actual = format!("{}", last_event);
     expected.assert_eq(&actual);
 }


### PR DESCRIPTION
A small set of residual cleanups noticed after the giant error change yesterday

1. Removing the dynamic formatting string stuff and tinyvec (no longer used)
2. Renaming functions and types for clarity and lack of redundancy
3. Allowing mixing host and xdr objects in topic and data so there's a place to put pre-formed `Hash` values
4. Splitting cases of `debug` diagnostics (redundant and meaningless) into specifically `log` or `error` cases
5. Fixing some typos and whitespace formatting in diagnostic messages