### PR TITLE
Add "coverage" Makefile target for lcov.info, add a test that extends coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,8 @@ publish:
 
 publish-dry-run:
 	./publish-dry-run.sh
+
+# Requires: cargo-install llvm-cov
+coverage:
+	rm -f lcov.info
+	cargo llvm-cov test --all-features --tests --lcov --output-path=lcov.info

--- a/soroban-env-host/src/events/diagnostic.rs
+++ b/soroban-env-host/src/events/diagnostic.rs
@@ -177,3 +177,20 @@ impl Host {
         })
     }
 }
+
+#[test]
+fn misc_coverage() -> Result<(), HostError> {
+    use crate::xdr::HostFunctionType;
+    let host = Host::default();
+
+    // cover get_current_contract_id_unmetered on HostFunctionType::InvokeContract
+    host.with_frame(
+        Frame::HostFunction(HostFunctionType::InvokeContract),
+        || {
+            assert_eq!(host.get_current_contract_id_unmetered()?, None);
+            Ok(Val::VOID.into())
+        },
+    )?;
+
+    Ok(())
+}


### PR DESCRIPTION
This adds a `make coverage` target that you can use to make an `lcov.info` file in your workspace. This in turn can be used directly by the VSCode [coverage gutters extension](https://marketplace.visualstudio.com/items?itemName=ryanluker.vscode-coverage-gutters) to display code coverage while editing and/or reviewing code.

It should be a helpful signal for review (and improving coverage).