### PR TITLE
Implement TryFrom<&Error> for ScVal

### DIFF
--- a/soroban-env-common/src/error.rs
+++ b/soroban-env-common/src/error.rs
@@ -104,6 +104,13 @@ impl TryFrom<Error> for ScVal {
     }
 }
 
+impl TryFrom<&Error> for ScVal {
+    type Error = stellar_xdr::Error;
+    fn try_from(value: &Error) -> Result<Self, stellar_xdr::Error> {
+        (*value).try_into()
+    }
+}
+
 impl From<ScError> for Error {
     fn from(er: ScError) -> Self {
         Error::from_scerror(er)


### PR DESCRIPTION
### What

`impl TryFrom<&Error> for ScVal`

### Why

`Error` cannot be stored in `#[contracttype]`s.

This impl is required for types to be stored in `#[contracttype]`. Without it the compiler produces errors like

```
error[E0277]: the trait bound `stellar_xdr::ScVal: From<&soroban_env_host::Error>` is not satisfied
    --> soroban-sdk/src/arbitrary.rs:1027:9
     |
1027 |         #[contracttype]
     |         ^^^^^^^^^^^^^^^ the trait `From<&soroban_env_host::Error>` is not implemented for `stellar_xdr::
ScVal`
     |
     = note: required for `&soroban_env_host::Error` to implement `Into<stellar_xdr::ScVal>`
     = note: required for `stellar_xdr::ScVal` to implement `TryFrom<&soroban_env_host::Error>`
     = note: required for `&soroban_env_host::Error` to implement `TryInto<stellar_xdr::ScVal>`
     = note: this error originates in the attribute macro `contracttype` (in Nightly builds, run with -Z macro-
backtrace for more info)
help: consider dereferencing here
     |
1027 |         (*#[contracttype])
     |         ++               +

For more information about this error, try `rustc --explain E0277`.
error: could not compile `soroban-sdk` (lib test) due to previous error
warning: build failed, waiting for other jobs to finish...
```

### Known limitations

na
