### PR TITLE
Tighten dependencies further

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,13 +349,13 @@ dependencies = [
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cdeb9ec472d588e539a818b2dee436825730da08ad0017c4b1a17676bdc8b7"
+checksum = "53e0efad4403bfc52dc201159c4b842a246a14b98c64b55dfd0f2d89729dfeb8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -674,27 +674,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 
 [[package]]
-name = "int-enum"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff87d3cc4b79b4559e3c75068d64247284aceb6a038bd4bb38387f3f164476d"
-dependencies = [
- "int-enum-impl",
-]
-
-[[package]]
-name = "int-enum-impl"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1f2f068675add1a3fc77f5f5ab2e29290c841ee34d151abc007bce902e5d34"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -911,13 +890,13 @@ dependencies = [
 
 [[package]]
 name = "num-derive"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+checksum = "9e6a0fd4f737c707bd9086cc16c925f294943eb62eb71499e9fd4cf71f8b9f4e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -948,6 +927,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70bf6736f74634d299d00086f02986875b3c2d924781a6a2cb6c201e73da0ceb"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ea360eafe1022f7cc56cd7b869ed57330fb2453d0c7831d99b74c65d2f5597"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -1066,9 +1066,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.58"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1365,10 +1365,9 @@ dependencies = [
  "arbitrary",
  "crate-git-revision",
  "ethnum",
- "int-enum",
  "num-derive",
- "num-integer",
  "num-traits",
+ "num_enum",
  "serde",
  "soroban-env-macros",
  "soroban-wasmi",
@@ -1434,7 +1433,6 @@ dependencies = [
  "serde_json",
  "stellar-xdr",
  "syn 2.0.16",
- "thiserror",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -44,13 +44,6 @@ exclude = [
    "ansi_term",
    "textplots",
    "linregress",
-   # for the time being some metaprogramming crates haven't updated to syn 2. The
-   # only way to deal with these is to prune them from the tree.
-   "derive_arbitrary",
-   "num-derive",
-   "zeroize_derive",
-   # also a not upgraded to syn 2, but just a dev-dep anyway
-   "int-enum",
    # the dep specs of tracy-client are weird and include "loom" which it
    # totally doesn't depend on but in any case it's compiled-out in real
    # production builds we care about.

--- a/soroban-env-common/Cargo.toml
+++ b/soroban-env-common/Cargo.toml
@@ -22,11 +22,10 @@ static_assertions = "1.1.0"
 ethnum = "1.3.2"
 arbitrary = { version = "1.3.0", features = ["derive"], optional = true }
 num-traits = {version = "0.2.15", default-features = false}
-num-integer = {version = "0.1.45", default-features = false}
-num-derive = "0.3.3"
+num-derive = "0.4.0"
 
 [dev-dependencies]
-int-enum = "0.5.0"
+num_enum = "0.7.0"
 num-traits = "0.2.15"
 
 [features]

--- a/soroban-env-common/src/val.rs
+++ b/soroban-env-common/src/val.rs
@@ -42,7 +42,7 @@ sa::const_assert!(MAJOR_BITS + MINOR_BITS == BODY_BITS);
 /// special cases (boolean true and false, small-value forms).
 #[repr(u8)]
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
-#[cfg_attr(test, derive(int_enum::IntEnum))]
+#[cfg_attr(test, derive(num_enum::TryFromPrimitive))]
 pub enum Tag {
     /// Tag for a [Val] that encodes [bool] `false`. The bool type is refined to
     /// two single-value subtypes in order for each tag number to coincides with
@@ -770,14 +770,14 @@ fn test_debug() {
 // `Tag::from_u8` is implemented by hand unsafely.
 //
 // This test ensures that all cases are correct by comparing to the
-// macro-generated results of the int-enum crate, which is only enabled as a
+// macro-generated results of the num_enum crate, which is only enabled as a
 // dev-dependency.
 #[test]
 fn test_tag_from_u8() {
-    use int_enum::IntEnum;
+    use num_enum::TryFromPrimitive;
 
     for i in 0_u8..=255 {
-        let expected_tag = Tag::from_int(i);
+        let expected_tag = Tag::try_from_primitive(i);
         let actual_tag = Tag::from_u8(i);
         match expected_tag {
             Ok(

--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -27,7 +27,7 @@ rand_chacha = "0.3.1"
 hex = "0.4.3"
 num-traits = "0.2.15"
 num-integer = "0.1.45"
-num-derive = "0.3.3"
+num-derive = "0.4.0"
 log = "0.4.17"
 backtrace = "0.3"
 k256 = {version = "0.13.1", features=["ecdsa", "arithmetic"]}

--- a/soroban-env-macros/Cargo.toml
+++ b/soroban-env-macros/Cargo.toml
@@ -20,7 +20,6 @@ proc-macro2 = "1.0"
 itertools = "0.10.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-thiserror = "1.0"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
In the process of updating deps in the SDK to take the dalek change I realized most of the syn2 exemptions are also no longer needed, so I tidied these up in env as well, and also got rid of a few unused deps.