### PR TITLE
Adapt to ResourceLimiter, replacing mem_fuel metering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,12 +695,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "intx"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f38a50a899dc47a6d0ed5508e7f601a2e34c3a85303514b5d137f3c10a0c75"
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1412,9 +1406,8 @@ version = "0.0.17"
 [[package]]
 name = "soroban-wasmi"
 version = "0.30.0-soroban"
-source = "git+https://github.com/stellar/wasmi?rev=3dc639fde3bebf0bf364a9fa4ac2f0efb7ee9995#3dc639fde3bebf0bf364a9fa4ac2f0efb7ee9995"
+source = "git+https://github.com/stellar/wasmi?rev=284c963ba080703061797e2a3cba0853edee0dd4#284c963ba080703061797e2a3cba0853edee0dd4"
 dependencies = [
- "intx",
  "smallvec",
  "spin",
  "wasmi_arena",
@@ -1840,12 +1833,12 @@ dependencies = [
 [[package]]
 name = "wasmi_arena"
 version = "0.4.0"
-source = "git+https://github.com/stellar/wasmi?rev=3dc639fde3bebf0bf364a9fa4ac2f0efb7ee9995#3dc639fde3bebf0bf364a9fa4ac2f0efb7ee9995"
+source = "git+https://github.com/stellar/wasmi?rev=284c963ba080703061797e2a3cba0853edee0dd4#284c963ba080703061797e2a3cba0853edee0dd4"
 
 [[package]]
 name = "wasmi_core"
 version = "0.12.0"
-source = "git+https://github.com/stellar/wasmi?rev=3dc639fde3bebf0bf364a9fa4ac2f0efb7ee9995#3dc639fde3bebf0bf364a9fa4ac2f0efb7ee9995"
+source = "git+https://github.com/stellar/wasmi?rev=284c963ba080703061797e2a3cba0853edee0dd4#284c963ba080703061797e2a3cba0853edee0dd4"
 dependencies = [
  "downcast-rs",
  "libm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ default-features = false
 package = "soroban-wasmi"
 version = "0.30.0-soroban"
 git = "https://github.com/stellar/wasmi"
-rev = "3dc639fde3bebf0bf364a9fa4ac2f0efb7ee9995"
+rev = "284c963ba080703061797e2a3cba0853edee0dd4"
 
 [workspace.dependencies.stellar-strkey]
 version = "0.0.7"

--- a/soroban-env-common/src/error.rs
+++ b/soroban-env-common/src/error.rs
@@ -164,7 +164,9 @@ impl From<wasmi::core::TrapCode> for Error {
 
             wasmi::core::TrapCode::BadSignature => ScErrorCode::UnexpectedType,
 
-            wasmi::core::TrapCode::StackOverflow | wasmi::core::TrapCode::OutOfFuel => {
+            wasmi::core::TrapCode::StackOverflow
+            | wasmi::core::TrapCode::OutOfFuel
+            | wasmi::core::TrapCode::GrowthOperationLimited => {
                 return Error::from_type_and_code(ScErrorType::Budget, ScErrorCode::ExceededLimit)
             }
         };

--- a/soroban-env-host/benches/common/measure.rs
+++ b/soroban-env-host/benches/common/measure.rs
@@ -220,7 +220,7 @@ impl Measurements {
 ///
 ///     f(x) = N_x * (a + b * Option<x>)                                    [1]
 ///
-/// The `N_x` here is batch size if the host is doing `batched_charge` for the
+/// The `N_x` here is batch size if the host is doing `bulk_charge` for the
 /// corresponding `x`.  The goal of the HCM is to record the relation of x and
 /// f(x) in order for  a, b -- the constant and linear cost parameters -- to be
 /// extracted. In the ideal setup, we pass in an array of samples with various

--- a/soroban-env-host/src/budget.rs
+++ b/soroban-env-host/src/budget.rs
@@ -69,7 +69,7 @@ impl HostCostModel for ContractCostParamEntry {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
 pub struct BudgetDimension {
     /// A set of cost models that map input values (eg. event counts, object
     /// sizes) from some CostType to whatever concrete resource type is being
@@ -205,7 +205,7 @@ impl BudgetDimension {
 /// doesn't derive all the traits we want. These fields (coarsely) define the
 /// relative costs of different wasm instruction types and are for wasmi internal
 /// fuel metering use only. Units are in "fuels".
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
 pub(crate) struct FuelConfig {
     /// The base fuel costs for all instructions.
     pub base: u64,
@@ -250,7 +250,7 @@ impl FuelConfig {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone)]
 pub(crate) struct BudgetImpl {
     pub cpu_insns: BudgetDimension,
     pub mem_bytes: BudgetDimension,
@@ -435,7 +435,7 @@ impl DepthLimiter for BudgetImpl {
     }
 }
 
-#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone)]
 pub struct Budget(pub(crate) Rc<RefCell<BudgetImpl>>);
 
 impl Debug for Budget {
@@ -508,7 +508,13 @@ impl Budget {
         f(self.0.try_borrow_mut_or_err()?)
     }
 
-    fn charge_in_bulk(
+    /// Performs a bulk charge to the budget under the specified [`CostType`].
+    /// The `iterations` is the batch size. The caller needs to ensure:
+    /// 1. the batched charges have identical costs (having the same
+    /// [`CostType`] and `input`)
+    /// 2. The input passed in (Some/None) is consistent with the [`CostModel`]
+    /// underneath the [`CostType`] (linear/constant).
+    pub fn bulk_charge(
         &self,
         ty: ContractCostType,
         iterations: u64,
@@ -559,27 +565,7 @@ impl Budget {
     /// Otherwise it is a linear model.  The caller needs to ensure the input
     /// passed is consistent with the inherent model underneath.
     pub fn charge(&self, ty: ContractCostType, input: Option<u64>) -> Result<(), HostError> {
-        self.charge_in_bulk(ty, 1, input)
-    }
-
-    pub fn apply_wasmi_fuels(&self, cpu_fuel: u64, mem_fuel: u64) -> Result<(), HostError> {
-        self.charge_in_bulk(ContractCostType::WasmInsnExec, cpu_fuel, None)?;
-        self.charge_in_bulk(ContractCostType::WasmMemAlloc, mem_fuel, None)
-    }
-
-    /// Performs a bulk charge to the budget under the specified [`CostType`].
-    /// The `iterations` is the batch size. The caller needs to ensure:
-    /// 1. the batched charges have identical costs (having the same
-    /// [`CostType`] and `input`)
-    /// 2. The input passed in (Some/None) is consistent with the [`CostModel`]
-    /// underneath the [`CostType`] (linear/constant).
-    pub fn batched_charge(
-        &self,
-        ty: ContractCostType,
-        iterations: u64,
-        input: Option<u64>,
-    ) -> Result<(), HostError> {
-        self.charge_in_bulk(ty, iterations, input)
+        self.bulk_charge(ty, 1, input)
     }
 
     pub fn with_free_budget<F, T>(&self, f: F) -> Result<T, HostError>
@@ -688,7 +674,7 @@ impl Budget {
         Ok(())
     }
 
-    fn get_cpu_insns_remaining_as_fuel(&self) -> Result<u64, HostError> {
+    pub(crate) fn get_cpu_insns_remaining_as_fuel(&self) -> Result<u64, HostError> {
         let cpu_remaining = self.get_cpu_insns_remaining()?;
         let cpu_per_fuel = self
             .0
@@ -712,29 +698,6 @@ impl Budget {
         // unspendable residual budget (see the other comment in `vm::wrapped_func_call`).
         // So it should be okay.
         Ok(cpu_remaining / cpu_per_fuel)
-    }
-
-    fn get_mem_bytes_remaining_as_fuel(&self) -> Result<u64, HostError> {
-        let bytes_remaining = self.get_mem_bytes_remaining()?;
-        let bytes_per_fuel = self
-            .0
-            .try_borrow_or_err()?
-            .mem_bytes
-            .get_cost_model(ContractCostType::WasmMemAlloc)
-            .linear_term;
-
-        if bytes_per_fuel < 0 {
-            return Err((ScErrorType::Context, ScErrorCode::InvalidInput).into());
-        }
-        let bytes_per_fuel = (bytes_per_fuel as u64).max(1);
-        // See comment about rounding above.
-        Ok(bytes_remaining / bytes_per_fuel)
-    }
-
-    pub fn get_fuels_budget(&self) -> Result<(u64, u64), HostError> {
-        let cpu_fuel = self.get_cpu_insns_remaining_as_fuel()?;
-        let mem_fuel = self.get_mem_bytes_remaining_as_fuel()?;
-        Ok((cpu_fuel, mem_fuel))
     }
 
     // generate a wasmi fuel cost schedule based on our calibration

--- a/soroban-env-host/src/host/metered_map.rs
+++ b/soroban-env-host/src/host/metered_map.rs
@@ -37,18 +37,18 @@ where
 {
     fn charge_access<B: AsBudget>(&self, count: usize, b: &B) -> Result<(), HostError> {
         b.as_budget()
-            .batched_charge(ContractCostType::MapEntry, count as u64, None)
+            .bulk_charge(ContractCostType::MapEntry, count as u64, None)
     }
 
     fn charge_scan<B: AsBudget>(&self, b: &B) -> Result<(), HostError> {
         b.as_budget()
-            .batched_charge(ContractCostType::MapEntry, self.map.len() as u64, None)
+            .bulk_charge(ContractCostType::MapEntry, self.map.len() as u64, None)
     }
 
     fn charge_binsearch<B: AsBudget>(&self, b: &B) -> Result<(), HostError> {
         let mag = 64 - (self.map.len() as u64).leading_zeros();
         b.as_budget()
-            .batched_charge(ContractCostType::MapEntry, 1 + mag as u64, None)
+            .bulk_charge(ContractCostType::MapEntry, 1 + mag as u64, None)
     }
 }
 
@@ -337,7 +337,7 @@ where
         a: &MeteredOrdMap<K, V, Host>,
         b: &MeteredOrdMap<K, V, Host>,
     ) -> Result<Ordering, Self::Error> {
-        self.as_budget().batched_charge(
+        self.as_budget().bulk_charge(
             ContractCostType::MapEntry,
             a.map.len().min(b.map.len()) as u64,
             None,
@@ -357,7 +357,7 @@ where
         a: &MeteredOrdMap<K, V, Budget>,
         b: &MeteredOrdMap<K, V, Budget>,
     ) -> Result<Ordering, Self::Error> {
-        self.batched_charge(
+        self.bulk_charge(
             ContractCostType::MapEntry,
             a.map.len().min(b.map.len()) as u64,
             None,

--- a/soroban-env-host/src/host/metered_vector.rs
+++ b/soroban-env-host/src/host/metered_vector.rs
@@ -31,16 +31,16 @@ where
     A: DeclaredSizeForMetering,
 {
     fn charge_access(&self, count: usize, budget: &Budget) -> Result<(), HostError> {
-        budget.batched_charge(ContractCostType::VecEntry, count as u64, None)
+        budget.bulk_charge(ContractCostType::VecEntry, count as u64, None)
     }
 
     fn charge_scan(&self, budget: &Budget) -> Result<(), HostError> {
-        budget.batched_charge(ContractCostType::VecEntry, self.vec.len() as u64, None)
+        budget.bulk_charge(ContractCostType::VecEntry, self.vec.len() as u64, None)
     }
 
     fn charge_binsearch(&self, budget: &Budget) -> Result<(), HostError> {
         let mag = 64 - (self.vec.len() as u64).leading_zeros();
-        budget.batched_charge(ContractCostType::VecEntry, 1 + mag as u64, None)
+        budget.bulk_charge(ContractCostType::VecEntry, 1 + mag as u64, None)
     }
 }
 
@@ -335,7 +335,7 @@ where
         a: &MeteredVector<Elt>,
         b: &MeteredVector<Elt>,
     ) -> Result<Ordering, Self::Error> {
-        self.as_budget().batched_charge(
+        self.as_budget().bulk_charge(
             ContractCostType::VecEntry,
             a.vec.len().min(b.vec.len()) as u64,
             None,
@@ -355,7 +355,7 @@ where
         a: &MeteredVector<Elt>,
         b: &MeteredVector<Elt>,
     ) -> Result<Ordering, Self::Error> {
-        self.as_budget().batched_charge(
+        self.as_budget().bulk_charge(
             ContractCostType::VecEntry,
             a.vec.len().min(b.vec.len()) as u64,
             None,

--- a/soroban-env-host/src/test/budget_metering.rs
+++ b/soroban-env-host/src/test/budget_metering.rs
@@ -262,7 +262,7 @@ fn total_amount_charged_from_random_inputs() -> Result<(), HostError> {
     ];
 
     for ty in ContractCostType::variants() {
-        host.with_budget(|b| b.batched_charge(ty, tracker[ty as usize].0, tracker[ty as usize].1))?;
+        host.with_budget(|b| b.bulk_charge(ty, tracker[ty as usize].0, tracker[ty as usize].1))?;
     }
     let actual = format!("{:?}", host.as_budget());
     expect![[r#"

--- a/soroban-env-host/src/test/budget_metering.rs
+++ b/soroban-env-host/src/test/budget_metering.rs
@@ -46,8 +46,9 @@ fn xdr_object_conversion() -> Result<(), HostError> {
 fn vm_hostfn_invocation() -> Result<(), HostError> {
     let host = Host::test_host_with_recording_footprint();
     let id_obj = host.register_test_contract_wasm(VEC);
+    // this contract requests initial pages = 16 worth of linear memory, not sure why
     let host = host
-        .test_budget(100_000, 100_000)
+        .test_budget(100_000, 1_048_576)
         .enable_model(ContractCostType::InvokeVmFunction, 10, 0, 1, 0)
         .enable_model(ContractCostType::InvokeHostFunction, 10, 0, 1, 0);
 

--- a/soroban-env-host/src/vm.rs
+++ b/soroban-env-host/src/vm.rs
@@ -225,7 +225,7 @@ impl Vm {
         inputs: &[Value],
     ) -> Result<Val, HostError> {
         let mut wasm_ret: [Value; 1] = [Value::I64(0)];
-        self.store.try_borrow_mut_or_err()?.fill_fuels(host)?;
+        self.store.try_borrow_mut_or_err()?.add_fuel_to_vm(host)?;
         let res = func.call(
             &mut *self.store.try_borrow_mut_or_err()?,
             inputs,
@@ -236,7 +236,9 @@ impl Vm {
         // wasmi instruction) remaining when the `OutOfFuel` trap occurs. This is only observable
         // if the contract traps with `OutOfFuel`, which may appear confusing if they look closely
         // at the budget amount consumed. So it should be fine.
-        self.store.try_borrow_mut_or_err()?.return_fuels(host)?;
+        self.store
+            .try_borrow_mut_or_err()?
+            .return_fuel_to_host(host)?;
 
         if let Err(e) = res {
             // When a call fails with a wasmi::Error::Trap that carries a HostError

--- a/soroban-env-host/src/vm.rs
+++ b/soroban-env-host/src/vm.rs
@@ -165,6 +165,8 @@ impl Vm {
         Self::check_meta_section(host, &module)?;
 
         let mut store = Store::new(&engine, host.clone());
+        store.limiter(|host| host);
+
         let mut linker = <Linker<Host>>::new(&engine);
 
         for hf in HOST_FUNCTIONS {

--- a/soroban-env-host/src/vm/dispatch.rs
+++ b/soroban-env-host/src/vm/dispatch.rs
@@ -147,7 +147,7 @@ macro_rules! generate_dispatch_functions {
                     // This is where the VM -> Host boundary is crossed.
                     // We first return all fuels from the VM back to the host such that
                     // the host maintains control of the budget.
-                    FuelRefillable::return_fuels(&mut caller, &host).map_err(|he| Trap::from(he))?;
+                    FuelRefillable::return_fuel_to_host(&mut caller, &host).map_err(|he| Trap::from(he))?;
 
                     host.charge_budget(ContractCostType::InvokeHostFunction, None)?;
                     let mut vmcaller = VmCaller(Some(caller));
@@ -185,7 +185,7 @@ macro_rules! generate_dispatch_functions {
                     // This is where the Host->VM boundary is crossed.
                     // We supply the remaining host budget as fuel to the VM.
                     let caller = vmcaller.try_mut().map_err(|e| Trap::from(HostError::from(e)))?;
-                    FuelRefillable::fill_fuels(caller, &host).map_err(|he| Trap::from(he))?;
+                    FuelRefillable::add_fuel_to_vm(caller, &host).map_err(|he| Trap::from(he))?;
 
                     res
                 }

--- a/soroban-env-host/src/vm/fuel_refillable.rs
+++ b/soroban-env-host/src/vm/fuel_refillable.rs
@@ -1,25 +1,25 @@
 use crate::{
     budget::AsBudget,
-    xdr::{ScErrorCode, ScErrorType},
+    xdr::{ContractCostType, ScErrorCode, ScErrorType},
     Host, HostError,
 };
 
 use wasmi::{errors::FuelError, Caller, Store};
 
 pub(crate) trait FuelRefillable {
-    fn fuels_consumed(&self) -> Result<(u64, u64), HostError>;
+    fn fuel_consumed(&self) -> Result<u64, HostError>;
 
-    fn fuels_total(&self) -> Result<(u64, u64), HostError>;
+    fn fuel_total(&self) -> Result<u64, HostError>;
 
-    fn add_fuels(&mut self, cpu: u64, mem: u64) -> Result<(), HostError>;
+    fn add_fuel(&mut self, fuel: u64) -> Result<(), HostError>;
 
-    fn reset_fuels(&mut self) -> Result<(), HostError>;
+    fn reset_fuel(&mut self) -> Result<(), HostError>;
 
     fn is_clean(&self) -> Result<bool, HostError> {
-        Ok(self.fuels_consumed()? == (0, 0) && self.fuels_total()? == (0, 0))
+        Ok(self.fuel_consumed()? == 0 && self.fuel_total()? == 0)
     }
 
-    fn fill_fuels(&mut self, host: &Host) -> Result<(), HostError> {
+    fn add_fuel_to_vm(&mut self, host: &Host) -> Result<(), HostError> {
         if !self.is_clean()? {
             return Err(host.err(
                 ScErrorType::WasmVm,
@@ -28,54 +28,41 @@ pub(crate) trait FuelRefillable {
                 &[],
             ));
         }
-        let (cpu, mem) = host.as_budget().get_fuels_budget()?;
-        self.add_fuels(cpu, mem)
+        let fuel = host.as_budget().get_cpu_insns_remaining_as_fuel()?;
+        self.add_fuel(fuel)
     }
 
-    fn return_fuels(&mut self, host: &Host) -> Result<(), HostError> {
-        let (cpu, mem) = self.fuels_consumed()?;
-        host.as_budget().apply_wasmi_fuels(cpu, mem)?;
-        self.reset_fuels()
+    fn return_fuel_to_host(&mut self, host: &Host) -> Result<(), HostError> {
+        let fuel = self.fuel_consumed()?;
+        host.as_budget()
+            .bulk_charge(ContractCostType::WasmInsnExec, fuel, None)?;
+        self.reset_fuel()
     }
 }
-//wasmi::Store<Host>
+
 macro_rules! impl_refillable_for_store {
     ($store: ty) => {
         impl<'a> FuelRefillable for $store {
-            fn fuels_consumed(&self) -> Result<(u64, u64), HostError> {
-                let cpu = self.fuel_consumed().ok_or_else(|| {
+            fn fuel_consumed(&self) -> Result<u64, HostError> {
+                self.fuel_consumed().ok_or_else(|| {
                     HostError::from(wasmi::Error::Store(FuelError::FuelMeteringDisabled))
-                })?;
-                let mem = self.mem_fuel_consumed().ok_or_else(|| {
-                    HostError::from(wasmi::Error::Store(FuelError::FuelMeteringDisabled))
-                })?;
-                Ok((cpu, mem))
+                })
             }
 
-            fn fuels_total(&self) -> Result<(u64, u64), HostError> {
-                let cpu = self.fuel_total().ok_or_else(|| {
+            fn fuel_total(&self) -> Result<u64, HostError> {
+                self.fuel_total().ok_or_else(|| {
                     HostError::from(wasmi::Error::Store(FuelError::FuelMeteringDisabled))
-                })?;
-                let mem = self.mem_fuel_total().ok_or_else(|| {
-                    HostError::from(wasmi::Error::Store(FuelError::FuelMeteringDisabled))
-                })?;
-                Ok((cpu, mem))
+                })
             }
 
-            fn add_fuels(&mut self, cpu: u64, mem: u64) -> Result<(), HostError> {
-                self.add_fuel(cpu)
-                    .map_err(|fe| HostError::from(wasmi::Error::Store(fe)))?;
-                self.add_mem_fuel(mem)
-                    .map_err(|fe| HostError::from(wasmi::Error::Store(fe)))?;
-                Ok(())
+            fn add_fuel(&mut self, fuel: u64) -> Result<(), HostError> {
+                self.add_fuel(fuel)
+                    .map_err(|fe| HostError::from(wasmi::Error::Store(fe)))
             }
 
-            fn reset_fuels(&mut self) -> Result<(), HostError> {
+            fn reset_fuel(&mut self) -> Result<(), HostError> {
                 self.reset_fuel()
-                    .map_err(|fe| HostError::from(wasmi::Error::Store(fe)))?;
-                self.reset_mem_fuel()
-                    .map_err(|fe| HostError::from(wasmi::Error::Store(fe)))?;
-                Ok(())
+                    .map_err(|fe| HostError::from(wasmi::Error::Store(fe)))
             }
         }
     };


### PR DESCRIPTION
### What

Resolves https://github.com/stellar/rs-soroban-env/issues/896

This is attempt 2. Follows up on https://github.com/stellar/rs-soroban-env/pull/946#pullrequestreview-1530786663

Make the host a `ResourceLimiter`, such that the entire memory budget is available to the Vm linear memory. 
Also hardcodes several other limits as `WASMI_LIMITS_CONFIG`, hopefully we won't need to change them ever. 
This is a superior approach to https://github.com/stellar/rs-soroban-env/pull/946, both in terms of functional (dynamic memory limit) and cleanness (does not require changing the StoreData). 

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
