### PR TITLE
Misc int32 issues

### DIFF
--- a/soroban-env-host/benches/common/cost_types/vec_ops.rs
+++ b/soroban-env-host/benches/common/cost_types/vec_ops.rs
@@ -18,7 +18,7 @@ impl HostCostMeasurement for VecEntryMeasure {
     fn new_random_case(_host: &Host, rng: &mut StdRng, input: u64) -> VecEntrySample {
         let input = 1 + input * Self::STEP_SIZE;
         let ov = util::to_rawval_u32(0..(input as u32)).collect();
-        let vec: MeteredVector<_> = MeteredVector::from_vec(ov);
+        let vec: MeteredVector<_> = MeteredVector::from_vec(ov).unwrap();
         let mut idxs: Vec<usize> = (0..input as usize).collect();
         idxs.shuffle(rng);
         VecEntrySample { vec, idxs }

--- a/soroban-env-host/benches/common/measure.rs
+++ b/soroban-env-host/benches/common/measure.rs
@@ -397,7 +397,7 @@ where
     ),
 {
     let mut recycled_samples = Vec::with_capacity(samples.len());
-    host.as_budget().reset_unlimited();
+    host.as_budget().reset_unlimited().unwrap();
 
     // start the cpu and mem measurement
     mem_tracker.0.store(0, Ordering::SeqCst);

--- a/soroban-env-host/benches/common/util.rs
+++ b/soroban-env-host/benches/common/util.rs
@@ -2,8 +2,8 @@ use soroban_env_host::{budget::AsBudget, Host, Val, I256};
 
 pub(crate) fn test_host() -> Host {
     let host = Host::default();
-    host.as_budget().reset_unlimited();
-    host.as_budget().reset_fuel_config();
+    host.as_budget().reset_unlimited().unwrap();
+    host.as_budget().reset_fuel_config().unwrap();
     host
 }
 

--- a/soroban-env-host/src/host/conversion.rs
+++ b/soroban-env-host/src/host/conversion.rs
@@ -484,7 +484,7 @@ impl Host {
                 for e in v.iter() {
                     vv.push(self.to_host_val(e)?)
                 }
-                Ok(self.add_host_object(HostVec::from_vec(vv))?.into())
+                Ok(self.add_host_object(HostVec::from_vec(vv)?)?.into())
             }
             ScVal::Map(Some(m)) => {
                 metered_clone::charge_heap_alloc::<(Val, Val)>(m.len() as u64, self.as_budget())?;

--- a/soroban-env-host/src/host/mem_helper.rs
+++ b/soroban-env-host/src/host/mem_helper.rs
@@ -167,7 +167,7 @@ impl Host {
         let mem_data = vm.get_memory(self)?.data(vmcaller.try_mut()?);
         self.charge_budget(
             ContractCostType::VmMemRead,
-            Some(num_slices.saturating_mul(8) as u64),
+            Some((num_slices as u64).saturating_mul(8)),
         )?;
 
         for i in 0..num_slices {

--- a/soroban-env-host/src/host/metered_map.rs
+++ b/soroban-env-host/src/host/metered_map.rs
@@ -84,6 +84,9 @@ where
     }
 
     pub fn from_map(map: Vec<(K, V)>, ctx: &Ctx) -> Result<Self, HostError> {
+        if u32::try_from(map.len()).is_err() {
+            return Err((ScErrorType::Object, ScErrorCode::ExceededLimit).into());
+        }
         // Allocation cost already paid for by caller, here just checks that input
         // has sorted and unique keys.
         let m = MeteredOrdMap {


### PR DESCRIPTION
This just fixes a couple issues that can cause 32 bit hosts to diverge from 64 bit hosts in extreme cases (not likely one could ever hit them due to metering, but whatever). Also explicitly caps size of vectors and maps to u32::max.

Fixes #895 