### PR TITLE
Add ACLs to contexts to control read-access to objects.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1336,6 +1351,7 @@ name = "soroban-env-host"
 version = "0.0.17"
 dependencies = [
  "backtrace",
+ "bit-set",
  "bytes-lit",
  "curve25519-dalek",
  "ed25519-dalek",

--- a/soroban-env-common/src/val.rs
+++ b/soroban-env-common/src/val.rs
@@ -376,6 +376,9 @@ impl_tryfroms_and_tryfromvals_delegating_to_rawvalconvertible!(Error);
 pub trait WasmiMarshal: Sized {
     fn try_marshal_from_value(v: wasmi::Value) -> Option<Self>;
     fn marshal_from_self(self) -> wasmi::Value;
+    fn try_to_val(&self) -> Option<Val> {
+        None
+    }
 }
 
 #[cfg(feature = "wasmi")]
@@ -390,6 +393,10 @@ impl WasmiMarshal for Val {
 
     fn marshal_from_self(self) -> wasmi::Value {
         wasmi::Value::I64(self.get_payload() as i64)
+    }
+
+    fn try_to_val(&self) -> Option<Val> {
+        Some(*self)
     }
 }
 

--- a/soroban-env-common/src/wrapper_macros.rs
+++ b/soroban-env-common/src/wrapper_macros.rs
@@ -99,6 +99,10 @@ macro_rules! impl_wrapper_wasmi_conversions {
             fn marshal_from_self(self) -> wasmi::Value {
                 wasmi::Value::I64(self.as_val().get_payload() as i64)
             }
+
+            fn try_to_val(&self) -> Option<Val> {
+                Some(*self.as_val())
+            }
         }
     };
 }

--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -36,6 +36,7 @@ k256 = {version = "0.13.1", features=["ecdsa", "arithmetic"]}
 # is needed to build the host for wasm (a rare but supported config).
 getrandom = { version = "0.2", features=["js"] }
 sha3 = "0.10.8"
+bit-set = "0.5.3"
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/soroban-env-host/src/events/mod.rs
+++ b/soroban-env-host/src/events/mod.rs
@@ -159,15 +159,17 @@ impl Host {
         topics: VecObject,
         data: Val,
     ) -> Result<(), HostError> {
-        self.validate_contract_event_topics(topics)?;
-        let ce = InternalContractEvent {
-            type_,
-            contract_id: self.bytesobj_from_internal_contract_id()?,
-            topics,
-            data,
-        };
-        self.with_events_mut(|events| {
-            Ok(events.record(InternalEvent::Contract(ce), self.as_budget()))
-        })?
+        self.with_system_mode(|| {
+            self.validate_contract_event_topics(topics)?;
+            let ce = InternalContractEvent {
+                type_,
+                contract_id: self.bytesobj_from_internal_contract_id()?,
+                topics,
+                data,
+            };
+            self.with_events_mut(|events| {
+                Ok(events.record(InternalEvent::Contract(ce), self.as_budget()))
+            })?
+        })
     }
 }

--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -44,7 +44,6 @@ pub(crate) mod metered_vector;
 pub(crate) mod metered_xdr;
 mod num;
 mod prng;
-use bit_set::BitSet;
 pub use prng::{Seed, SEED_BYTES};
 mod validity;
 pub use error::HostError;
@@ -96,7 +95,7 @@ pub(crate) struct HostImpl {
     ledger: RefCell<Option<LedgerInfo>>,
     pub(crate) objects: RefCell<Vec<HostObject>>,
     system_mode: RefCell<bool>,
-    system_objects: RefCell<BitSet>,
+    system_objects: RefCell<Vec<HostObject>>,
     storage: RefCell<Storage>,
     pub(crate) context: RefCell<Vec<Context>>,
     // Note: budget is refcounted and is _not_ deep-cloned when you call HostImpl::deep_clone,
@@ -175,7 +174,7 @@ impl_checked_borrow_helpers!(
 );
 impl_checked_borrow_helpers!(
     system_objects,
-    BitSet,
+    Vec<HostObject>,
     try_borrow_system_objects,
     try_borrow_system_objects_mut
 );

--- a/soroban-env-host/src/host/error.rs
+++ b/soroban-env-host/src/host/error.rs
@@ -312,19 +312,19 @@ where
     HostError: From<<Val as TryFromVal<Host, T>>::Error>,
 {
     fn debug_arg_maybe_expensive_or_fallible(host: &Host, arg: &Self) -> Result<Val, HostError> {
-        Val::try_from_val(host, arg).map_err(|e| e.into())
+        host.with_system_mode(|| Val::try_from_val(host, arg).map_err(|e| e.into()))
     }
 }
 
 impl DebugArg for xdr::Hash {
     fn debug_arg_maybe_expensive_or_fallible(host: &Host, arg: &Self) -> Result<Val, HostError> {
-        host.bytes_new_from_slice(arg.as_slice()).map(|b| b.into())
+        host.with_system_mode(|| host.bytes_new_from_slice(arg.as_slice()).map(|b| b.into()))
     }
 }
 
 impl DebugArg for str {
     fn debug_arg_maybe_expensive_or_fallible(host: &Host, arg: &Self) -> Result<Val, HostError> {
-        host.string_new_from_slice(arg).map(|s| s.into())
+        host.with_system_mode(|| host.string_new_from_slice(arg).map(|s| s.into()))
     }
 }
 

--- a/soroban-env-host/src/host/frame.rs
+++ b/soroban-env-host/src/host/frame.rs
@@ -6,7 +6,7 @@ use soroban_env_common::{
 use crate::{
     auth::AuthorizationManagerSnapshot,
     budget::AsBudget,
-    err,
+    err, host_object,
     storage::{InstanceStorageMap, StorageMap},
     xdr::{ContractCostType, ContractExecutable, Hash, HostFunction, HostFunctionType, ScVal},
     Error, Host, HostError, Object, Symbol, SymbolStr, TryFromVal, TryIntoVal, Val,
@@ -124,11 +124,11 @@ impl Frame {
             Frame::TestContract(tc) => (&tc.func, &tc.args),
         };
         if let Ok(obj) = Object::try_from(sym.to_val()) {
-            bs.insert(obj.get_handle() as usize);
+            bs.insert(host_object::handle_to_index(obj.get_handle()));
         }
         for v in args.iter() {
             if let Ok(obj) = Object::try_from(*v) {
-                bs.insert(obj.get_handle() as usize);
+                bs.insert(host_object::handle_to_index(obj.get_handle()));
             }
         }
 

--- a/soroban-env-host/src/host_object.rs
+++ b/soroban-env-host/src/host_object.rs
@@ -39,6 +39,27 @@ pub enum HostObject {
     Address(xdr::ScAddress),
 }
 
+impl core::fmt::Debug for HostObject {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Vec(_) => f.debug_tuple("Vec(...)").finish(),
+            Self::Map(_) => f.debug_tuple("Map(...)").finish(),
+            Self::U64(arg0) => f.debug_tuple("U64").field(arg0).finish(),
+            Self::I64(arg0) => f.debug_tuple("I64").field(arg0).finish(),
+            Self::TimePoint(arg0) => f.debug_tuple("TimePoint").field(arg0).finish(),
+            Self::Duration(arg0) => f.debug_tuple("Duration").field(arg0).finish(),
+            Self::U128(arg0) => f.debug_tuple("U128").field(arg0).finish(),
+            Self::I128(arg0) => f.debug_tuple("I128").field(arg0).finish(),
+            Self::U256(arg0) => f.debug_tuple("U256").field(arg0).finish(),
+            Self::I256(arg0) => f.debug_tuple("I256").field(arg0).finish(),
+            Self::Bytes(arg0) => f.debug_tuple("Bytes").field(arg0).finish(),
+            Self::String(arg0) => f.debug_tuple("String").field(arg0).finish(),
+            Self::Symbol(arg0) => f.debug_tuple("Symbol").field(arg0).finish(),
+            Self::Address(arg0) => f.debug_tuple("Address").field(arg0).finish(),
+        }
+    }
+}
+
 impl HostObject {
     // Temporarily performs a shallow comparison against a Val of the
     // associated small value type, returning None if the Val is of
@@ -107,7 +128,7 @@ impl HostObject {
 }
 
 pub trait HostObjectType: MeteredClone {
-    type Wrapper: Into<Object>;
+    type Wrapper: Into<Object> + Clone;
     fn new_from_handle(handle: u32) -> Self::Wrapper;
     fn inject(self) -> HostObject;
     fn try_extract(obj: &HostObject) -> Option<&Self>;
@@ -170,6 +191,77 @@ declare_mem_host_object_type!(xdr::ScSymbol, SymbolObject, Symbol);
 declare_host_object_type!(xdr::ScAddress, AddressObject, Address);
 
 impl Host {
+    // Execute `f` in system mode, restoring the state of the flag on exit (and allowing re-entry of system-mode).
+    pub(crate) fn with_system_mode<T>(
+        &self,
+        f: impl FnOnce() -> Result<T, HostError>,
+    ) -> Result<T, HostError> {
+        let saved_flag = {
+            let mut flag = self.try_borrow_system_mode_mut()?;
+            let saved_flag = *flag;
+            *flag = true;
+            saved_flag
+        };
+        let res = f();
+        let mut flag = self.try_borrow_system_mode_mut()?;
+        *flag = saved_flag;
+        res
+    }
+
+    fn in_system_mode(&self) -> Result<bool, HostError> {
+        Ok(*self.try_borrow_system_mode()?)
+    }
+
+    fn system_obj_allowed(&self, obj: Object) -> Result<bool, HostError> {
+        if !self.in_system_mode()? {
+            return Ok(false);
+        }
+        let objs = self.try_borrow_system_objects()?;
+        Ok(objs.contains(obj.get_handle() as usize))
+    }
+
+    fn allow_system_obj(&self, obj: Object) -> Result<(), HostError> {
+        let mut objs = self.try_borrow_system_objects_mut()?;
+        objs.insert(obj.get_handle() as usize);
+        Ok(())
+    }
+
+    fn obj_allowed(&self, obj: Object) -> Result<bool, HostError> {
+        if self.system_obj_allowed(obj)? {
+            return Ok(true);
+        }
+        self.with_current_context_opt(|ctx| {
+            Ok(if let Some(ctx) = ctx {
+                ctx.acl.contains(obj.get_handle() as usize)
+            } else {
+                // When there's no context, it means we're accessing the
+                // host from outside of a contract or anything (eg. in the
+                // embedding program or a test) so all objects are allowed.
+                true
+            })
+        })
+    }
+
+    fn allow_obj(&self, obj: Object) -> Result<(), HostError> {
+        if self.in_system_mode()? {
+            return self.allow_system_obj(obj);
+        }
+        self.with_current_context_mut_opt(|ctx| {
+            if let Some(ctx) = ctx {
+                ctx.acl.insert(obj.get_handle() as usize);
+            }
+            Ok(())
+        })
+    }
+
+    pub(crate) fn allow_val(&self, val: Val) -> Result<(), HostError> {
+        if let Ok(obj) = Object::try_from(val) {
+            self.allow_obj(obj)
+        } else {
+            Ok(())
+        }
+    }
+
     /// Moves a value of some type implementing [`HostObjectType`] into the host's
     /// object array, returning a [`HostObj`] containing the new object's array
     /// index, tagged with the [`xdr::ScObjectType`].
@@ -186,7 +278,10 @@ impl Host {
         metered_clone::charge_heap_alloc::<HostObject>(1, self.as_budget())?;
         self.try_borrow_objects_mut()?.push(HOT::inject(hot));
         let handle = prev_len as u32;
-        Ok(HOT::new_from_handle(handle))
+        let wrapper = HOT::new_from_handle(handle);
+        // Any object we _create_ we're implicitly allowed to access.
+        self.allow_obj(wrapper.clone().into())?;
+        Ok(wrapper)
     }
 
     // Notes on metering: closure call needs to be metered separatedly. `VisitObject` only covers
@@ -202,8 +297,22 @@ impl Host {
         self.charge_budget(ContractCostType::VisitObject, None)?;
         let r = self.try_borrow_objects()?;
         let obj: Object = obj.into();
-        let handle: u32 = obj.get_handle();
-        f(r.get(handle as usize))
+        if self.obj_allowed(obj)? {
+            let handle: u32 = obj.get_handle();
+            f(r.get(handle as usize))
+        } else {
+            eprintln!(
+                "access denied to object {:?} = {:?}",
+                obj,
+                r.get(obj.get_handle() as usize)
+            );
+            eprintln!(
+                "context ACL: {:?}",
+                self.with_current_context(|ctx| Ok(ctx.acl.clone()))?
+            );
+            eprintln!("system ACL: {:?}", self.try_borrow_system_objects()?);
+            f(None)
+        }
     }
 
     pub(crate) fn check_val_integrity(&self, val: Val) -> Result<(), HostError> {

--- a/soroban-env-host/src/test/vec.rs
+++ b/soroban-env-host/src/test/vec.rs
@@ -17,7 +17,7 @@ fn vec_as_seen_by_host() -> Result<(), HostError> {
     let obj0: Object = val0.try_into()?;
     let obj1: Object = val1.try_into()?;
     assert_eq!(obj0.get_handle(), 0);
-    assert_eq!(obj1.get_handle(), 1);
+    assert_eq!(obj1.get_handle(), 2);
     assert_eq!(obj0.as_val().get_tag(), Tag::VecObject);
     assert_eq!(obj1.as_val().get_tag(), Tag::VecObject);
     // Check that we got 2 distinct Vec objects

--- a/soroban-env-host/src/vm/dispatch.rs
+++ b/soroban-env-host/src/vm/dispatch.rs
@@ -94,8 +94,11 @@ macro_rules! generate_dispatch_functions {
 
                     let res = match res {
                         Ok(ok) => {
-                            let val: Value = ok.marshal_from_self();
-                            if let Value::I64(v) = val {
+                            if let Some(val) = ok.try_to_val() {
+                                host.check_value_is_non_system_object(val)?;
+                            }
+                            let value: Value = ok.marshal_from_self();
+                            if let Value::I64(v) = value {
                                 Ok((v,))
                             } else {
                                 Err(BadSignature.into())


### PR DESCRIPTION
Another attempt at solving the problem of object access control (an alternative to #930).

This adds 3 separate but related mechanisms to object access control:

1. Every context (i.e. call-stack frame) gains an ACL which is a bitset indicating which objects in the host object pool the frame can access. When an object is passed from frame A to frame B (during a call) or from B to A (during a return) its corresponding access bit is set in the receiving frame -- the idea being that if you pass someone an object, you intend for them to be able to read it!
2. The set of objects in the host is split in two separate vectors: one behaving as before, and a new one called "system objects". Object references now come in two flavors depending on their low bit: 1 means system objects and 0 means user objects. The VM marshalling path is modified to check that system object handles are never returned to users (by accident) and if a user tries to forge one it won't work anyway (unless they can figure out a way to feed it into code running in system mode, which should not exist).
3. The host gains a new boolean flag indicating whether it's running in "system mode", which grants two privileges: access to system objects, and ignoring the context's ACL when looking at non-system objects. Only the auth and event subsystems run in system mode -- there are explicit short-lived transitions into it in a few places, easy to grep for.

The first mechanism (ACLs) broadly isolates objects belonging to each contract from one another. The second mechanism (system objects) lets two subsystems of the host -- auth and events -- freely allocate "their own" objects without perturbing object numbers seen by users and without worrying if they can be seen from the current context. The final mechanism (system mode) allows those subsystems to access system objects from any context, as well as access user objects (eg. for recording objects into the event buffer or authentication trees).

When the auth system calls contracts back for custom auth logic, it transitions back from system to user, and copies the objects of interest from the system table to the object table. Not ideal, but it works.

This is not 100% perfect isolation: there is still a covert channel observable in the allocation of objects. Namely if contract A calls contract B, after B returns A can tell how many objects B allocated by looking at the next available object number. This might be enough to leak information about behaviour B wanted to keep secret. I have an idea of how to close this channel also (changing the system/user split to a global/local split and replacing the ACL with a per-contract indirection table) but that'll take a bit more time. This at least "works" and closes the most egregious channel.

(There are no tests yet, I'm still trying to figure out if this is even the right / final approach to settle on)