### PR TITLE
Calibrate wasmi fuel and tiered wasm instructions

### DIFF
--- a/soroban-env-host/benches/common/measure.rs
+++ b/soroban-env-host/benches/common/measure.rs
@@ -449,8 +449,7 @@ where
     );
     loop {
         // prepare the measurement
-        let host = Host::default();
-        host.as_budget().reset_unlimited(); // it is possible to exceed the default limits
+        let host = crate::common::util::test_host();
         let sample = match next_sample(&host) {
             Some(s) => s,
             None => break,

--- a/soroban-env-host/benches/common/mod.rs
+++ b/soroban-env-host/benches/common/mod.rs
@@ -68,8 +68,6 @@ pub(crate) fn for_each_host_cost_measurement<B: Benchmark>(
     call_bench::<B, VmInstantiationMeasure>(&mut params)?;
     call_bench::<B, VmMemReadMeasure>(&mut params)?;
     call_bench::<B, VmMemWriteMeasure>(&mut params)?;
-    call_bench::<B, WasmInsnExecMeasure>(&mut params)?;
-    call_bench::<B, WasmMemAllocMeasure>(&mut params)?;
     call_bench::<B, VisitObjectMeasure>(&mut params)?;
     call_bench::<B, GuardFrameMeasure>(&mut params)?;
     call_bench::<B, ValXdrConvMeasure>(&mut params)?;
@@ -127,7 +125,8 @@ run_wasm_insn_measurement!(
     WasmLocalGetMeasure,
     WasmLocalSetMeasure,
     WasmLocalTeeMeasure,
-    WasmCallMeasure,
+    WasmCallLocalMeasure,
+    WasmCallImportMeasure,
     WasmCallIndirectMeasure,
     WasmGlobalGetMeasure,
     WasmGlobalSetMeasure,
@@ -164,3 +163,71 @@ run_wasm_insn_measurement!(
     WasmI64RotlMeasure,
     WasmI64RotrMeasure
 );
+
+#[derive(Debug, PartialEq, PartialOrd, Eq, Ord)]
+pub(crate) enum WasmInsnTier {
+    BASE = 0,
+    ENTITY = 1,
+    LOAD = 2,
+    STORE = 3,
+    CALL = 4,
+}
+
+pub(crate) const WASM_INSN_BASE: [WasmInsnType; 30] = [
+    WasmInsnType::LocalGet,
+    WasmInsnType::LocalSet,
+    WasmInsnType::LocalTee,
+    WasmInsnType::Br,
+    WasmInsnType::BrTable,
+    WasmInsnType::Drop,
+    WasmInsnType::Select,
+    WasmInsnType::Const,
+    WasmInsnType::I64Eqz,
+    WasmInsnType::I64Eq,
+    WasmInsnType::I64Ne,
+    WasmInsnType::I64LtS,
+    WasmInsnType::I64GtS,
+    WasmInsnType::I64LeS,
+    WasmInsnType::I64GeS,
+    WasmInsnType::I64Clz,
+    WasmInsnType::I64Ctz,
+    WasmInsnType::I64Popcnt,
+    WasmInsnType::I64Add,
+    WasmInsnType::I64Sub,
+    WasmInsnType::I64Mul,
+    WasmInsnType::I64DivS,
+    WasmInsnType::I64RemS,
+    WasmInsnType::I64And,
+    WasmInsnType::I64Or,
+    WasmInsnType::I64Xor,
+    WasmInsnType::I64Shl,
+    WasmInsnType::I64ShrS,
+    WasmInsnType::I64Rotl,
+    WasmInsnType::I64Rotr,
+];
+
+pub(crate) const WASM_INSN_ENTITY: [WasmInsnType; 3] = [
+    WasmInsnType::GlobalGet,
+    WasmInsnType::GlobalSet,
+    WasmInsnType::MemorySize,
+];
+
+pub(crate) const WASM_INSN_LOAD: [WasmInsnType; 4] = [
+    WasmInsnType::I64Load,
+    WasmInsnType::I64Load8S,
+    WasmInsnType::I64Load16S,
+    WasmInsnType::I64Load32S,
+];
+
+pub(crate) const WASM_INSN_STORE: [WasmInsnType; 4] = [
+    WasmInsnType::I64Store,
+    WasmInsnType::I64Store8,
+    WasmInsnType::I64Store16,
+    WasmInsnType::I64Store32,
+];
+
+pub(crate) const WASM_INSN_CALL: [WasmInsnType; 3] = [
+    WasmInsnType::CallLocal,
+    WasmInsnType::CallImport,
+    WasmInsnType::CallIndirect,
+];

--- a/soroban-env-host/benches/common/util.rs
+++ b/soroban-env-host/benches/common/util.rs
@@ -1,4 +1,11 @@
-use soroban_env_host::RawVal;
+use soroban_env_host::{budget::AsBudget, Host, RawVal};
+
+pub(crate) fn test_host() -> Host {
+    let host = Host::default();
+    host.as_budget().reset_unlimited();
+    host.as_budget().reset_fuel_config();
+    host
+}
 
 pub(crate) const TEST_WASMS: [&'static [u8]; 10] = [
     soroban_test_wasms::ADD_I32,

--- a/soroban-env-host/benches/worst_case_linear_models.rs
+++ b/soroban-env-host/benches/worst_case_linear_models.rs
@@ -39,29 +39,155 @@ fn write_cost_params_table<T: Debug>(
     tw.flush()
 }
 
-fn write_budget_params_code(params: BTreeMap<ContractCostType, (FPCostModel, FPCostModel)>) {
+fn write_budget_params_code(
+    params: &BTreeMap<ContractCostType, (FPCostModel, FPCostModel)>,
+    wasm_tier_cost: &BTreeMap<WasmInsnTier, f64>,
+) {
     println!("");
     println!("");
+
+    let base_cpu_per_fuel = wasm_tier_cost[&WasmInsnTier::BASE] as u64;
+    let entity_cpu_per_fuel = wasm_tier_cost[&WasmInsnTier::ENTITY] as u64;
+    let load_cpu_per_fuel = wasm_tier_cost[&WasmInsnTier::LOAD] as u64;
+    let store_cpu_per_fuel = wasm_tier_cost[&WasmInsnTier::STORE] as u64;
+    let call_cpu_per_fuel = wasm_tier_cost[&WasmInsnTier::CALL] as u64;
+    println!(
+        "
+        // This is the host cpu insn cost per wasm \"fuel\". Every \"base\" wasm
+        // instruction costs 1 fuel (by default), and some particular types of
+        // instructions may cost additional amount of fuel based on
+        // wasmi's config setting. \n
+        ContractCostType::{:?} => {{ cpu.const_term = {}; cpu.linear_term = {}; }}",
+        ContractCostType::WasmInsnExec,
+        base_cpu_per_fuel,
+        0
+    );
+    println!(
+        "
+        // Host cpu insns per wasm \"memory fuel\". This has to be zero since
+        // the fuel (representing cpu cost) has been covered by `WasmInsnExec`.
+        // The extra cost of mem processing is accounted for by wasmi's
+        // `config.memory_bytes_per_fuel` parameter.
+        // This type is designated to the mem cost. \n
+        ContractCostType::{:?} => {{ cpu.const_term = {}; cpu.linear_term = {}; }}",
+        ContractCostType::WasmMemAlloc,
+        0,
+        0
+    );
+
     for (ty, (cpu, _)) in params
         .iter()
         .map(|(ty, (cpu, mem))| (ty, (cpu.params_as_u64(), mem.params_as_u64())))
     {
         println!(
-            "ContractCostType::{:?} => {{ cpu.const_term = {}; cpu.linear_term = {}; }}",
+            "
+            ContractCostType::{:?} => {{ cpu.const_term = {}; cpu.linear_term = {}; }}",
             ty, cpu.0, cpu.1
         );
     }
     println!("");
     println!("");
+
+    println!(
+        "
+        // This type is designated to the cpu cost. By definition, the memory cost\n
+        // of a (cpu) fuel is zero.\n
+        ContractCostType::{:?} => {{ mem.const_term = {}; mem.linear_term = {}; }}",
+        ContractCostType::WasmInsnExec,
+        0,
+        0
+    );
+    println!(
+        "
+        // Bytes per wasmi \"memory fuel\". By definition this has to be a const = 1\n
+        // because of the 1-to-1 equivalence of the Wasm mem fuel and a host byte.\n
+        ContractCostType::{:?} => {{ mem.const_term = {}; mem.linear_term = {}; }}",
+        ContractCostType::WasmMemAlloc,
+        1,
+        0
+    );
     for (ty, (_, mem)) in params
         .iter()
         .map(|(ty, (cpu, mem))| (ty, (cpu.params_as_u64(), mem.params_as_u64())))
     {
         println!(
-            "ContractCostType::{:?} => {{ mem.const_term = {}; mem.linear_term = {}; }}",
+            "
+            ContractCostType::{:?} => {{ mem.const_term = {}; mem.linear_term = {}; }}",
             ty, mem.0, mem.1
         );
     }
+
+    println!("");
+    println!("");
+    println!(
+        "
+        FuelConfig {{base: {}, entity: {}, load: {}, store: {}, call: {}}}",
+        1,
+        (entity_cpu_per_fuel / base_cpu_per_fuel).max(1),
+        (load_cpu_per_fuel / base_cpu_per_fuel).max(1),
+        (store_cpu_per_fuel / base_cpu_per_fuel).max(1),
+        (call_cpu_per_fuel / base_cpu_per_fuel).max(1)
+    )
+}
+
+fn extract_tier(
+    params_wasm: &BTreeMap<WasmInsnType, (FPCostModel, FPCostModel)>,
+    insn_tier: &[WasmInsnType],
+) -> (BTreeMap<WasmInsnType, (FPCostModel, FPCostModel)>, f64) {
+    let mut params_tier: BTreeMap<WasmInsnType, (FPCostModel, FPCostModel)> = BTreeMap::new();
+    for ty in insn_tier {
+        if let Some(res) = params_wasm.get(&ty) {
+            params_tier.insert(ty.clone(), res.clone());
+        }
+    }
+
+    let cpu_per_fuel: Vec<f64> = params_tier
+        .iter()
+        .map(|(_, (cpu, _))| cpu.const_param)
+        .collect();
+    let ave_cpu_per_fuel = cpu_per_fuel.iter().sum::<f64>() / cpu_per_fuel.len() as f64;
+    (params_tier, ave_cpu_per_fuel)
+}
+
+fn process_tier(
+    tier: WasmInsnTier,
+    params_wasm: &BTreeMap<WasmInsnType, (FPCostModel, FPCostModel)>,
+    insn_tier: &[WasmInsnType],
+) -> f64 {
+    println!("\n");
+    println!("\n{:=<100}", "");
+    println!("\"{:?}\" tier", tier);
+
+    let (params_tier, ave_cpu_per_fuel) = extract_tier(params_wasm, insn_tier);
+
+    let mut tw = TabWriter::new(vec![])
+        .padding(5)
+        .alignment(Alignment::Right);
+    write_cost_params_table::<WasmInsnType>(&mut tw, &params_tier).unwrap();
+    eprintln!("{}", String::from_utf8(tw.into_inner().unwrap()).unwrap());
+    println!(
+        "average cpu insns per fuel for \"{:?}\" tier: {}",
+        tier, ave_cpu_per_fuel
+    );
+    println!("{:=<100}\n", "");
+    ave_cpu_per_fuel
+}
+
+fn extract_wasmi_fuel_costs(
+    params_wasm: &BTreeMap<WasmInsnType, (FPCostModel, FPCostModel)>,
+) -> BTreeMap<WasmInsnTier, f64> {
+    let base_cost = process_tier(WasmInsnTier::BASE, params_wasm, &WASM_INSN_BASE);
+    let entity_cost = process_tier(WasmInsnTier::ENTITY, params_wasm, &WASM_INSN_ENTITY);
+    let load_cost = process_tier(WasmInsnTier::LOAD, params_wasm, &WASM_INSN_LOAD);
+    let store_cost = process_tier(WasmInsnTier::STORE, params_wasm, &WASM_INSN_STORE);
+    let call_cost = process_tier(WasmInsnTier::CALL, params_wasm, &WASM_INSN_CALL);
+    let mut res: BTreeMap<WasmInsnTier, f64> = BTreeMap::new();
+    res.insert(WasmInsnTier::BASE, base_cost);
+    res.insert(WasmInsnTier::ENTITY, entity_cost);
+    res.insert(WasmInsnTier::LOAD, load_cost);
+    res.insert(WasmInsnTier::STORE, store_cost);
+    res.insert(WasmInsnTier::CALL, call_cost);
+    res
 }
 
 #[cfg(all(test, any(target_os = "linux", target_os = "macos")))]
@@ -74,11 +200,12 @@ fn main() -> std::io::Result<()> {
         .padding(5)
         .alignment(Alignment::Right);
     write_cost_params_table::<ContractCostType>(&mut tw, &params)?;
-    write_cost_params_table::<WasmInsnType>(&mut tw, &params_wasm)?;
     eprintln!("{}", String::from_utf8(tw.into_inner().unwrap()).unwrap());
 
-    if std::env::var("WRITE_BUDGET_PARAMS").is_ok() {
-        write_budget_params_code(params);
+    let wasm_tier_cost = extract_wasmi_fuel_costs(&params_wasm);
+
+    if std::env::var("WRITE_PARAMS").is_ok() {
+        write_budget_params_code(&params, &wasm_tier_cost);
     }
     Ok(())
 }

--- a/soroban-env-host/src/test/budget_metering.rs
+++ b/soroban-env-host/src/test/budget_metering.rs
@@ -226,8 +226,8 @@ fn total_amount_charged_from_random_inputs() -> Result<(), HostError> {
     let host = Host::default();
 
     let tracker: Vec<(u64, Option<u64>)> = vec![
-        (1, Some(246)),
-        (1, Some(184)),
+        (246, None),
+        (184, None),
         (1, Some(152)),
         (1, Some(65)),
         (1, Some(74)),
@@ -255,31 +255,31 @@ fn total_amount_charged_from_random_inputs() -> Result<(), HostError> {
     let actual = format!("{:?}", host.as_budget());
     expect![[r#"
         =====================================================================================================================================================================
-        Cpu limit: 40000000; used: 8190576
-        Mem limit: 52428800; used: 275768
+        Cpu limit: 40000000; used: 7964683
+        Mem limit: 52428800; used: 218984
         =====================================================================================================================================================================
         CostType                 iterations     input          cpu_insns      mem_bytes      const_term_cpu      lin_term_cpu        const_term_mem      lin_term_mem        
-        WasmInsnExec             1              Some(246)      5412           0              0                   22                  0                   0                   
-        WasmMemAlloc             1              Some(184)      0              66320          0                   0                   66136               1                   
-        HostMemAlloc             1              Some(152)      220            160            220                 0                   8                   1                   
+        WasmInsnExec             246            None           1722           0              7                   0                   0                   0                   
+        WasmMemAlloc             184            None           0              184            0                   0                   1                   0                   
+        HostMemAlloc             1              Some(152)      2350           160            2350                0                   8                   1                   
         HostMemCpy               1              Some(65)       23             0              23                  0                   0                   0                   
-        HostMemCmp               1              Some(74)       115            0              41                  1                   0                   0                   
-        InvokeHostFunction       176            None           109296         0              621                 0                   0                   0                   
-        VisitObject              97             None           2134           0              22                  0                   0                   0                   
+        HostMemCmp               1              Some(74)       117            0              43                  1                   0                   0                   
+        InvokeHostFunction       176            None           163328         0              928                 0                   0                   0                   
+        VisitObject              97             None           1843           0              19                  0                   0                   0                   
         ValXdrConv               148            None           19832          0              134                 0                   0                   0                   
-        ValSer                   1              Some(49)       688            156            639                 1                   9                   3                   
-        ValDeser                 1              Some(103)      706            107            706                 0                   4                   1                   
-        ComputeSha256Hash        1              Some(193)      8269           40             1900                33                  40                  0                   
-        ComputeEd25519PubKey     226            None           5821760        0              25760               0                   0                   0                   
-        MapEntry                 250            None           13750          0              55                  0                   0                   0                   
-        VecEntry                 186            None           1302           0              7                   0                   0                   0                   
-        GuardFrame               152            None           689776         71744          4538                0                   472                 0                   
-        VerifyEd25519Sig         1              Some(227)      372911         0              368371              20                  0                   0                   
-        VmMemRead                1              Some(69)       119            0              119                 0                   0                   0                   
-        VmMemWrite               1              Some(160)      118            0              118                 0                   0                   0                   
-        VmInstantiation          1              Some(147)      836597         115057         736049              684                 107854              49                  
-        InvokeVmFunction         47             None           270344         22184          5752                0                   472                 0                   
-        ChargeBudget             284            None           37204          0              131                 0                   0                   0                   
+        ValSer                   1              Some(49)       636            156            587                 1                   9                   3                   
+        ValDeser                 1              Some(103)      870            107            870                 0                   4                   1                   
+        ComputeSha256Hash        1              Some(193)      8094           40             1725                33                  40                  0                   
+        ComputeEd25519PubKey     226            None           5774526        0              25551               0                   0                   0                   
+        MapEntry                 250            None           13250          0              53                  0                   0                   0                   
+        VecEntry                 186            None           930            0              5                   0                   0                   0                   
+        GuardFrame               152            None           615600         71744          4050                0                   472                 0                   
+        VerifyEd25519Sig         1              Some(227)      374401         0              369634              21                  0                   0                   
+        VmMemRead                1              Some(69)       0              0              0                   0                   0                   0                   
+        VmMemWrite               1              Some(160)      124            0              124                 0                   0                   0                   
+        VmInstantiation          1              Some(147)      671595         123751         600447              484                 117871              40                  
+        InvokeVmFunction         47             None           278522         22842          5926                0                   486                 0                   
+        ChargeBudget             284            None           36920          0              130                 0                   0                   0                   
         =====================================================================================================================================================================
 
     "#]]

--- a/soroban-env-host/src/vm.rs
+++ b/soroban-env-host/src/vm.rs
@@ -27,9 +27,11 @@ use soroban_env_common::{
 use wasmi::{Engine, FuelConsumptionMode, Func, Instance, Linker, Memory, Module, Store, Value};
 
 #[cfg(any(test, feature = "testutils"))]
+use crate::VmCaller;
+#[cfg(test)]
 use crate::{
     xdr::{ScVal, ScVec},
-    TryFromVal, VmCaller,
+    TryFromVal,
 };
 #[cfg(any(test, feature = "testutils"))]
 use wasmi::{Caller, StoreContextMut};
@@ -329,7 +331,7 @@ impl Vm {
     //
     // NB: This function has to take self by [Rc] because it stores self in
     // a new Frame
-    #[cfg(any(test, feature = "testutils"))]
+    #[cfg(test)]
     pub(crate) fn invoke_function(
         self: &Rc<Self>,
         host: &Host,


### PR DESCRIPTION
Resolves https://github.com/stellar/rs-soroban-env/issues/610

- Adapts to the new Wasmi
- Add Wasm instruction tiers and generate tiered calibration
- Extract the base fuel cost and the ratios between tiers (used for `FuelCost` config for Wasmi)
- Misc. clean ups and improvements: 
    - remove `WasmInsnExec`, the single-tiered calibration of a mix-bag of sample wasm insns.
    - remove `WasmMemAlloc`, no longer needed.
    - document the difference between trapping and passing baseline measurements. Converted some from passing to trapping.
- Updated cost parameters based on [output](https://github.com/stellar/rs-soroban-env/files/11703796/output21.txt)

### What

[TODO: Short statement about what is changing.]

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
