### PR TITLE
Prohibit using disjoint signatures to cover the auth tree.

### DIFF
--- a/soroban-env-host/src/test/auth.rs
+++ b/soroban-env-host/src/test/auth.rs
@@ -708,6 +708,36 @@ fn test_single_authorized_call_tree() {
 }
 
 #[test]
+fn test_disjoint_tree_not_allowed() {
+    let mut test = AuthTest::setup(1, 2);
+    let setup = SetupNode::new(
+        &test.contracts[0],
+        vec![true],
+        vec![SetupNode::new(&test.contracts[1], vec![true], vec![])],
+    );
+    // Correct call
+    test.tree_test_enforcing(
+        &setup,
+        vec![vec![SignNode::tree_fn(
+            &test.contracts[0],
+            vec![SignNode::tree_fn(&test.contracts[1], vec![])],
+        )]],
+        true,
+    );
+    test.verify_nonces_consumed(vec![1]);
+
+    // Incorrect call - tree has been split into two separate nodes.
+    test.tree_test_enforcing(
+        &setup,
+        vec![vec![
+            SignNode::tree_fn(&test.contracts[0], vec![]),
+            SignNode::tree_fn(&test.contracts[1], vec![]),
+        ]],
+        false,
+    );
+}
+
+#[test]
 fn test_two_authorized_trees() {
     let mut test = AuthTest::setup(1, 5);
     let setup = SetupNode::new(


### PR DESCRIPTION
### What

Prohibit using disjoint signatures to cover the auth tree.

Also did a passing-by cleanup to not load the source account lazily. We should have source account available in relevant contexts that use enforcing auth.

### Why

This makes it so require auth calls like A->B can't succeed if signatures for A and B are passed separately. This is achieved via requiring all the authorized calls to belong to some active root higher up the tree (if any).

It is still possible to have multiple disjoint trees on behalf of the same address, but they must have their roots at the same call tree level.

### Known limitations

N/A
