### PR TITLE
Fix comparison in Tag::is_object

### DIFF
--- a/soroban-env-common/src/val.rs
+++ b/soroban-env-common/src/val.rs
@@ -155,7 +155,7 @@ impl Tag {
     }
     pub const fn is_object(self) -> bool {
         let tu8 = self as u8;
-        tu8 > (Tag::ObjectCodeLowerBound as u8) || tu8 < (Tag::ObjectCodeUpperBound as u8)
+        tu8 > (Tag::ObjectCodeLowerBound as u8) && tu8 < (Tag::ObjectCodeUpperBound as u8)
     }
 
     #[inline(always)]


### PR DESCRIPTION
### What

Fix comparison in `Tag::is_object`.

### Why

This function incorrectly always returns true. The more-commonly-used `Val::is_object` is correct. This patch makes both functions agree.

I would prefer `Val::is_object` delegate to `Tag::is_object`, but that can't be done without constructing a `Tag`, which has several branches, and I take it `Val::is_object` is a fast path.

### Known limitations

`Tag::is_object` and `Val::is_object` duplicate code.