### PR TITLE
Adapt to `wasmi::ResourceLimiter`, replacing mem_fuel metering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,12 +695,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "intx"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f38a50a899dc47a6d0ed5508e7f601a2e34c3a85303514b5d137f3c10a0c75"
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1412,9 +1406,8 @@ version = "0.0.17"
 [[package]]
 name = "soroban-wasmi"
 version = "0.30.0-soroban"
-source = "git+https://github.com/stellar/wasmi?rev=3dc639fde3bebf0bf364a9fa4ac2f0efb7ee9995#3dc639fde3bebf0bf364a9fa4ac2f0efb7ee9995"
+source = "git+https://github.com/jayz22/wasmi?rev=284c963ba080703061797e2a3cba0853edee0dd4#284c963ba080703061797e2a3cba0853edee0dd4"
 dependencies = [
- "intx",
  "smallvec",
  "spin",
  "wasmi_arena",
@@ -1840,12 +1833,12 @@ dependencies = [
 [[package]]
 name = "wasmi_arena"
 version = "0.4.0"
-source = "git+https://github.com/stellar/wasmi?rev=3dc639fde3bebf0bf364a9fa4ac2f0efb7ee9995#3dc639fde3bebf0bf364a9fa4ac2f0efb7ee9995"
+source = "git+https://github.com/jayz22/wasmi?rev=284c963ba080703061797e2a3cba0853edee0dd4#284c963ba080703061797e2a3cba0853edee0dd4"
 
 [[package]]
 name = "wasmi_core"
 version = "0.12.0"
-source = "git+https://github.com/stellar/wasmi?rev=3dc639fde3bebf0bf364a9fa4ac2f0efb7ee9995#3dc639fde3bebf0bf364a9fa4ac2f0efb7ee9995"
+source = "git+https://github.com/jayz22/wasmi?rev=284c963ba080703061797e2a3cba0853edee0dd4#284c963ba080703061797e2a3cba0853edee0dd4"
 dependencies = [
  "downcast-rs",
  "libm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1406,7 +1406,7 @@ version = "0.0.17"
 [[package]]
 name = "soroban-wasmi"
 version = "0.30.0-soroban"
-source = "git+https://github.com/jayz22/wasmi?rev=284c963ba080703061797e2a3cba0853edee0dd4#284c963ba080703061797e2a3cba0853edee0dd4"
+source = "git+https://github.com/stellar/wasmi?rev=284c963ba080703061797e2a3cba0853edee0dd4#284c963ba080703061797e2a3cba0853edee0dd4"
 dependencies = [
  "smallvec",
  "spin",
@@ -1833,12 +1833,12 @@ dependencies = [
 [[package]]
 name = "wasmi_arena"
 version = "0.4.0"
-source = "git+https://github.com/jayz22/wasmi?rev=284c963ba080703061797e2a3cba0853edee0dd4#284c963ba080703061797e2a3cba0853edee0dd4"
+source = "git+https://github.com/stellar/wasmi?rev=284c963ba080703061797e2a3cba0853edee0dd4#284c963ba080703061797e2a3cba0853edee0dd4"
 
 [[package]]
 name = "wasmi_core"
 version = "0.12.0"
-source = "git+https://github.com/jayz22/wasmi?rev=284c963ba080703061797e2a3cba0853edee0dd4#284c963ba080703061797e2a3cba0853edee0dd4"
+source = "git+https://github.com/stellar/wasmi?rev=284c963ba080703061797e2a3cba0853edee0dd4#284c963ba080703061797e2a3cba0853edee0dd4"
 dependencies = [
  "downcast-rs",
  "libm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ default-features = false
 [workspace.dependencies.wasmi]
 package = "soroban-wasmi"
 version = "0.30.0-soroban"
-git = "https://github.com/jayz22/wasmi"
+git = "https://github.com/stellar/wasmi"
 rev = "284c963ba080703061797e2a3cba0853edee0dd4"
 
 [workspace.dependencies.stellar-strkey]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,8 @@ default-features = false
 [workspace.dependencies.wasmi]
 package = "soroban-wasmi"
 version = "0.30.0-soroban"
-git = "https://github.com/stellar/wasmi"
-rev = "3dc639fde3bebf0bf364a9fa4ac2f0efb7ee9995"
+git = "https://github.com/jayz22/wasmi"
+rev = "284c963ba080703061797e2a3cba0853edee0dd4"
 
 [workspace.dependencies.stellar-strkey]
 version = "0.0.7"

--- a/soroban-env-common/src/error.rs
+++ b/soroban-env-common/src/error.rs
@@ -159,7 +159,9 @@ impl From<wasmi::core::TrapCode> for Error {
 
             wasmi::core::TrapCode::BadSignature => ScErrorCode::UnexpectedType,
 
-            wasmi::core::TrapCode::StackOverflow | wasmi::core::TrapCode::OutOfFuel => {
+            wasmi::core::TrapCode::StackOverflow
+            | wasmi::core::TrapCode::OutOfFuel
+            | wasmi::core::TrapCode::GrowthOperationLimited => {
                 return Error::from_type_and_code(ScErrorType::Budget, ScErrorCode::ExceededLimit)
             }
         };

--- a/soroban-env-host/src/budget.rs
+++ b/soroban-env-host/src/budget.rs
@@ -68,7 +68,7 @@ impl HostCostModel for ContractCostParamEntry {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
 pub struct BudgetDimension {
     /// A set of cost models that map input values (eg. event counts, object
     /// sizes) from some CostType to whatever concrete resource type is being
@@ -204,7 +204,7 @@ impl BudgetDimension {
 /// doesn't derive all the traits we want. These fields (coarsely) define the
 /// relative costs of different wasm instruction types and are for wasmi internal
 /// fuel metering use only. Units are in "fuels".
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
 pub(crate) struct FuelConfig {
     /// The base fuel costs for all instructions.
     pub base: u64,
@@ -249,7 +249,7 @@ impl FuelConfig {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
 pub(crate) struct BudgetImpl {
     pub cpu_insns: BudgetDimension,
     pub mem_bytes: BudgetDimension,
@@ -408,7 +408,7 @@ impl Display for BudgetImpl {
     }
 }
 
-#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone)]
 pub struct Budget(pub(crate) Rc<RefCell<BudgetImpl>>);
 
 impl Debug for Budget {
@@ -469,7 +469,13 @@ impl Budget {
         f(self.0.try_borrow_mut_or_err()?)
     }
 
-    fn charge_in_bulk(
+    /// Performs a bulk charge to the budget under the specified [`CostType`].
+    /// The `iterations` is the batch size. The caller needs to ensure:
+    /// 1. the batched charges have identical costs (having the same
+    /// [`CostType`] and `input`)
+    /// 2. The input passed in (Some/None) is consistent with the [`CostModel`]
+    /// underneath the [`CostType`] (linear/constant).
+    pub fn bulk_charge(
         &self,
         ty: ContractCostType,
         iterations: u64,
@@ -520,27 +526,7 @@ impl Budget {
     /// Otherwise it is a linear model.  The caller needs to ensure the input
     /// passed is consistent with the inherent model underneath.
     pub fn charge(&self, ty: ContractCostType, input: Option<u64>) -> Result<(), HostError> {
-        self.charge_in_bulk(ty, 1, input)
-    }
-
-    pub fn apply_wasmi_fuels(&self, cpu_fuel: u64, mem_fuel: u64) -> Result<(), HostError> {
-        self.charge_in_bulk(ContractCostType::WasmInsnExec, cpu_fuel, None)?;
-        self.charge_in_bulk(ContractCostType::WasmMemAlloc, mem_fuel, None)
-    }
-
-    /// Performs a bulk charge to the budget under the specified [`CostType`].
-    /// The `iterations` is the batch size. The caller needs to ensure:
-    /// 1. the batched charges have identical costs (having the same
-    /// [`CostType`] and `input`)
-    /// 2. The input passed in (Some/None) is consistent with the [`CostModel`]
-    /// underneath the [`CostType`] (linear/constant).
-    pub fn batched_charge(
-        &self,
-        ty: ContractCostType,
-        iterations: u64,
-        input: Option<u64>,
-    ) -> Result<(), HostError> {
-        self.charge_in_bulk(ty, iterations, input)
+        self.bulk_charge(ty, 1, input)
     }
 
     pub fn with_free_budget<F, T>(&self, f: F) -> Result<T, HostError>
@@ -649,7 +635,7 @@ impl Budget {
         Ok(())
     }
 
-    fn get_cpu_insns_remaining_as_fuel(&self) -> Result<u64, HostError> {
+    pub(crate) fn get_cpu_insns_remaining_as_fuel(&self) -> Result<u64, HostError> {
         let cpu_remaining = self.get_cpu_insns_remaining()?;
         let cpu_per_fuel = self
             .0
@@ -673,29 +659,6 @@ impl Budget {
         // unspendable residual budget (see the other comment in `vm::wrapped_func_call`).
         // So it should be okay.
         Ok(cpu_remaining / cpu_per_fuel)
-    }
-
-    fn get_mem_bytes_remaining_as_fuel(&self) -> Result<u64, HostError> {
-        let bytes_remaining = self.get_mem_bytes_remaining()?;
-        let bytes_per_fuel = self
-            .0
-            .try_borrow_or_err()?
-            .mem_bytes
-            .get_cost_model(ContractCostType::WasmMemAlloc)
-            .linear_term;
-
-        if bytes_per_fuel < 0 {
-            return Err((ScErrorType::Context, ScErrorCode::InvalidInput).into());
-        }
-        let bytes_per_fuel = (bytes_per_fuel as u64).max(1);
-        // See comment about rounding above.
-        Ok(bytes_remaining / bytes_per_fuel)
-    }
-
-    pub fn get_fuels_budget(&self) -> Result<(u64, u64), HostError> {
-        let cpu_fuel = self.get_cpu_insns_remaining_as_fuel()?;
-        let mem_fuel = self.get_mem_bytes_remaining_as_fuel()?;
-        Ok((cpu_fuel, mem_fuel))
     }
 
     // generate a wasmi fuel cost schedule based on our calibration

--- a/soroban-env-host/src/host/mem_helper.rs
+++ b/soroban-env-host/src/host/mem_helper.rs
@@ -3,7 +3,9 @@ use soroban_env_common::{
     U32Val,
 };
 
-use crate::{host_object::MemHostObjectType, xdr::ContractCostType, Host, HostError, VmCaller};
+use crate::{
+    host_object::MemHostObjectType, xdr::ContractCostType, Host, HostError, StoreData, VmCaller,
+};
 
 use std::rc::Rc;
 
@@ -33,7 +35,7 @@ impl Host {
 
     pub(crate) fn metered_vm_write_bytes_to_linear_memory(
         &self,
-        vmcaller: &mut VmCaller<Host>,
+        vmcaller: &mut VmCaller<StoreData>,
         vm: &Rc<Vm>,
         mem_pos: u32,
         buf: &[u8],
@@ -48,7 +50,7 @@ impl Host {
 
     pub(crate) fn metered_vm_read_bytes_from_linear_memory(
         &self,
-        vmcaller: &mut VmCaller<Host>,
+        vmcaller: &mut VmCaller<StoreData>,
         vm: &Rc<Vm>,
         mem_pos: u32,
         buf: &mut [u8],
@@ -63,7 +65,7 @@ impl Host {
 
     pub(crate) fn metered_vm_write_vals_to_linear_memory<const VAL_SZ: usize, VAL>(
         &self,
-        vmcaller: &mut VmCaller<Host>,
+        vmcaller: &mut VmCaller<StoreData>,
         vm: &Rc<Vm>,
         mem_pos: u32,
         buf: &[VAL],
@@ -104,7 +106,7 @@ impl Host {
 
     pub(crate) fn metered_vm_read_vals_from_linear_memory<const VAL_SZ: usize, VAL>(
         &self,
-        vmcaller: &mut VmCaller<Host>,
+        vmcaller: &mut VmCaller<StoreData>,
         vm: &Rc<Vm>,
         mem_pos: u32,
         buf: &mut [VAL],
@@ -158,7 +160,7 @@ impl Host {
     // cause the callback to return an error.
     pub(crate) fn metered_vm_scan_slices_in_linear_memory(
         &self,
-        vmcaller: &mut VmCaller<Host>,
+        vmcaller: &mut VmCaller<StoreData>,
         vm: &Rc<Vm>,
         mut mem_pos: u32,
         num_slices: usize,
@@ -276,7 +278,7 @@ impl Host {
 
     pub(crate) fn memobj_copy_to_linear_memory<HOT: MemHostObjectType>(
         &self,
-        vmcaller: &mut VmCaller<Host>,
+        vmcaller: &mut VmCaller<StoreData>,
         obj: HOT::Wrapper,
         obj_pos: U32Val,
         lm_pos: U32Val,
@@ -339,7 +341,7 @@ impl Host {
 
     pub(crate) fn memobj_copy_from_linear_memory<HOT: MemHostObjectType>(
         &self,
-        vmcaller: &mut VmCaller<Host>,
+        vmcaller: &mut VmCaller<StoreData>,
         obj: HOT::Wrapper,
         obj_pos: U32Val,
         lm_pos: U32Val,
@@ -353,7 +355,7 @@ impl Host {
 
     pub(crate) fn memobj_new_from_linear_memory<HOT: MemHostObjectType>(
         &self,
-        vmcaller: &mut VmCaller<Host>,
+        vmcaller: &mut VmCaller<StoreData>,
         lm_pos: U32Val,
         len: U32Val,
     ) -> Result<HOT::Wrapper, HostError> {

--- a/soroban-env-host/src/host/metered_map.rs
+++ b/soroban-env-host/src/host/metered_map.rs
@@ -37,18 +37,18 @@ where
 {
     fn charge_access<B: AsBudget>(&self, count: usize, b: &B) -> Result<(), HostError> {
         b.as_budget()
-            .batched_charge(ContractCostType::MapEntry, count as u64, None)
+            .bulk_charge(ContractCostType::MapEntry, count as u64, None)
     }
 
     fn charge_scan<B: AsBudget>(&self, b: &B) -> Result<(), HostError> {
         b.as_budget()
-            .batched_charge(ContractCostType::MapEntry, self.map.len() as u64, None)
+            .bulk_charge(ContractCostType::MapEntry, self.map.len() as u64, None)
     }
 
     fn charge_binsearch<B: AsBudget>(&self, b: &B) -> Result<(), HostError> {
         let mag = 64 - (self.map.len() as u64).leading_zeros();
         b.as_budget()
-            .batched_charge(ContractCostType::MapEntry, 1 + mag as u64, None)
+            .bulk_charge(ContractCostType::MapEntry, 1 + mag as u64, None)
     }
 }
 
@@ -337,7 +337,7 @@ where
         a: &MeteredOrdMap<K, V, Host>,
         b: &MeteredOrdMap<K, V, Host>,
     ) -> Result<Ordering, Self::Error> {
-        self.as_budget().batched_charge(
+        self.as_budget().bulk_charge(
             ContractCostType::MapEntry,
             a.map.len().min(b.map.len()) as u64,
             None,
@@ -357,7 +357,7 @@ where
         a: &MeteredOrdMap<K, V, Budget>,
         b: &MeteredOrdMap<K, V, Budget>,
     ) -> Result<Ordering, Self::Error> {
-        self.batched_charge(
+        self.bulk_charge(
             ContractCostType::MapEntry,
             a.map.len().min(b.map.len()) as u64,
             None,

--- a/soroban-env-host/src/host/metered_vector.rs
+++ b/soroban-env-host/src/host/metered_vector.rs
@@ -31,16 +31,16 @@ where
     A: DeclaredSizeForMetering,
 {
     fn charge_access(&self, count: usize, budget: &Budget) -> Result<(), HostError> {
-        budget.batched_charge(ContractCostType::VecEntry, count as u64, None)
+        budget.bulk_charge(ContractCostType::VecEntry, count as u64, None)
     }
 
     fn charge_scan(&self, budget: &Budget) -> Result<(), HostError> {
-        budget.batched_charge(ContractCostType::VecEntry, self.vec.len() as u64, None)
+        budget.bulk_charge(ContractCostType::VecEntry, self.vec.len() as u64, None)
     }
 
     fn charge_binsearch(&self, budget: &Budget) -> Result<(), HostError> {
         let mag = 64 - (self.vec.len() as u64).leading_zeros();
-        budget.batched_charge(ContractCostType::VecEntry, 1 + mag as u64, None)
+        budget.bulk_charge(ContractCostType::VecEntry, 1 + mag as u64, None)
     }
 }
 
@@ -335,7 +335,7 @@ where
         a: &MeteredVector<Elt>,
         b: &MeteredVector<Elt>,
     ) -> Result<Ordering, Self::Error> {
-        self.as_budget().batched_charge(
+        self.as_budget().bulk_charge(
             ContractCostType::VecEntry,
             a.vec.len().min(b.vec.len()) as u64,
             None,
@@ -355,7 +355,7 @@ where
         a: &MeteredVector<Elt>,
         b: &MeteredVector<Elt>,
     ) -> Result<Ordering, Self::Error> {
-        self.as_budget().batched_charge(
+        self.as_budget().bulk_charge(
             ContractCostType::VecEntry,
             a.vec.len().min(b.vec.len()) as u64,
             None,

--- a/soroban-env-host/src/host/num.rs
+++ b/soroban-env-host/src/host/num.rs
@@ -3,9 +3,9 @@ macro_rules! impl_wrapping_obj_from_num {
     ($host_fn: ident, $hot: ty, $num: ty) => {
         fn $host_fn(
             &self,
-            _vmcaller: &mut VmCaller<Host>,
+            _vmcaller: &mut VmCaller<Self::VmUserState>,
             u: $num,
-        ) -> Result<<$hot as HostObjectType>::Wrapper, HostError> {
+        ) -> Result<<$hot as HostObjectType>::Wrapper, Self::Error> {
             self.add_host_object(<$hot>::from(u))
         }
     };
@@ -16,9 +16,9 @@ macro_rules! impl_wrapping_obj_to_num {
     ($host_fn: ident, $data: ty, $num: ty) => {
         fn $host_fn(
             &self,
-            _vmcaller: &mut VmCaller<Host>,
+            _vmcaller: &mut VmCaller<Self::VmUserState>,
             obj: <$data as HostObjectType>::Wrapper,
-        ) -> Result<$num, HostError> {
+        ) -> Result<$num, Self::Error> {
             self.visit_obj(obj, |t: &$data| Ok(t.clone().into()))
         }
     };

--- a/soroban-env-host/src/lib.rs
+++ b/soroban-env-host/src/lib.rs
@@ -34,7 +34,7 @@ mod native_contract;
 
 pub mod auth;
 pub mod vm;
-pub use vm::Vm;
+pub use vm::{StoreData, Vm};
 #[cfg(any(test, feature = "testutils"))]
 pub mod cost_runner;
 pub mod storage;

--- a/soroban-env-host/src/test/budget_metering.rs
+++ b/soroban-env-host/src/test/budget_metering.rs
@@ -262,7 +262,7 @@ fn total_amount_charged_from_random_inputs() -> Result<(), HostError> {
     ];
 
     for ty in ContractCostType::variants() {
-        host.with_budget(|b| b.batched_charge(ty, tracker[ty as usize].0, tracker[ty as usize].1))?;
+        host.with_budget(|b| b.bulk_charge(ty, tracker[ty as usize].0, tracker[ty as usize].1))?;
     }
     let actual = format!("{:?}", host.as_budget());
     expect![[r#"

--- a/soroban-env-host/src/test/hostile.rs
+++ b/soroban-env-host/src/test/hostile.rs
@@ -116,3 +116,37 @@ fn hostile_objs_traps() -> Result<(), HostError> {
     ));
     Ok(())
 }
+
+use soroban_synth_wasm::{Arity, ModEmitter, Operand};
+
+fn wasm_module_with_mem_grow(n_pages: usize) -> Vec<u8> {
+    let mut fe = ModEmitter::new().func(Arity(0), 0);
+    fe.push(Operand::Const32(n_pages as i32));
+    fe.memory_grow();
+    // need to drop the return value on the stack because it's an i32
+    // and the function needs an i64 return value.
+    fe.drop();
+    fe.push(Symbol::try_from_small_str("pass").unwrap());
+    fe.finish_and_export("test").finish()
+}
+
+#[test]
+fn excessive_memory_growth() -> Result<(), HostError> {
+    let wasm = wasm_module_with_mem_grow(32);
+    let host = Host::test_host_with_recording_footprint();
+    let contract_id_obj = host.register_test_contract_wasm(wasm.as_slice());
+    host.set_diagnostic_level(crate::DiagnosticLevel::Debug)?;
+
+    // This one should just run out of memory
+    let res = host.call(
+        contract_id_obj,
+        Symbol::try_from_small_str("test")?,
+        host.add_host_object(HostVec::new())?,
+    );
+
+    assert!(HostError::result_matches_err(
+        res,
+        (ScErrorType::Budget, ScErrorCode::ExceededLimit)
+    ));
+    Ok(())
+}

--- a/soroban-env-host/src/vm.rs
+++ b/soroban-env-host/src/vm.rs
@@ -36,7 +36,7 @@ use wasmi::{Caller, StoreContextMut};
 
 impl wasmi::core::HostError for HostError {}
 
-pub const WASM_LINEAR_MEMORY_SIZE_LIMIT_BYTES: usize = 0x200000; // 20MB
+pub const WASM_LINEAR_MEMORY_SIZE_LIMIT_BYTES: usize = 0x200000; // 2MB
 pub const WASM_TABLE_ELEMENTS_LIMIT_COUNT: u32 = 1000;
 
 /// A [Vm] is a thin wrapper around an instance of [wasmi::Module]. Multiple

--- a/soroban-env-host/src/vm/dispatch.rs
+++ b/soroban-env-host/src/vm/dispatch.rs
@@ -1,9 +1,9 @@
 use super::FuelRefillable;
-use crate::{xdr::ContractCostType, Host, HostError, VmCaller, VmCallerEnv};
+use crate::{xdr::ContractCostType, HostError, VmCaller, VmCallerEnv};
 use crate::{
     AddressObject, BytesObject, DurationObject, Error, I128Object, I256Object, I256Val, I64Object,
-    MapObject, StorageType, StringObject, Symbol, SymbolObject, TimepointObject, U128Object,
-    U256Object, U256Val, U32Val, U64Object, Val, VecObject,
+    MapObject, StorageType, StoreData, StringObject, Symbol, SymbolObject, TimepointObject,
+    U128Object, U256Object, U256Val, U32Val, U64Object, Val, VecObject,
 };
 use soroban_env_common::{call_macro_with_all_host_functions, WasmiMarshal};
 use wasmi::{
@@ -66,18 +66,18 @@ macro_rules! generate_dispatch_functions {
                 // expansion, flattening all functions from all 'mod' blocks
                 // into a set of functions.
                 $(#[$fn_attr])*
-                pub(crate) fn $fn_id(mut caller: wasmi::Caller<Host>, $($arg:i64),*) ->
+                pub(crate) fn $fn_id(mut caller: wasmi::Caller<StoreData>, $($arg:i64),*) ->
                     Result<(i64,), Trap>
                 {
                     // Notes on metering: a flat charge per host function invocation.
                     // This does not account for the actual work being done in those functions,
                     // which are accounted for individually at the operation level.
-                    let host = caller.data().clone();
+                    let host = caller.data().host.clone();
 
                     // This is where the VM -> Host boundary is crossed.
                     // We first return all fuels from the VM back to the host such that
                     // the host maintains control of the budget.
-                    FuelRefillable::return_fuels(&mut caller, &host).map_err(|he| Trap::from(he))?;
+                    FuelRefillable::return_fuel_to_host(&mut caller, &host).map_err(|he| Trap::from(he))?;
 
                     host.charge_budget(ContractCostType::InvokeHostFunction, None)?;
                     let mut vmcaller = VmCaller(Some(caller));
@@ -115,7 +115,7 @@ macro_rules! generate_dispatch_functions {
                     // This is where the Host->VM boundary is crossed.
                     // We supply the remaining host budget as fuel to the VM.
                     let caller = vmcaller.try_mut().map_err(|e| Trap::from(HostError::from(e)))?;
-                    FuelRefillable::fill_fuels(caller, &host).map_err(|he| Trap::from(he))?;
+                    FuelRefillable::add_fuel_to_vm(caller, &host).map_err(|he| Trap::from(he))?;
 
                     res
                 }

--- a/soroban-env-host/src/vm/fuel_refillable.rs
+++ b/soroban-env-host/src/vm/fuel_refillable.rs
@@ -1,25 +1,25 @@
 use crate::{
     budget::AsBudget,
-    xdr::{ScErrorCode, ScErrorType},
-    Host, HostError,
+    xdr::{ContractCostType, ScErrorCode, ScErrorType},
+    Host, HostError, StoreData,
 };
 
 use wasmi::{errors::FuelError, Caller, Store};
 
 pub(crate) trait FuelRefillable {
-    fn fuels_consumed(&self) -> Result<(u64, u64), HostError>;
+    fn fuel_consumed(&self) -> Result<u64, HostError>;
 
-    fn fuels_total(&self) -> Result<(u64, u64), HostError>;
+    fn fuel_total(&self) -> Result<u64, HostError>;
 
-    fn add_fuels(&mut self, cpu: u64, mem: u64) -> Result<(), HostError>;
+    fn add_fuel(&mut self, fuel: u64) -> Result<(), HostError>;
 
-    fn reset_fuels(&mut self) -> Result<(), HostError>;
+    fn reset_fuel(&mut self) -> Result<(), HostError>;
 
     fn is_clean(&self) -> Result<bool, HostError> {
-        Ok(self.fuels_consumed()? == (0, 0) && self.fuels_total()? == (0, 0))
+        Ok(self.fuel_consumed()? == 0 && self.fuel_total()? == 0)
     }
 
-    fn fill_fuels(&mut self, host: &Host) -> Result<(), HostError> {
+    fn add_fuel_to_vm(&mut self, host: &Host) -> Result<(), HostError> {
         if !self.is_clean()? {
             return Err(host.err(
                 ScErrorType::WasmVm,
@@ -28,57 +28,44 @@ pub(crate) trait FuelRefillable {
                 &[],
             ));
         }
-        let (cpu, mem) = host.as_budget().get_fuels_budget()?;
-        self.add_fuels(cpu, mem)
+        let fuel = host.as_budget().get_cpu_insns_remaining_as_fuel()?;
+        self.add_fuel(fuel)
     }
 
-    fn return_fuels(&mut self, host: &Host) -> Result<(), HostError> {
-        let (cpu, mem) = self.fuels_consumed()?;
-        host.as_budget().apply_wasmi_fuels(cpu, mem)?;
-        self.reset_fuels()
+    fn return_fuel_to_host(&mut self, host: &Host) -> Result<(), HostError> {
+        let fuel = self.fuel_consumed()?;
+        host.as_budget()
+            .bulk_charge(ContractCostType::WasmInsnExec, fuel, None)?;
+        self.reset_fuel()
     }
 }
-//wasmi::Store<Host>
+
 macro_rules! impl_refillable_for_store {
     ($store: ty) => {
         impl<'a> FuelRefillable for $store {
-            fn fuels_consumed(&self) -> Result<(u64, u64), HostError> {
-                let cpu = self.fuel_consumed().ok_or_else(|| {
+            fn fuel_consumed(&self) -> Result<u64, HostError> {
+                self.fuel_consumed().ok_or_else(|| {
                     HostError::from(wasmi::Error::Store(FuelError::FuelMeteringDisabled))
-                })?;
-                let mem = self.mem_fuel_consumed().ok_or_else(|| {
-                    HostError::from(wasmi::Error::Store(FuelError::FuelMeteringDisabled))
-                })?;
-                Ok((cpu, mem))
+                })
             }
 
-            fn fuels_total(&self) -> Result<(u64, u64), HostError> {
-                let cpu = self.fuel_total().ok_or_else(|| {
+            fn fuel_total(&self) -> Result<u64, HostError> {
+                self.fuel_total().ok_or_else(|| {
                     HostError::from(wasmi::Error::Store(FuelError::FuelMeteringDisabled))
-                })?;
-                let mem = self.mem_fuel_total().ok_or_else(|| {
-                    HostError::from(wasmi::Error::Store(FuelError::FuelMeteringDisabled))
-                })?;
-                Ok((cpu, mem))
+                })
             }
 
-            fn add_fuels(&mut self, cpu: u64, mem: u64) -> Result<(), HostError> {
-                self.add_fuel(cpu)
-                    .map_err(|fe| HostError::from(wasmi::Error::Store(fe)))?;
-                self.add_mem_fuel(mem)
-                    .map_err(|fe| HostError::from(wasmi::Error::Store(fe)))?;
-                Ok(())
+            fn add_fuel(&mut self, fuel: u64) -> Result<(), HostError> {
+                self.add_fuel(fuel)
+                    .map_err(|fe| HostError::from(wasmi::Error::Store(fe)))
             }
 
-            fn reset_fuels(&mut self) -> Result<(), HostError> {
+            fn reset_fuel(&mut self) -> Result<(), HostError> {
                 self.reset_fuel()
-                    .map_err(|fe| HostError::from(wasmi::Error::Store(fe)))?;
-                self.reset_mem_fuel()
-                    .map_err(|fe| HostError::from(wasmi::Error::Store(fe)))?;
-                Ok(())
+                    .map_err(|fe| HostError::from(wasmi::Error::Store(fe)))
             }
         }
     };
 }
-impl_refillable_for_store!(Store<Host>);
-impl_refillable_for_store!(Caller<'a, Host>);
+impl_refillable_for_store!(Store<StoreData>);
+impl_refillable_for_store!(Caller<'a, StoreData>);

--- a/soroban-env-host/src/vm/func_info.rs
+++ b/soroban-env-host/src/vm/func_info.rs
@@ -1,5 +1,5 @@
 use super::dispatch;
-use crate::Host;
+use crate::StoreData;
 use soroban_env_common::call_macro_with_all_host_functions;
 use wasmi::{Func, Store};
 
@@ -14,7 +14,7 @@ pub(crate) struct HostFuncInfo {
     /// Function that takes a wasmi::Store and _wraps_ a dispatch function
     /// for this host function, with the specific type of the dispatch function,
     /// into a Func in the Store.
-    pub(crate) wrap: fn(&mut Store<Host>) -> Func,
+    pub(crate) wrap: fn(&mut Store<StoreData>) -> Func,
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### What

This PR adapts to the new `wasmi::ResourceLimiter` api, replacing our current metering-based guest memory limiting mechanism. The main benefits are:
- More resources (table, instances) are limited, not just memory
- It also limits memory allocation on startup, preventing guest contract from declaring large memory in in the wasm file. Resolves #896 


### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
