### PR TITLE
Make `del_contract_data` no-op for removing non-existent instance storage key.

### DIFF
--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -2108,18 +2108,9 @@ impl VmCallerEnv for Host {
             }
             StorageType::Instance => {
                 self.with_mut_instance_storage(|s| {
-                    s.map = s
-                        .map
-                        .remove(&k, self)?
-                        .ok_or_else(|| {
-                            self.err(
-                                ScErrorType::Storage,
-                                ScErrorCode::MissingValue,
-                                "key is missing from instance storage",
-                                &[k],
-                            )
-                        })?
-                        .0;
+                    if let Some((new_map, _)) = s.map.remove(&k, self)? {
+                        s.map = new_map;
+                    }
                     Ok(())
                 })?;
             }

--- a/soroban-env-host/src/test/storage.rs
+++ b/soroban-env-host/src/test/storage.rs
@@ -149,7 +149,7 @@ fn test_storage(host: &Host, contract_id: AddressObject, storage: &str) {
         host_vec![host, key_1].into(),
     )
     .unwrap();
-    // Delete again - that's a no-op, but it should fail either.
+    // Delete again - that's a no-op, but it shouldn't fail either.
     host.call(
         contract_id,
         storage_fn_name(host, "del", storage),

--- a/soroban-env-host/src/test/storage.rs
+++ b/soroban-env-host/src/test/storage.rs
@@ -149,6 +149,13 @@ fn test_storage(host: &Host, contract_id: AddressObject, storage: &str) {
         host_vec![host, key_1].into(),
     )
     .unwrap();
+    // Delete again - that's a no-op, but it should fail either.
+    host.call(
+        contract_id,
+        storage_fn_name(host, "del", storage),
+        host_vec![host, key_1].into(),
+    )
+    .unwrap();
     // Only the second key is now present
     assert_eq!(
         bool::try_from_val(


### PR DESCRIPTION
### What

Make `del_contract_data` no-op for removing non-existent instance storage key.

Resolves https://github.com/stellar/rs-soroban-env/issues/949

### Why

This was inconsistent with persistent/temp storage, which doesn't return error for non-existent keys.

### Known limitations

N/A
