### PR TITLE
Add pop_mergeable host function

### DIFF
--- a/soroban-env-common/env.json
+++ b/soroban-env-common/env.json
@@ -1075,6 +1075,18 @@
                     ],
                     "return": "Void",
                     "docs": "Bumps the expiration ledger of the key specified so the entry will live for `min` ledgers from now. If the current expiration ledger is already large enough to live at least `min` more ledgers, then nothing happens."
+                },
+                {
+                    "export": "8",
+                    "name": "pop_mergeable",
+                    "args": [
+                        {
+                            "name": "k",
+                            "type": "RawVal"
+                        }
+                    ],
+                    "return": "RawVal",
+                    "docs": "Removes and returns the top of the ESS for this key."
                 }
             ]
         },

--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -1848,6 +1848,14 @@ impl VmCallerEnv for Host {
         Ok(RawVal::VOID)
     }
 
+    fn pop_mergeable(
+        &self,
+        _vmcaller: &mut VmCaller<Host>,
+        k: RawVal,
+    ) -> Result<RawVal, HostError> {
+        Ok(RawVal::from_void().into())
+    }
+
     // Notes on metering: covered by the components.
     fn create_contract(
         &self,


### PR DESCRIPTION
### What

The env side of https://github.com/stellar/rs-soroban-env/issues/822.

There were a couple conversations on if the host should be updated in a way that coupled the `get_contract_data` host function with popping from the ESS with a callback, but it's cleaner and simpler to put that logic in the SDK, and just provide the primitives in the host.

Another thing to note is that I wanted to enforce that the ESS was empty when calling `get_contract_data`, but I was told that there might be strategies where you pop a group of keys at a time, so popping all entries for a single key at once may not work (@SirTyson)