### PR TITLE
Make `RecordedAuthPayload` consistently return `None` for invoker.

### DIFF
--- a/soroban-env-host/src/auth.rs
+++ b/soroban-env-host/src/auth.rs
@@ -1119,7 +1119,11 @@ impl AccountAuthorizationTracker {
     fn get_recorded_auth_payload(&self, host: &Host) -> Result<RecordedAuthPayload, HostError> {
         Ok(RecordedAuthPayload {
             address: if let Some(addr) = self.address {
-                Some(host.visit_obj(addr, |a: &ScAddress| Ok(a.clone()))?)
+                if !self.is_invoker {
+                    Some(host.visit_obj(addr, |a: &ScAddress| Ok(a.clone()))?)
+                } else {
+                    None
+                }
             } else {
                 if !self.is_invoker {
                     return Err(host.err(


### PR DESCRIPTION
### What

Make `RecordedAuthPayload` consistently return `None` for invoker.

This check has accidentally been removed during refactoring.

### Why

Bugfix

### Known limitations

N/A
