### PR TITLE
Take change from txSOROBAN_RESOURCE_LIMIT_EXCEEDED to txSOROBAN_INVALID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1506,7 +1506,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "0.0.17"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=936273b737b99d79eee7a28dd4823436d0bd0abb#936273b737b99d79eee7a28dd4823436d0bd0abb"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=39904e09941046dab61e6e35fc89e31bf2dea1cd#39904e09941046dab61e6e35fc89e31bf2dea1cd"
 dependencies = [
  "arbitrary",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ soroban-native-sdk-macros = { version = "0.0.17", path = "soroban-native-sdk-mac
 [workspace.dependencies.stellar-xdr]
 version = "0.0.17"
 git = "https://github.com/stellar/rs-stellar-xdr"
-rev = "936273b737b99d79eee7a28dd4823436d0bd0abb"
+rev = "39904e09941046dab61e6e35fc89e31bf2dea1cd"
 default-features = false
 
 [workspace.dependencies.wasmi]


### PR DESCRIPTION
Implementation of [this plan](https://github.com/stellar/stellar-xdr/pull/141#discussion_r1307930385). Needs to not land until the corresponding XDR and rs-XDR lands and its rev is updated.