### PR TITLE
Adapt to SCError change to be an enum, with ContractError(u32)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "0.0.17"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=3a853f63639ba729454f53c16545dcddcaa59737#3a853f63639ba729454f53c16545dcddcaa59737"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=4eaf2388c1de6fc295ed5f7df8174c199923df5b#4eaf2388c1de6fc295ed5f7df8174c199923df5b"
 dependencies = [
  "arbitrary",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ soroban-native-sdk-macros = { version = "0.0.17", path = "soroban-native-sdk-mac
 [workspace.dependencies.stellar-xdr]
 version = "0.0.17"
 git = "https://github.com/stellar/rs-stellar-xdr"
-rev = "3a853f63639ba729454f53c16545dcddcaa59737"
+rev = "4eaf2388c1de6fc295ed5f7df8174c199923df5b"
 default-features = false
 
 [workspace.dependencies.wasmi]

--- a/soroban-env-common/src/error.rs
+++ b/soroban-env-common/src/error.rs
@@ -92,8 +92,19 @@ impl TryFrom<Error> for ScError {
     type Error = stellar_xdr::Error;
     fn try_from(er: Error) -> Result<Self, Self::Error> {
         let type_: ScErrorType = (er.as_val().get_minor() as i32).try_into()?;
-        let code: ScErrorCode = (er.as_val().get_major() as i32).try_into()?;
-        Ok(ScError { type_, code })
+        let u: u32 = er.as_val().get_major();
+        Ok(match type_ {
+            ScErrorType::Contract => ScError::Contract(u),
+            ScErrorType::WasmVm => ScError::WasmVm((u as i32).try_into()?),
+            ScErrorType::Context => ScError::Context((u as i32).try_into()?),
+            ScErrorType::Storage => ScError::Storage((u as i32).try_into()?),
+            ScErrorType::Object => ScError::Object((u as i32).try_into()?),
+            ScErrorType::Crypto => ScError::Crypto((u as i32).try_into()?),
+            ScErrorType::Events => ScError::Events((u as i32).try_into()?),
+            ScErrorType::Budget => ScError::Budget((u as i32).try_into()?),
+            ScErrorType::Value => ScError::Value((u as i32).try_into()?),
+            ScErrorType::Auth => ScError::Auth((u as i32).try_into()?),
+        })
     }
 }
 
@@ -217,7 +228,18 @@ impl Error {
 
     #[inline(always)]
     pub const fn from_scerror(sc: ScError) -> Error {
-        Self::from_type_and_code(sc.type_, sc.code)
+        match sc {
+            ScError::Contract(u) => Self::from_contract_error(u),
+            ScError::WasmVm(code) => Self::from_type_and_code(ScErrorType::WasmVm, code),
+            ScError::Context(code) => Self::from_type_and_code(ScErrorType::Context, code),
+            ScError::Storage(code) => Self::from_type_and_code(ScErrorType::Storage, code),
+            ScError::Object(code) => Self::from_type_and_code(ScErrorType::Object, code),
+            ScError::Crypto(code) => Self::from_type_and_code(ScErrorType::Crypto, code),
+            ScError::Events(code) => Self::from_type_and_code(ScErrorType::Events, code),
+            ScError::Budget(code) => Self::from_type_and_code(ScErrorType::Budget, code),
+            ScError::Value(code) => Self::from_type_and_code(ScErrorType::Value, code),
+            ScError::Auth(code) => Self::from_type_and_code(ScErrorType::Auth, code),
+        }
     }
 }
 
@@ -241,9 +263,58 @@ mod tests {
         // then checks that both lists are sorted the same.
 
         let mut xdr_vals = Vec::new();
-        for code in crate::xdr::ScErrorCode::VARIANTS {
-            for type_ in crate::xdr::ScErrorType::VARIANTS {
-                xdr_vals.push(ScError { type_, code })
+        for type_ in crate::xdr::ScErrorType::VARIANTS {
+            match type_ {
+                ScErrorType::Contract => {
+                    for i in 0..=512 {
+                        xdr_vals.push(ScError::Contract(i))
+                    }
+                }
+                ScErrorType::WasmVm => {
+                    for code in crate::xdr::ScErrorCode::VARIANTS {
+                        xdr_vals.push(ScError::WasmVm(code))
+                    }
+                }
+                ScErrorType::Context => {
+                    for code in crate::xdr::ScErrorCode::VARIANTS {
+                        xdr_vals.push(ScError::Context(code))
+                    }
+                }
+                ScErrorType::Storage => {
+                    for code in crate::xdr::ScErrorCode::VARIANTS {
+                        xdr_vals.push(ScError::Storage(code))
+                    }
+                }
+                ScErrorType::Object => {
+                    for code in crate::xdr::ScErrorCode::VARIANTS {
+                        xdr_vals.push(ScError::Object(code))
+                    }
+                }
+                ScErrorType::Crypto => {
+                    for code in crate::xdr::ScErrorCode::VARIANTS {
+                        xdr_vals.push(ScError::Crypto(code))
+                    }
+                }
+                ScErrorType::Events => {
+                    for code in crate::xdr::ScErrorCode::VARIANTS {
+                        xdr_vals.push(ScError::Events(code))
+                    }
+                }
+                ScErrorType::Budget => {
+                    for code in crate::xdr::ScErrorCode::VARIANTS {
+                        xdr_vals.push(ScError::Budget(code))
+                    }
+                }
+                ScErrorType::Value => {
+                    for code in crate::xdr::ScErrorCode::VARIANTS {
+                        xdr_vals.push(ScError::Value(code))
+                    }
+                }
+                ScErrorType::Auth => {
+                    for code in crate::xdr::ScErrorCode::VARIANTS {
+                        xdr_vals.push(ScError::Auth(code))
+                    }
+                }
             }
         }
 

--- a/soroban-env-common/src/val.rs
+++ b/soroban-env-common/src/val.rs
@@ -735,7 +735,7 @@ impl Debug for Val {
 fn test_debug() {
     use super::{Error, Object, SymbolSmall};
     use crate::{
-        xdr::{ScError, ScErrorCode, ScErrorType},
+        xdr::{ScError, ScErrorCode},
         I64Small, U64Small,
     };
     assert_eq!(format!("{:?}", Val::from_void()), "Void");
@@ -761,10 +761,7 @@ fn test_debug() {
     assert_eq!(
         format!(
             "{:?}",
-            Error::from_scerror(ScError {
-                type_: ScErrorType::Value,
-                code: ScErrorCode::InvalidInput
-            })
+            Error::from_scerror(ScError::Value(ScErrorCode::InvalidInput))
         ),
         "Error(Value, InvalidInput)"
     );

--- a/soroban-env-host/src/test/bytes.rs
+++ b/soroban-env-host/src/test/bytes.rs
@@ -131,11 +131,7 @@ fn bytes_xdr_roundtrip() -> Result<(), HostError> {
         host.map_err("stellar".to_string().try_into())?,
     )))?;
     // error
-    roundtrip(ScVal::Error(ScError {
-        type_: ScErrorType::Context,
-        code: ScErrorCode::InternalError,
-    }))?;
-
+    roundtrip(ScVal::Error(ScError::Context(ScErrorCode::InternalError)))?;
     Ok(())
 }
 


### PR DESCRIPTION
This is the env-side change accompanying https://github.com/stellar/stellar-xdr/pull/125

Fixes https://github.com/stellar/rs-soroban-env/issues/953