### PR TITLE
Update XDR to take change that removes SCSpecTypeSet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1506,7 +1506,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "0.0.17"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=2d2526f515a476b1e3df70233a4cf9232287977e#2d2526f515a476b1e3df70233a4cf9232287977e"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=e2a9cbf72d94941de1bde6ba34a38e1f49328567#e2a9cbf72d94941de1bde6ba34a38e1f49328567"
 dependencies = [
  "arbitrary",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ soroban-native-sdk-macros = { version = "0.0.17", path = "soroban-native-sdk-mac
 [workspace.dependencies.stellar-xdr]
 version = "0.0.17"
 git = "https://github.com/stellar/rs-stellar-xdr"
-rev = "2d2526f515a476b1e3df70233a4cf9232287977e"
+rev = "e2a9cbf72d94941de1bde6ba34a38e1f49328567"
 default-features = false
 
 [workspace.dependencies.wasmi]


### PR DESCRIPTION
This will just update the env to take the XDR change that removes SCSpecTypeSet. Will need to adjust it once the XDR actually lands.