### PR TITLE
Tighten signature of unchecked_visit_val_obj, fix #595

### DIFF
--- a/soroban-env-host/src/cost_runner/cost_types/visit_object.rs
+++ b/soroban-env-host/src/cost_runner/cost_types/visit_object.rs
@@ -14,18 +14,14 @@ impl CostRunner for VisitObjectRun {
     type RecycledType = Self::SampleType;
 
     fn run_iter(host: &crate::Host, iter: u64, sample: Self::SampleType) -> Self::RecycledType {
-        unsafe {
-            let _ = black_box(
-                host.unchecked_visit_val_obj(sample[iter as usize % sample.len()], |obj| match obj
-                    .unwrap()
-                {
-                    HostObject::I64(i) => Ok(*i),
-                    _ => panic!("unexpected type, check HCM"),
-                })
-                .unwrap(),
-            );
-            black_box(sample)
-        }
+        let _ = black_box(
+            host.visit_obj_untyped(sample[iter as usize % sample.len()], |obj| match obj {
+                HostObject::I64(i) => Ok(*i),
+                _ => panic!("unexpected type, check HCM"),
+            })
+            .unwrap(),
+        );
+        black_box(sample)
     }
 
     fn run_baseline_iter(

--- a/soroban-env-host/src/host/comparison.rs
+++ b/soroban-env-host/src/host/comparison.rs
@@ -638,11 +638,9 @@ mod tests {
 
         pairs_xdr_sorted.sort_by(|&(v1, _), &(v2, _)| v1.cmp(&v2));
 
-        pairs_host_sorted.sort_by(|&(_, v1), &(_, v2)| unsafe {
-            host.unchecked_visit_val_obj(v1, |v1| {
-                host.unchecked_visit_val_obj(v2, |v2| {
-                    let v1 = v1.unwrap();
-                    let v2 = v2.unwrap();
+        pairs_host_sorted.sort_by(|&(_, v1), &(_, v2)| {
+            host.visit_obj_untyped(v1, |v1| {
+                host.visit_obj_untyped(v2, |v2| {
                     let v1d = host_obj_discriminant(v1);
                     let v2d = host_obj_discriminant(v2);
                     Ok(v1d.cmp(&v2d))


### PR DESCRIPTION
This does three things:

- Sinks the check for unknown object handles into `unchecked_visit_val_obj` (it's currently done in all callers).
- Removes the `unsafe` qualifier, there's really nothing about it that a caller has to think carefully about (and arguably we're misusing `unsafe` for this purpose all through the codebase, I expect nobody appreciates this instance!)
- Renames the function to be a little less hazardous-sounding: `visit_obj_untyped`

This (plus earlier work tightening up its args) addresses anything I had in mind for #595