### PR TITLE
Upgrade dalek to at least next-pre-release versions.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,15 +138,6 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
@@ -165,12 +156,6 @@ name = "bytemuck"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
-
-[[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes-lit"
@@ -274,7 +259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4c2f4e1afd912bc40bfd6fed5d9dc1f288e0ba01bfcc835cc5bc3eb13efe15"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -291,15 +276,30 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.0"
+version = "4.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
+checksum = "436ace70fc06e06f7f689d2624dc4e2f0ea666efb5aa704215f7249ae6e047a7"
 dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core 0.5.1",
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "platforms",
+ "rustc_version",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -360,20 +360,11 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "const-oid",
  "crypto-common",
  "subtle",
@@ -408,33 +399,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0997c976637b606099b9985693efa3581e84e41f5c11ba5255f88711058ad428"
 dependencies = [
  "der",
- "digest 0.10.7",
+ "digest",
  "elliptic-curve",
  "rfc6979",
- "signature 2.1.0",
+ "signature",
  "spki",
 ]
 
 [[package]]
 name = "ed25519"
-version = "1.5.3"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
+checksum = "5fb04eee5d9d907f29e80ee6b0e78f7e2c82342c63e3580d8c4f69d9d5aad963"
 dependencies = [
- "signature 1.6.4",
+ "pkcs8",
+ "signature",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "1.0.1"
+version = "2.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+checksum = "faa8e9049d5d72bfc12acbc05914731b5322f79b5e2f195e9f2d705fca22ab4c"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand",
+ "rand_core",
  "serde",
- "sha2 0.9.9",
+ "sha2",
  "zeroize",
 ]
 
@@ -452,12 +444,12 @@ checksum = "968405c8fdc9b3bf4df0a6638858cc0b52462836ab6b1c87377785dd09cf1c0b"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest 0.10.7",
+ "digest",
  "ff",
  "generic-array",
  "group",
  "pkcs8",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1",
  "subtle",
  "zeroize",
@@ -498,9 +490,15 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
 
 [[package]]
 name = "fnv"
@@ -543,17 +541,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
@@ -561,7 +548,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -578,7 +565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -621,7 +608,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -741,8 +728,8 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2 0.10.6",
- "signature 2.1.0",
+ "sha2",
+ "signature",
 ]
 
 [[package]]
@@ -979,12 +966,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1036,6 +1017,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "platforms"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630"
 
 [[package]]
 name = "ppv-lite86"
@@ -1097,34 +1084,23 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "getrandom 0.1.16",
  "libc",
  "rand_chacha",
- "rand_core 0.5.1",
- "rand_hc",
+ "rand_core",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -1133,16 +1109,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.10",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
+ "getrandom",
 ]
 
 [[package]]
@@ -1209,6 +1176,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,6 +1224,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
@@ -1310,26 +1292,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "sha2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -1338,7 +1307,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "keccak",
 ]
 
@@ -1353,18 +1322,12 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
-
-[[package]]
-name = "signature"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
 dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
+ "digest",
+ "rand_core",
 ]
 
 [[package]]
@@ -1431,7 +1394,7 @@ dependencies = [
  "ed25519-dalek",
  "env_logger",
  "expect-test",
- "getrandom 0.2.10",
+ "getrandom",
  "hex",
  "itertools",
  "k256",
@@ -1443,7 +1406,7 @@ dependencies = [
  "num-traits",
  "rand",
  "rand_chacha",
- "sha2 0.9.9",
+ "sha2",
  "sha3",
  "soroban-bench-utils",
  "soroban-env-common",
@@ -1922,12 +1885,6 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -2161,17 +2118,3 @@ name = "zeroize"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.16",
-]

--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -16,14 +16,14 @@ soroban-env-common = { workspace = true, features = ["std", "wasmi"] }
 stellar-strkey = { workspace = true }
 wasmi = { workspace = true }
 static_assertions = "1.1.0"
-sha2 = "0.9.0"
-ed25519-dalek = "1.0.1"
+sha2 = "0.10.0"
+ed25519-dalek = {version = "2.0.0-rc.3", features = ["rand_core"] }
 # NB: this must match the same curve25519 version used by ed25519-dalek above
-curve25519-dalek = "3.0.0"
+curve25519-dalek = "4.0.0-rc.3"
 # NB: this must match the same rand version used by ed25519-dalek above
-rand = "0.7.3"
+rand = "0.8.4"
 # NB: this must match the same rand_chacha version used by ed25519-dalek above
-rand_chacha = "0.2.2"
+rand_chacha = "0.3.0"
 hex = "0.4.3"
 num-traits = "0.2.15"
 num-integer = "0.1.45"

--- a/soroban-env-host/src/auth.rs
+++ b/soroban-env-host/src/auth.rs
@@ -1409,7 +1409,7 @@ impl AccountAuthorizationTracker {
             false
         };
         let nonce = if !is_invoker {
-            let random_nonce: i64 = rand::thread_rng().gen_range(0, i64::MAX);
+            let random_nonce: i64 = rand::thread_rng().gen_range(0..=i64::MAX);
             host.consume_nonce(address, random_nonce, 0)?;
             Some((random_nonce, 0))
         } else {

--- a/soroban-env-host/src/cost_runner/cost_types/compute_ed25519_pubkey.rs
+++ b/soroban-env-host/src/cost_runner/cost_types/compute_ed25519_pubkey.rs
@@ -1,6 +1,6 @@
 use std::hint::black_box;
 
-use ed25519_dalek::PublicKey;
+use ed25519_dalek::VerifyingKey;
 
 use crate::{cost_runner::CostRunner, xdr::ContractCostType};
 
@@ -11,7 +11,7 @@ impl CostRunner for ComputeEd25519PubKeyRun {
 
     type SampleType = Vec<u8>;
 
-    type RecycledType = (Option<PublicKey>, Vec<u8>);
+    type RecycledType = (Option<VerifyingKey>, Vec<u8>);
 
     fn run_iter(host: &crate::Host, _iter: u64, sample: Self::SampleType) -> Self::RecycledType {
         let pk = black_box(

--- a/soroban-env-host/src/cost_runner/cost_types/verify_ed25519_sig.rs
+++ b/soroban-env-host/src/cost_runner/cost_types/verify_ed25519_sig.rs
@@ -1,13 +1,13 @@
 use std::hint::black_box;
 
 use crate::{cost_runner::CostRunner, xdr::ContractCostType};
-use ed25519_dalek::{PublicKey, Signature};
+use ed25519_dalek::{Signature, VerifyingKey};
 
 pub struct VerifyEd25519SigRun;
 
 #[derive(Clone)]
 pub struct VerifyEd25519SigSample {
-    pub key: PublicKey,
+    pub key: VerifyingKey,
     pub msg: Vec<u8>,
     pub sig: Signature,
 }

--- a/soroban-env-host/src/test/token.rs
+++ b/soroban-env-host/src/test/token.rs
@@ -11,14 +11,14 @@ use crate::{
         testutils::{
             account_to_address, authorize_single_invocation,
             authorize_single_invocation_with_nonce, contract_id_to_address, create_account,
-            generate_keypair, keypair_to_account_id, AccountSigner, HostVec, TestSigner,
+            generate_signing_key, signing_key_to_account_id, AccountSigner, HostVec, TestSigner,
         },
         token::test_token::TestToken,
     },
     test::util::generate_bytes_array,
     Host, HostError, LedgerInfo,
 };
-use ed25519_dalek::Keypair;
+use ed25519_dalek::SigningKey;
 use soroban_env_common::{
     xdr::{
         self, AccountFlags, InvokeContractArgs, ScAddress, ScSymbol, ScVal,
@@ -38,11 +38,11 @@ use crate::native_contract::base_types::BytesN;
 
 struct TokenTest {
     host: Host,
-    issuer_key: Keypair,
-    user_key: Keypair,
-    user_key_2: Keypair,
-    user_key_3: Keypair,
-    user_key_4: Keypair,
+    issuer_key: SigningKey,
+    user_key: SigningKey,
+    user_key_2: SigningKey,
+    user_key_3: SigningKey,
+    user_key_4: SigningKey,
     asset_code: [u8; 4],
 }
 
@@ -63,11 +63,11 @@ impl TokenTest {
         .unwrap();
         Self {
             host,
-            issuer_key: generate_keypair(),
-            user_key: generate_keypair(),
-            user_key_2: generate_keypair(),
-            user_key_3: generate_keypair(),
-            user_key_4: generate_keypair(),
+            issuer_key: generate_signing_key(),
+            user_key: generate_signing_key(),
+            user_key_2: generate_signing_key(),
+            user_key_3: generate_signing_key(),
+            user_key_4: generate_signing_key(),
             asset_code: [0_u8; 4],
         }
     }
@@ -80,7 +80,7 @@ impl TokenTest {
     }
 
     fn default_token(&self) -> TestToken {
-        let issuer_id = keypair_to_account_id(&self.issuer_key);
+        let issuer_id = signing_key_to_account_id(&self.issuer_key);
         self.create_account(
             &issuer_id,
             vec![(&self.issuer_key, 100)],
@@ -121,7 +121,7 @@ impl TokenTest {
     fn create_default_trustline(&self, user: &TestSigner) -> Rc<LedgerKey> {
         self.create_trustline(
             &user.account_id(),
-            &keypair_to_account_id(&self.issuer_key),
+            &signing_key_to_account_id(&self.issuer_key),
             &self.asset_code,
             0,
             i64::MAX,
@@ -148,7 +148,7 @@ impl TokenTest {
     fn create_account(
         &self,
         account_id: &AccountId,
-        signers: Vec<(&Keypair, u32)>,
+        signers: Vec<(&SigningKey, u32)>,
         balance: i64,
         num_sub_entries: u32,
         thresholds: [u8; 4],
@@ -311,7 +311,7 @@ fn to_contract_err(e: HostError) -> ContractError {
 fn test_native_token_smart_roundtrip() {
     let test = TokenTest::setup();
 
-    let account_id = keypair_to_account_id(&test.user_key);
+    let account_id = signing_key_to_account_id(&test.user_key);
     test.create_account(
         &account_id,
         vec![(&test.user_key, 100)],
@@ -351,8 +351,8 @@ fn test_native_token_smart_roundtrip() {
 fn test_asset_init(asset_code: &[u8]) {
     let test = TokenTest::setup();
 
-    let account_id = keypair_to_account_id(&test.user_key);
-    let issuer_id = keypair_to_account_id(&test.issuer_key);
+    let account_id = signing_key_to_account_id(&test.user_key);
+    let issuer_id = signing_key_to_account_id(&test.issuer_key);
 
     test.create_account(
         &account_id,
@@ -406,7 +406,7 @@ fn test_asset_init(asset_code: &[u8]) {
 
     let mut expected = String::from_utf8(asset_code.to_vec()).unwrap();
     expected.push(':');
-    let k = ed25519::PublicKey(test.issuer_key.public.to_bytes());
+    let k = ed25519::PublicKey(test.issuer_key.verifying_key().to_bytes());
     expected.push_str(k.to_string().as_str());
 
     assert_eq!(name, expected);
@@ -879,7 +879,7 @@ fn test_burn() {
 fn test_cannot_burn_native() {
     let test = TokenTest::setup();
     let token = TestToken::new_from_asset(&test.host, Asset::Native);
-    let user_acc_id = keypair_to_account_id(&test.user_key);
+    let user_acc_id = signing_key_to_account_id(&test.user_key);
 
     let user = TestSigner::account_with_multisig(&user_acc_id, vec![&test.user_key]);
     let user2 = TestSigner::account(&test.user_key_2);
@@ -1048,7 +1048,7 @@ fn test_clawback_on_contract() {
 
     let issuer_ledger_key = test
         .host
-        .to_account_key(keypair_to_account_id(&test.issuer_key));
+        .to_account_key(signing_key_to_account_id(&test.issuer_key));
 
     let user_1 = generate_bytes_array();
     let user_2 = generate_bytes_array();
@@ -1114,7 +1114,7 @@ fn test_auth_revocable_on_contract() {
 
     let issuer_ledger_key = test
         .host
-        .to_account_key(keypair_to_account_id(&test.issuer_key));
+        .to_account_key(signing_key_to_account_id(&test.issuer_key));
 
     let user_1 = generate_bytes_array();
     let user_1_addr = contract_id_to_address(&test.host, user_1);
@@ -1249,7 +1249,7 @@ fn test_set_admin() {
 fn test_account_spendable_balance() {
     let test = TokenTest::setup();
     let token = TestToken::new_from_asset(&test.host, Asset::Native);
-    let user_acc_id = keypair_to_account_id(&test.user_key);
+    let user_acc_id = signing_key_to_account_id(&test.user_key);
     let user_addr = account_to_address(&test.host, user_acc_id.clone());
 
     test.create_account(
@@ -1273,8 +1273,8 @@ fn test_account_spendable_balance() {
 fn test_trustline_auth() {
     let test = TokenTest::setup();
     // the admin is the issuer_key
-    let admin_acc_id = keypair_to_account_id(&test.issuer_key);
-    let user_acc_id = keypair_to_account_id(&test.user_key);
+    let admin_acc_id = signing_key_to_account_id(&test.issuer_key);
+    let user_acc_id = signing_key_to_account_id(&test.user_key);
 
     let admin = TestSigner::account_with_multisig(&admin_acc_id, vec![&test.issuer_key]);
     let user = TestSigner::account_with_multisig(&user_acc_id, vec![&test.user_key]);
@@ -1436,8 +1436,8 @@ fn test_trustline_auth() {
 #[test]
 fn test_account_invoker_auth_with_issuer_admin() {
     let test = TokenTest::setup();
-    let admin_acc = keypair_to_account_id(&test.issuer_key);
-    let user_acc = keypair_to_account_id(&test.user_key);
+    let admin_acc = signing_key_to_account_id(&test.issuer_key);
+    let user_acc = signing_key_to_account_id(&test.user_key);
 
     test.create_account(
         &admin_acc,
@@ -1644,9 +1644,9 @@ fn test_contract_invoker_auth() {
     assert_eq!(token.balance(admin_contract_address.clone()).unwrap(), 1700);
 
     // Account invoker can't perform unauthorized admin operation.
-    let acc_invoker = TestSigner::AccountInvoker(keypair_to_account_id(&test.issuer_key));
+    let acc_invoker = TestSigner::AccountInvoker(signing_key_to_account_id(&test.issuer_key));
     assert_eq!(
-        test.run_from_account(keypair_to_account_id(&test.issuer_key), || {
+        test.run_from_account(signing_key_to_account_id(&test.issuer_key), || {
             token.mint(&acc_invoker, user_contract_address.clone(), 1000)
         })
         .err()
@@ -1850,7 +1850,7 @@ fn test_auth_rejected_for_incorrect_payload() {
 fn test_classic_account_multisig_auth() {
     let test = TokenTest::setup();
 
-    let account_id = keypair_to_account_id(&test.user_key);
+    let account_id = signing_key_to_account_id(&test.user_key);
     test.create_account(
         &account_id,
         vec![
@@ -2036,7 +2036,7 @@ fn test_classic_account_multisig_auth() {
         &test.user_key_3,
         &test.user_key_4,
     ];
-    out_of_order_signers.sort_by_key(|k| k.public.as_bytes());
+    out_of_order_signers.sort_by_key(|k| k.verifying_key().as_bytes().clone());
     out_of_order_signers.swap(1, 2);
     assert!(token
         .transfer(
@@ -2141,8 +2141,8 @@ fn test_native_token_classic_balance_boundaries(
 ) {
     let token = TestToken::new_from_asset(&test.host, Asset::Native);
 
-    let new_balance_key = generate_keypair();
-    let new_balance_acc = keypair_to_account_id(&new_balance_key);
+    let new_balance_key = generate_signing_key();
+    let new_balance_acc = signing_key_to_account_id(&new_balance_key);
     let new_balance_signer =
         TestSigner::account_with_multisig(&new_balance_acc, vec![&new_balance_key]);
     test.create_account(
@@ -2194,8 +2194,8 @@ fn test_native_token_classic_balance_boundaries(
     // to the account being tested. That's not a realistic scenario
     // given limited XLM supply, but that's the only way to
     // cover max_balance.
-    let large_balance_key = generate_keypair();
-    let large_balance_acc = keypair_to_account_id(&large_balance_key);
+    let large_balance_key = generate_signing_key();
+    let large_balance_acc = signing_key_to_account_id(&large_balance_key);
     let large_balance_signer =
         TestSigner::account_with_multisig(&large_balance_acc, vec![&large_balance_key]);
     test.create_account(
@@ -2242,7 +2242,7 @@ fn test_native_token_classic_balance_boundaries(
 fn test_native_token_classic_balance_boundaries_simple() {
     let test = TokenTest::setup();
 
-    let account_id = keypair_to_account_id(&test.user_key);
+    let account_id = signing_key_to_account_id(&test.user_key);
     let user = TestSigner::account_with_multisig(&account_id, vec![&test.user_key]);
     // Account with no liabilities/sponsorships.
     test.create_account(
@@ -2270,7 +2270,7 @@ fn test_native_token_classic_balance_boundaries_simple() {
 #[test]
 fn test_native_token_classic_balance_boundaries_with_liabilities() {
     let test = TokenTest::setup();
-    let account_id = keypair_to_account_id(&test.user_key);
+    let account_id = signing_key_to_account_id(&test.user_key);
     let user = TestSigner::account_with_multisig(&account_id, vec![&test.user_key]);
     test.create_account(
         &account_id,
@@ -2299,7 +2299,7 @@ fn test_native_token_classic_balance_boundaries_with_liabilities() {
 #[test]
 fn test_native_token_classic_balance_boundaries_with_sponsorships() {
     let test = TokenTest::setup();
-    let account_id = keypair_to_account_id(&test.user_key);
+    let account_id = signing_key_to_account_id(&test.user_key);
     let user = TestSigner::account_with_multisig(&account_id, vec![&test.user_key]);
     test.create_account(
         &account_id,
@@ -2327,7 +2327,7 @@ fn test_native_token_classic_balance_boundaries_with_sponsorships() {
 #[test]
 fn test_native_token_classic_balance_boundaries_with_sponsorships_and_liabilities() {
     let test = TokenTest::setup();
-    let account_id = keypair_to_account_id(&test.user_key);
+    let account_id = signing_key_to_account_id(&test.user_key);
     let user = TestSigner::account_with_multisig(&account_id, vec![&test.user_key]);
     test.create_account(
         &account_id,
@@ -2356,7 +2356,7 @@ fn test_native_token_classic_balance_boundaries_with_sponsorships_and_liabilitie
 #[test]
 fn test_native_token_classic_balance_boundaries_with_large_values() {
     let test = TokenTest::setup();
-    let account_id = keypair_to_account_id(&test.user_key);
+    let account_id = signing_key_to_account_id(&test.user_key);
     let user = TestSigner::account_with_multisig(&account_id, vec![&test.user_key]);
     test.create_account(
         &account_id,
@@ -2389,7 +2389,7 @@ fn test_wrapped_asset_classic_balance_boundaries(
     limit: i64,
 ) {
     let test = TokenTest::setup();
-    let account_id = keypair_to_account_id(&test.user_key);
+    let account_id = signing_key_to_account_id(&test.user_key);
     let user = TestSigner::account_with_multisig(&account_id, vec![&test.user_key]);
     test.create_account(
         &account_id,
@@ -2402,7 +2402,7 @@ fn test_wrapped_asset_classic_balance_boundaries(
         0,
     );
 
-    let account_id2 = keypair_to_account_id(&test.user_key_2);
+    let account_id2 = signing_key_to_account_id(&test.user_key_2);
     let user2 = TestSigner::account_with_multisig(&account_id2, vec![&test.user_key_2]);
     test.create_account(
         &account_id2,
@@ -2415,7 +2415,7 @@ fn test_wrapped_asset_classic_balance_boundaries(
         0,
     );
 
-    let issuer_id = keypair_to_account_id(&test.issuer_key);
+    let issuer_id = signing_key_to_account_id(&test.issuer_key);
     let issuer = TestSigner::account_with_multisig(&issuer_id, vec![&test.issuer_key]);
     test.create_account(
         &issuer_id,
@@ -2578,7 +2578,7 @@ fn test_asset_token_classic_balance_boundaries_large_values() {
 #[test]
 fn test_classic_transfers_not_possible_for_unauthorized_asset() {
     let test = TokenTest::setup();
-    let account_id = keypair_to_account_id(&test.user_key);
+    let account_id = signing_key_to_account_id(&test.user_key);
     let user = TestSigner::account(&test.user_key);
     test.create_account(
         &account_id,
@@ -2591,7 +2591,7 @@ fn test_classic_transfers_not_possible_for_unauthorized_asset() {
         0,
     );
 
-    let issuer_id = keypair_to_account_id(&test.issuer_key);
+    let issuer_id = signing_key_to_account_id(&test.issuer_key);
 
     let trustline_key = test.create_trustline(
         &account_id,
@@ -2647,7 +2647,10 @@ fn test_classic_transfers_not_possible_for_unauthorized_asset() {
 }
 
 #[allow(clippy::type_complexity)]
-fn simple_account_sign_fn<'a>(host: &'a Host, kp: &'a Keypair) -> Box<dyn Fn(&[u8]) -> Val + 'a> {
+fn simple_account_sign_fn<'a>(
+    host: &'a Host,
+    kp: &'a SigningKey,
+) -> Box<dyn Fn(&[u8]) -> Val + 'a> {
     use crate::native_contract::testutils::sign_payload_for_ed25519;
     Box::new(|payload: &[u8]| -> Val { sign_payload_for_ed25519(host, kp, payload).into() })
 }
@@ -2659,7 +2662,7 @@ fn test_custom_account_auth() {
     use soroban_test_wasms::SIMPLE_ACCOUNT_CONTRACT;
 
     let test = TokenTest::setup();
-    let admin_kp = generate_keypair();
+    let admin_kp = generate_signing_key();
     let account_contract_addr_obj = test
         .host
         .register_test_contract_wasm(SIMPLE_ACCOUNT_CONTRACT);
@@ -2674,7 +2677,7 @@ fn test_custom_account_auth() {
         &test.host,
         &test
             .host
-            .bytes_new_from_slice(admin_kp.public.as_bytes().as_slice())
+            .bytes_new_from_slice(admin_kp.verifying_key().as_bytes().as_slice())
             .unwrap(),
     )
     .unwrap();
@@ -2698,7 +2701,7 @@ fn test_custom_account_auth() {
 
     // Create a signer for the new admin, but not yet set its key as the account
     // owner.
-    let new_admin_kp = generate_keypair();
+    let new_admin_kp = generate_signing_key();
     let new_admin = TestSigner::AccountContract(AccountContractSigner {
         address: account_contract_addr,
         sign: simple_account_sign_fn(&test.host, &new_admin_kp),
@@ -2707,7 +2710,7 @@ fn test_custom_account_auth() {
         &test.host,
         &test
             .host
-            .bytes_new_from_slice(new_admin_kp.public.as_bytes().as_slice())
+            .bytes_new_from_slice(new_admin_kp.verifying_key().as_bytes().as_slice())
             .unwrap(),
     )
     .unwrap();

--- a/soroban-test-wasms/wasm-workspace/Cargo.lock
+++ b/soroban-test-wasms/wasm-workspace/Cargo.lock
@@ -244,6 +244,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.0.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436ace70fc06e06f7f689d2624dc4e2f0ea666efb5aa704215f7249ae6e047a7"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "platforms",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,16 +378,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fb04eee5d9d907f29e80ee6b0e78f7e2c82342c63e3580d8c4f69d9d5aad963"
+dependencies = [
+ "pkcs8",
+ "signature 2.1.0",
+]
+
+[[package]]
 name = "ed25519-dalek"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
- "rand",
+ "curve25519-dalek 3.2.0",
+ "ed25519 1.5.3",
+ "rand 0.7.3",
  "serde",
  "sha2 0.9.9",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.0.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faa8e9049d5d72bfc12acbc05914731b5322f79b5e2f195e9f2d705fca22ab4c"
+dependencies = [
+ "curve25519-dalek 4.0.0-rc.3",
+ "ed25519 2.2.1",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2 0.10.6",
  "zeroize",
 ]
 
@@ -502,6 +554,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
 
 [[package]]
 name = "fnv"
@@ -790,6 +848,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "platforms"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -831,9 +895,20 @@ checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom 0.1.16",
  "libc",
- "rand_chacha",
+ "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -844,6 +919,16 @@ checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1069,8 +1154,8 @@ name = "soroban-env-host"
 version = "0.0.17"
 dependencies = [
  "backtrace",
- "curve25519-dalek",
- "ed25519-dalek",
+ "curve25519-dalek 4.0.0-rc.3",
+ "ed25519-dalek 2.0.0-rc.3",
  "getrandom 0.2.10",
  "hex",
  "k256",
@@ -1078,9 +1163,9 @@ dependencies = [
  "num-derive",
  "num-integer",
  "num-traits",
- "rand",
- "rand_chacha",
- "sha2 0.9.9",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "sha2 0.10.6",
  "sha3",
  "soroban-env-common",
  "soroban-native-sdk-macros",
@@ -1131,8 +1216,8 @@ dependencies = [
  "arbitrary",
  "bytes-lit",
  "ctor",
- "ed25519-dalek",
- "rand",
+ "ed25519-dalek 1.0.1",
+ "rand 0.7.3",
  "soroban-env-guest",
  "soroban-env-host",
  "soroban-ledger-snapshot",


### PR DESCRIPTION
This is related to #963 -- it turns out dalek only released a stable (4.0) of the _curve25519_ crate not the _ed25519_ crate -- they're still working on the latter. This PR does the work of upgrading to a prerelease state of both (4.0-rc.3 and 2.0-rc.3 respectively) which is .. _probably_ identical API-wise to what we'll see on 4.0 and 2.0. But it's not stable _yet_.

I'm not 100% sure what to do here. I think it's _probably_ better to move to their prereleases assuming an imminent and uneventful final (especially given how old and unmaintained the previous release had got). But that could also be taking a risk of immature or incompletely-tested new code we don't really want to take. Open to input.