### PR TITLE
Turn dynamic borrow panics into HostErrors

### DIFF
--- a/soroban-env-host/src/cost_runner/cost_types/vm_ops.rs
+++ b/soroban-env-host/src/cost_runner/cost_types/vm_ops.rs
@@ -52,10 +52,19 @@ impl CostRunner for VmMemReadRun {
         _iter: u64,
         mut sample: Self::SampleType,
     ) -> Self::RecycledType {
-        black_box(sample.vm.with_vmcaller(|caller| {
-            host.metered_vm_read_bytes_from_linear_memory(caller, &sample.vm, 0, &mut sample.buf)
-                .unwrap()
-        }));
+        black_box(
+            sample
+                .vm
+                .with_vmcaller(|caller| {
+                    host.metered_vm_read_bytes_from_linear_memory(
+                        caller,
+                        &sample.vm,
+                        0,
+                        &mut sample.buf,
+                    )
+                })
+                .unwrap(),
+        );
         sample
     }
 
@@ -82,10 +91,19 @@ impl CostRunner for VmMemWriteRun {
         _iter: u64,
         mut sample: Self::SampleType,
     ) -> Self::RecycledType {
-        black_box(sample.vm.with_vmcaller(|caller| {
-            host.metered_vm_write_bytes_to_linear_memory(caller, &sample.vm, 0, &mut sample.buf)
-                .unwrap()
-        }));
+        black_box(
+            sample
+                .vm
+                .with_vmcaller(|caller| {
+                    host.metered_vm_write_bytes_to_linear_memory(
+                        caller,
+                        &sample.vm,
+                        0,
+                        &mut sample.buf,
+                    )
+                })
+                .unwrap(),
+        );
         sample
     }
 

--- a/soroban-env-host/src/cost_runner/runner.rs
+++ b/soroban-env-host/src/cost_runner/runner.rs
@@ -66,6 +66,6 @@ pub trait CostRunner: Sized {
     /// actual input from the host's perspective. So use it carefully. This should be
     /// after the `run`, outside of the CPU-and-memory tracking machineary.
     fn get_tracker(host: &Host) -> (u64, Option<u64>) {
-        host.0.budget.get_tracker(Self::COST_TYPE)
+        host.0.budget.get_tracker(Self::COST_TYPE).unwrap()
     }
 }

--- a/soroban-env-host/src/events/diagnostic.rs
+++ b/soroban-env-host/src/events/diagnostic.rs
@@ -21,17 +21,21 @@ pub enum DiagnosticLevel {
 
 /// None of these functions are metered, which is why they're behind the is_debug check
 impl Host {
-    pub fn set_diagnostic_level(&self, diagnostic_level: DiagnosticLevel) {
-        *self.0.diagnostic_level.borrow_mut() = diagnostic_level;
+    pub fn set_diagnostic_level(&self, diagnostic_level: DiagnosticLevel) -> Result<(), HostError> {
+        *self.try_borrow_diagnostic_level_mut()? = diagnostic_level;
+        Ok(())
     }
 
     // As above, avoids having to import DiagnosticLevel.
-    pub fn enable_debug(&self) {
+    pub fn enable_debug(&self) -> Result<(), HostError> {
         self.set_diagnostic_level(DiagnosticLevel::Debug)
     }
 
-    pub fn is_debug(&self) -> bool {
-        matches!(*self.0.diagnostic_level.borrow(), DiagnosticLevel::Debug)
+    pub fn is_debug(&self) -> Result<bool, HostError> {
+        Ok(matches!(
+            *self.try_borrow_diagnostic_level()?,
+            DiagnosticLevel::Debug
+        ))
     }
 
     /// Records a `System` contract event. `topics` is expected to be a `SCVec`
@@ -70,7 +74,7 @@ impl Host {
     }
 
     pub fn log_diagnostics(&self, msg: &str, args: &[Val]) -> Result<(), HostError> {
-        if !self.is_debug() {
+        if !self.is_debug()? {
             return Ok(());
         }
         let calling_contract = self.get_current_contract_id_unmetered()?;
@@ -92,7 +96,7 @@ impl Host {
         msg: &str,
         args: &[Val],
     ) -> Result<(), HostError> {
-        if !self.is_debug() {
+        if !self.is_debug()? {
             return Ok(());
         }
 
@@ -130,7 +134,7 @@ impl Host {
         func: &Symbol,
         args: &[Val],
     ) -> Result<(), HostError> {
-        if !self.is_debug() {
+        if !self.is_debug()? {
             return Ok(());
         }
 
@@ -162,7 +166,7 @@ impl Host {
         func: &Symbol,
         res: &Val,
     ) -> Result<(), HostError> {
-        if !self.is_debug() {
+        if !self.is_debug()? {
             return Ok(());
         }
 

--- a/soroban-env-host/src/events/mod.rs
+++ b/soroban-env-host/src/events/mod.rs
@@ -145,11 +145,11 @@ impl Host {
     where
         F: FnOnce(&mut InternalEventsBuffer) -> Result<U, HostError>,
     {
-        f(&mut self.0.events.borrow_mut())
+        f(&mut *self.try_borrow_events_mut()?)
     }
 
     pub fn get_events(&self) -> Result<Events, HostError> {
-        self.0.events.borrow().externalize(self)
+        self.try_borrow_events()?.externalize(self)
     }
 
     // Records a contract event.

--- a/soroban-env-host/src/storage.rs
+++ b/soroban-env-host/src/storage.rs
@@ -329,7 +329,7 @@ mod test_footprint {
     #[test]
     fn footprint_record_access() -> Result<(), HostError> {
         let budget = Budget::default();
-        budget.reset_unlimited();
+        budget.reset_unlimited()?;
         let mut fp = Footprint::default();
         // record when key not exist
         let key = Rc::new(LedgerKey::ContractData(LedgerKeyContractData {

--- a/soroban-env-host/src/test/auth.rs
+++ b/soroban-env-host/src/test/auth.rs
@@ -89,8 +89,8 @@ impl AuthTest {
         let host = Host::test_host_with_recording_footprint();
         // TODO: remove the `reset_unlimited` and instead reset inputs wherever appropriate
         // to respect the budget limit.
-        host.as_budget().reset_unlimited();
-        host.enable_debug();
+        host.as_budget().reset_unlimited().unwrap();
+        host.enable_debug().unwrap();
 
         host.with_mut_ledger_info(|li| {
             li.sequence_number = 100;
@@ -251,7 +251,7 @@ impl AuthTest {
         fn_name: Symbol,
         args: HostVec,
     ) -> Vec<RecordedAuthPayload> {
-        self.host.switch_to_recording_auth();
+        self.host.switch_to_recording_auth().unwrap();
         self.host
             .call(contract_address.clone().into(), fn_name, args.into())
             .unwrap();

--- a/soroban-env-host/src/test/budget_metering.rs
+++ b/soroban-env-host/src/test/budget_metering.rs
@@ -34,9 +34,9 @@ fn xdr_object_conversion() -> Result<(), HostError> {
         // a "value" on separate paths that both need metering,
         // we wind up double-counting the conversion of "objects".
         // Possibly this should be improved in the future.
-        assert_eq!(budget.get_tracker(ContractCostType::ValXdrConv).0, 6);
-        assert_eq!(budget.get_cpu_insns_consumed(), 60);
-        assert_eq!(budget.get_mem_bytes_consumed(), 6);
+        assert_eq!(budget.get_tracker(ContractCostType::ValXdrConv)?.0, 6);
+        assert_eq!(budget.get_cpu_insns_consumed()?, 60);
+        assert_eq!(budget.get_mem_bytes_consumed()?, 6);
         Ok(())
     })?;
     Ok(())
@@ -59,13 +59,13 @@ fn vm_hostfn_invocation() -> Result<(), HostError> {
     // try_call
     host.try_call(id_obj, sym, args)?;
     host.with_budget(|budget| {
-        assert_eq!(budget.get_tracker(ContractCostType::InvokeVmFunction).0, 1);
+        assert_eq!(budget.get_tracker(ContractCostType::InvokeVmFunction)?.0, 1);
         assert_eq!(
-            budget.get_tracker(ContractCostType::InvokeHostFunction).0,
+            budget.get_tracker(ContractCostType::InvokeHostFunction)?.0,
             2
         );
-        assert_eq!(budget.get_cpu_insns_consumed(), 30);
-        assert_eq!(budget.get_mem_bytes_consumed(), 3);
+        assert_eq!(budget.get_cpu_insns_consumed()?, 30);
+        assert_eq!(budget.get_mem_bytes_consumed()?, 3);
         Ok(())
     })?;
 
@@ -95,7 +95,7 @@ fn metered_xdr() -> Result<(), HostError> {
     host.metered_write_xdr(&scmap, &mut w)?;
     host.with_budget(|budget| {
         assert_eq!(
-            budget.get_tracker(ContractCostType::ValSer).1,
+            budget.get_tracker(ContractCostType::ValSer)?.1,
             Some(w.len() as u64)
         );
         Ok(())
@@ -104,7 +104,7 @@ fn metered_xdr() -> Result<(), HostError> {
     host.metered_from_xdr::<ScMap>(w.as_slice())?;
     host.with_budget(|budget| {
         assert_eq!(
-            budget.get_tracker(ContractCostType::ValDeser).1,
+            budget.get_tracker(ContractCostType::ValDeser)?.1,
             Some(w.len() as u64)
         );
         Ok(())
@@ -157,9 +157,9 @@ fn map_insert_key_vec_obj() -> Result<(), HostError> {
     host.with_budget(|budget| {
         // 6 = 1 visit map + 1 visit k1 + (obj_cmp which needs to) 1 visit both k0 and k1 during lookup,
         // and then 2 more to validate order of resulting map.
-        assert_eq!(budget.get_tracker(ContractCostType::VisitObject).0, 6);
+        assert_eq!(budget.get_tracker(ContractCostType::VisitObject)?.0, 6);
         // upper bound of number of map-accesses, counting both binary-search, point-access and validate-scan.
-        assert_eq!(budget.get_tracker(ContractCostType::MapEntry).0, 8);
+        assert_eq!(budget.get_tracker(ContractCostType::MapEntry)?.0, 8);
         Ok(())
     })?;
 
@@ -200,7 +200,7 @@ fn test_recursive_type_clone() -> Result<(), HostError> {
     //*********************************************************************************************************************************************/
     expect!["864"].assert_eq(
         host.as_budget()
-            .get_tracker(ContractCostType::HostMemAlloc)
+            .get_tracker(ContractCostType::HostMemAlloc)?
             .1
             .unwrap()
             .to_string()
@@ -210,7 +210,7 @@ fn test_recursive_type_clone() -> Result<(), HostError> {
     // memory layout of the top level type (Vec).
     expect!["888"].assert_eq(
         host.as_budget()
-            .get_tracker(ContractCostType::HostMemCpy)
+            .get_tracker(ContractCostType::HostMemCpy)?
             .1
             .unwrap()
             .to_string()

--- a/soroban-env-host/src/test/complex.rs
+++ b/soroban-env-host/src/test/complex.rs
@@ -24,7 +24,7 @@ fn run_complex() -> Result<(), HostError> {
     // Run 1: record footprint, emulating "preflight".
     let foot = {
         let host = Host::test_host_with_recording_footprint();
-        host.set_ledger_info(info.clone());
+        host.set_ledger_info(info.clone())?;
         let contract_id_obj = host.register_test_contract_wasm_from_source_account(
             COMPLEX,
             account_id.clone(),
@@ -43,7 +43,7 @@ fn run_complex() -> Result<(), HostError> {
     {
         let store = Storage::with_enforcing_footprint_and_map(foot, MeteredOrdMap::default());
         let host = Host::with_storage_and_budget(store, Budget::default());
-        host.set_ledger_info(info);
+        host.set_ledger_info(info)?;
         let contract_id_obj =
             host.register_test_contract_wasm_from_source_account(COMPLEX, account_id, salt);
         host.call(

--- a/soroban-env-host/src/test/hostile.rs
+++ b/soroban-env-host/src/test/hostile.rs
@@ -99,9 +99,9 @@ fn hostile_objs_traps() -> Result<(), HostError> {
     let host = Host::test_host_with_recording_footprint();
     let contract_id_obj = host.register_test_contract_wasm(HOSTILE);
 
-    host.set_diagnostic_level(crate::DiagnosticLevel::Debug);
-    host.with_budget(|b| Ok(b.reset_default()))?;
-    host.with_budget(|b| Ok(b.reset_unlimited_cpu()))?;
+    host.set_diagnostic_level(crate::DiagnosticLevel::Debug)?;
+    host.with_budget(|b| b.reset_default())?;
+    host.with_budget(|b| b.reset_unlimited_cpu())?;
 
     // This one should just run out of memory
     let res = host.call(

--- a/soroban-env-host/src/test/invocation.rs
+++ b/soroban-env-host/src/test/invocation.rs
@@ -32,7 +32,7 @@ fn invoke_single_contract_function() -> Result<(), HostError> {
 fn invoke_cross_contract(diagnostics: bool) -> Result<(), HostError> {
     let host = Host::test_host_with_recording_footprint();
     if diagnostics {
-        host.set_diagnostic_level(crate::DiagnosticLevel::Debug);
+        host.set_diagnostic_level(crate::DiagnosticLevel::Debug)?;
     }
 
     let id_obj = host.register_test_contract_wasm(ADD_I32);
@@ -59,7 +59,7 @@ fn invoke_cross_contract_with_diagnostics() -> Result<(), HostError> {
 #[test]
 fn invoke_cross_contract_with_err() -> Result<(), HostError> {
     let host = Host::test_host_with_recording_footprint();
-    host.enable_debug();
+    host.enable_debug()?;
     let id_obj = host.register_test_contract_wasm(VEC);
     // prepare arguments
     let sym = Symbol::try_from_small_str("vec_err").unwrap();
@@ -118,7 +118,7 @@ fn invoke_cross_contract_indirect() -> Result<(), HostError> {
 #[test]
 fn invoke_cross_contract_indirect_err() -> Result<(), HostError> {
     let host = Host::test_host_with_recording_footprint();
-    host.enable_debug();
+    host.enable_debug()?;
     let id0_obj = host.register_test_contract_wasm(INVOKE_CONTRACT);
     let sym = Symbol::try_from_small_str("add_with").unwrap();
     let args = host.test_vec_obj::<i32>(&[i32::MAX, 1])?;

--- a/soroban-env-host/src/test/ledger.rs
+++ b/soroban-env-host/src/test/ledger.rs
@@ -22,7 +22,7 @@ fn ledger_network_id() -> Result<(), HostError> {
         min_persistent_entry_expiration: 4096,
         min_temp_entry_expiration: 16,
         max_entry_expiration: 6312000,
-    });
+    })?;
     let obj = host.get_ledger_network_id()?;
     let np = host.visit_obj(obj, |np: &ScBytes| Ok(np.to_vec()))?;
     assert_eq!(np, vec![7; 32],);

--- a/soroban-env-host/src/test/lifecycle.rs
+++ b/soroban-env-host/src/test/lifecycle.rs
@@ -75,7 +75,8 @@ fn test_host() -> Host {
     host.set_ledger_info(LedgerInfo {
         network_id: generate_bytes_array(),
         ..Default::default()
-    });
+    })
+    .unwrap();
 
     host
 }
@@ -83,7 +84,7 @@ fn test_host() -> Host {
 fn test_create_contract_from_source_account(host: &Host, wasm: &[u8]) -> Hash {
     let source_account = generate_account_id();
     let salt = generate_bytes_array();
-    host.set_source_account(source_account.clone());
+    host.set_source_account(source_account.clone()).unwrap();
     let contract_id_preimage = ContractIdPreimage::Address(ContractIdPreimageFromAddress {
         address: ScAddress::Account(source_account.clone()),
         salt: Uint256(salt.to_vec().try_into().unwrap()),

--- a/soroban-env-host/src/test/prng.rs
+++ b/soroban-env-host/src/test/prng.rs
@@ -60,8 +60,8 @@ impl ContractFunctionSet for PRNGUsingTest {
 fn prng_test() -> Result<(), HostError> {
     let host = Host::default();
 
-    host.enable_debug();
-    host.set_base_prng_seed([0; 32]);
+    host.enable_debug()?;
+    host.set_base_prng_seed([0; 32])?;
 
     let dummy_id = [0; 32];
     let dummy_address = ScAddress::Contract(Hash(dummy_id.clone()));

--- a/soroban-env-host/src/test/storage.rs
+++ b/soroban-env-host/src/test/storage.rs
@@ -206,7 +206,7 @@ fn test_storage_mix() {
     // This makes sure the keyspaces are not mixed between storage types.
     let host = Host::test_host_with_recording_footprint();
     host.with_budget(|b| {
-        b.reset_unlimited();
+        b.reset_unlimited().unwrap();
         Ok(())
     })
     .unwrap();

--- a/soroban-env-host/src/test/token.rs
+++ b/soroban-env-host/src/test/token.rs
@@ -58,7 +58,8 @@ impl TokenTest {
             min_persistent_entry_expiration: 4096,
             min_temp_entry_expiration: 16,
             max_entry_expiration: 10000,
-        });
+        })
+        .unwrap();
         Self {
             host,
             issuer_key: generate_keypair(),
@@ -290,7 +291,7 @@ impl TokenTest {
         T: Into<Val>,
         F: FnOnce() -> Result<T, HostError>,
     {
-        self.host.set_source_account(account_id);
+        self.host.set_source_account(account_id)?;
         self.host.with_frame(
             Frame::HostFunction(HostFunctionType::InvokeContract),
             || {
@@ -2748,7 +2749,7 @@ fn test_recording_auth_for_token() {
     let user = TestSigner::account(&test.user_key);
     test.create_default_account(&user);
     test.create_default_trustline(&user);
-    test.host.switch_to_recording_auth();
+    test.host.switch_to_recording_auth().unwrap();
 
     let args = host_vec![&test.host, user.address(&test.host), 100_i128];
     test.host

--- a/soroban-env-host/tests/integration.rs
+++ b/soroban-env-host/tests/integration.rs
@@ -39,7 +39,7 @@ fn map_host_fn() -> Result<(), HostError> {
 #[test]
 fn debug_log() {
     let host = Host::default();
-    host.set_diagnostic_level(DiagnosticLevel::Debug);
+    host.set_diagnostic_level(DiagnosticLevel::Debug).unwrap();
     // Call a debug-log helper.
     host.log_from_slice("can't convert value", &[Val::from_i32(1).to_val()])
         .unwrap();


### PR DESCRIPTION
Fix #817 

I'm still not 100% sure we _want_ this -- a dynamic borrow error usually means there's something structurally wrong with the control pattern calling the function, and this might basically make it "recoverable" in some partial sense where it might be cleaner to panic out to the outermost panic handler -- but in either case if someone triggers one we'll be stuck preserving it for backwards compatibility for all time, and this might be a _little_ easier to preserve?

Anyway, assuming we do, this does it.
