### PR TITLE
Fix comparison in Tag::is_object

### DIFF
--- a/soroban-env-common/src/val.rs
+++ b/soroban-env-common/src/val.rs
@@ -153,9 +153,11 @@ impl Tag {
     pub fn rawval_const(&self) -> i64 {
         *self as i64
     }
+
+    #[inline(always)]
     pub const fn is_object(self) -> bool {
         let tu8 = self as u8;
-        tu8 > (Tag::ObjectCodeLowerBound as u8) || tu8 < (Tag::ObjectCodeUpperBound as u8)
+        tu8 > (Tag::ObjectCodeLowerBound as u8) && tu8 < (Tag::ObjectCodeUpperBound as u8)
     }
 
     #[inline(always)]
@@ -622,8 +624,7 @@ impl Val {
 
     #[inline(always)]
     pub const fn is_object(self) -> bool {
-        let tag = self.get_tag_u8();
-        tag > (Tag::ObjectCodeLowerBound as u8) && tag < (Tag::ObjectCodeUpperBound as u8)
+        self.get_tag().is_object()
     }
 
     #[inline(always)]


### PR DESCRIPTION
### What

Fix `Tag::is_object` and delegate `Val::is_object` to it.

### Why

The comparison in `Tag::is_object` is incorrect, causing the function to always return `true`.

This code is duplicated from the (correct) `Val::is_object` function.

### Known limitations

None.
