### PR TITLE
Enforce object handle integrity when inserting into containers, fix #569

### DIFF
--- a/soroban-env-host/src/test/budget_metering.rs
+++ b/soroban-env-host/src/test/budget_metering.rs
@@ -155,9 +155,10 @@ fn map_insert_key_vec_obj() -> Result<(), HostError> {
     host.map_put(m, k1.into(), v1)?;
 
     host.with_budget(|budget| {
-        // 6 = 1 visit map + 1 visit k1 + (obj_cmp which needs to) 1 visit both k0 and k1 during lookup,
-        // and then 2 more to validate order of resulting map.
-        assert_eq!(budget.get_tracker(ContractCostType::VisitObject)?.0, 6);
+        // 6 = 2 visits to ensure object handle integrity + 1 visit map + 1
+        // visit k1 + (obj_cmp which needs to) 1 visit both k0 and k1 during
+        // lookup, and then 2 more to validate order of resulting map.
+        assert_eq!(budget.get_tracker(ContractCostType::VisitObject)?.0, 8);
         // upper bound of number of map-accesses, counting both binary-search, point-access and validate-scan.
         assert_eq!(budget.get_tracker(ContractCostType::MapEntry)?.0, 8);
         Ok(())

--- a/soroban-env-host/src/test/map.rs
+++ b/soroban-env-host/src/test/map.rs
@@ -302,3 +302,38 @@ fn map_stack_no_overflow_65536_boxed_keys_and_vals() {
         }
     }
 }
+
+#[test]
+fn map_build_bad_element_integrity() -> Result<(), HostError> {
+    use crate::EnvBase;
+    let host = Host::default();
+    let obj = host.map_new()?;
+
+    let ok_val = obj.to_val();
+    let payload = ok_val.get_payload();
+
+    // The low 8 bits of an object-handle payload are the
+    // tag indicating its type. We just add one to the
+    // object type here, corrupting it.
+    let bad_tag = Val::from_payload(payload + 1);
+
+    // the high 32 bits of an object-handle payload are the
+    // index number of the handle. We corrupt those here with
+    // an object index far greater than any allocated.
+    let bad_handle = Val::from_payload(payload | 0xff_u64 << 48);
+
+    // Inserting ok object referejces into maps should work.
+    assert!(host.map_put(obj, ok_val, ok_val).is_ok());
+    assert!(host.map_new_from_slices(&["hi"], &[ok_val]).is_ok());
+
+    // Inserting corrupt object references into maps should fail.
+    assert!(host.map_put(obj, ok_val, bad_tag).is_err());
+    assert!(host.map_put(obj, bad_tag, ok_val).is_err());
+    assert!(host.map_new_from_slices(&["hi"], &[bad_tag]).is_err());
+
+    assert!(host.map_put(obj, ok_val, bad_handle).is_err());
+    assert!(host.map_put(obj, bad_handle, ok_val).is_err());
+    assert!(host.map_new_from_slices(&["hi"], &[bad_handle]).is_err());
+
+    Ok(())
+}


### PR DESCRIPTION
This isn't so much a "safety" issue as a confusion-of-users issue. We want to detect any malformed object handles (bad index, bad tags) as early as possible, so users don't have to diagnose late errors when a lookup finally traps.

Anyway, this makes it impossible to insert a malformed one into a container, and since containers are how you form argument lists to making calls, it implicitly confines malformed object handles to a single contract instance.