### PR TITLE
Graydon code review

### DIFF
--- a/soroban-env-common/src/arbitrary.rs
+++ b/soroban-env-common/src/arbitrary.rs
@@ -10,9 +10,8 @@ use arbitrary::{Arbitrary, Unstructured};
 
 impl<'a> Arbitrary<'a> for Error {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let scstatus = ScError::arbitrary(u)?;
-        let status = Error::from(scstatus);
-
-        Ok(status)
+        let scerror = ScError::arbitrary(u)?;
+        let error = Error::from(scerror);
+        Ok(error)
     }
 }

--- a/soroban-env-common/src/convert.rs
+++ b/soroban-env-common/src/convert.rs
@@ -1,15 +1,16 @@
 use crate::{
     num::{i256_from_pieces, i256_into_pieces, u256_from_pieces, u256_into_pieces},
-    ConversionError, DurationSmall, DurationVal, Env, I128Small, I128Val, I256Small, I256Val,
-    I64Small, TimepointSmall, TimepointVal, U128Small, U128Val, U256Small, U256Val, U64Small,
-    U64Val, Val, I256, U256,
+    DurationSmall, DurationVal, Env, I128Small, I128Val, I256Small, I256Val, I64Small,
+    TimepointSmall, TimepointVal, U128Small, U128Val, U256Small, U256Val, U64Small, U64Val, Val,
+    I256, U256,
 };
 use core::fmt::Debug;
 use stellar_xdr::int128_helpers;
 
 #[cfg(feature = "std")]
 use crate::{
-    num, object::ScValObjRef, val::ValConvert, Error, Object, ScValObject, SymbolSmall, Tag,
+    num, object::ScValObjRef, val::ValConvert, ConversionError, Error, Object, ScValObject,
+    SymbolSmall, Tag,
 };
 #[cfg(feature = "std")]
 use stellar_xdr::{
@@ -59,7 +60,7 @@ where
 // i64 conversions
 
 impl<E: Env> TryFromVal<E, Val> for i64 {
-    type Error = ConversionError;
+    type Error = crate::Error;
 
     fn try_from_val(env: &E, val: &Val) -> Result<Self, Self::Error> {
         let val = *val;
@@ -67,20 +68,20 @@ impl<E: Env> TryFromVal<E, Val> for i64 {
             Ok(so.into())
         } else {
             let obj = val.try_into()?;
-            Ok(env.obj_to_i64(obj).map_err(|_| ConversionError)?)
+            Ok(env.obj_to_i64(obj).map_err(Into::into)?)
         }
     }
 }
 
 impl<E: Env> TryFromVal<E, i64> for Val {
-    type Error = ConversionError;
+    type Error = crate::Error;
 
     fn try_from_val(env: &E, v: &i64) -> Result<Self, Self::Error> {
         let v = *v;
         if let Ok(so) = I64Small::try_from(v) {
             Ok(so.into())
         } else {
-            Ok(env.obj_from_i64(v).map_err(|_| ConversionError)?.to_val())
+            Ok(env.obj_from_i64(v).map_err(Into::into)?.to_val())
         }
     }
 }
@@ -88,7 +89,7 @@ impl<E: Env> TryFromVal<E, i64> for Val {
 // u64 conversions
 
 impl<E: Env> TryFromVal<E, Val> for u64 {
-    type Error = ConversionError;
+    type Error = crate::Error;
 
     fn try_from_val(env: &E, val: &Val) -> Result<Self, Self::Error> {
         let val = *val;
@@ -96,13 +97,13 @@ impl<E: Env> TryFromVal<E, Val> for u64 {
             Ok(so.into())
         } else {
             let obj = val.try_into()?;
-            Ok(env.obj_to_u64(obj).map_err(|_| ConversionError)?)
+            Ok(env.obj_to_u64(obj).map_err(Into::into)?)
         }
     }
 }
 
 impl<E: Env> TryFromVal<E, u64> for Val {
-    type Error = ConversionError;
+    type Error = crate::Error;
 
     fn try_from_val(env: &E, v: &u64) -> Result<Self, Self::Error> {
         Ok(U64Val::try_from_val(env, v)?.to_val())
@@ -110,7 +111,7 @@ impl<E: Env> TryFromVal<E, u64> for Val {
 }
 
 impl<E: Env> TryFromVal<E, U64Val> for u64 {
-    type Error = ConversionError;
+    type Error = crate::Error;
 
     fn try_from_val(env: &E, val: &U64Val) -> Result<Self, Self::Error> {
         let val = *val;
@@ -118,20 +119,20 @@ impl<E: Env> TryFromVal<E, U64Val> for u64 {
             Ok(so.into())
         } else {
             let obj = val.try_into()?;
-            Ok(env.obj_to_u64(obj).map_err(|_| ConversionError)?)
+            Ok(env.obj_to_u64(obj).map_err(Into::into)?)
         }
     }
 }
 
 impl<E: Env> TryFromVal<E, u64> for U64Val {
-    type Error = ConversionError;
+    type Error = crate::Error;
 
     fn try_from_val(env: &E, v: &u64) -> Result<Self, Self::Error> {
         let v = *v;
         if let Ok(so) = U64Small::try_from(v) {
             Ok(so.into())
         } else {
-            Ok(env.obj_from_u64(v).map_err(|_| ConversionError)?.into())
+            Ok(env.obj_from_u64(v).map_err(Into::into)?.into())
         }
     }
 }
@@ -139,7 +140,7 @@ impl<E: Env> TryFromVal<E, u64> for U64Val {
 // {Timepoint, Duration} <-> u64 conversions
 
 impl<E: Env> TryFromVal<E, TimepointVal> for u64 {
-    type Error = ConversionError;
+    type Error = crate::Error;
 
     fn try_from_val(env: &E, val: &TimepointVal) -> Result<Self, Self::Error> {
         let val = *val;
@@ -147,29 +148,26 @@ impl<E: Env> TryFromVal<E, TimepointVal> for u64 {
             Ok(so.into())
         } else {
             let obj = val.try_into()?;
-            Ok(env.timepoint_obj_to_u64(obj).map_err(|_| ConversionError)?)
+            Ok(env.timepoint_obj_to_u64(obj).map_err(Into::into)?)
         }
     }
 }
 
 impl<E: Env> TryFromVal<E, u64> for TimepointVal {
-    type Error = ConversionError;
+    type Error = crate::Error;
 
     fn try_from_val(env: &E, v: &u64) -> Result<Self, Self::Error> {
         let v = *v;
         if let Ok(so) = TimepointSmall::try_from(v) {
             Ok(so.into())
         } else {
-            Ok(env
-                .timepoint_obj_from_u64(v)
-                .map_err(|_| ConversionError)?
-                .into())
+            Ok(env.timepoint_obj_from_u64(v).map_err(Into::into)?.into())
         }
     }
 }
 
 impl<E: Env> TryFromVal<E, DurationVal> for u64 {
-    type Error = ConversionError;
+    type Error = crate::Error;
 
     fn try_from_val(env: &E, val: &DurationVal) -> Result<Self, Self::Error> {
         let val = *val;
@@ -177,23 +175,20 @@ impl<E: Env> TryFromVal<E, DurationVal> for u64 {
             Ok(so.into())
         } else {
             let obj = val.try_into()?;
-            Ok(env.duration_obj_to_u64(obj).map_err(|_| ConversionError)?)
+            Ok(env.duration_obj_to_u64(obj).map_err(Into::into)?)
         }
     }
 }
 
 impl<E: Env> TryFromVal<E, u64> for DurationVal {
-    type Error = ConversionError;
+    type Error = crate::Error;
 
     fn try_from_val(env: &E, v: &u64) -> Result<Self, Self::Error> {
         let v = *v;
         if let Ok(so) = DurationSmall::try_from(v) {
             Ok(so.into())
         } else {
-            Ok(env
-                .duration_obj_from_u64(v)
-                .map_err(|_| ConversionError)?
-                .into())
+            Ok(env.duration_obj_from_u64(v).map_err(Into::into)?.into())
         }
     }
 }
@@ -201,7 +196,7 @@ impl<E: Env> TryFromVal<E, u64> for DurationVal {
 // i128 conversions
 
 impl<E: Env> TryFromVal<E, Val> for i128 {
-    type Error = ConversionError;
+    type Error = crate::Error;
 
     fn try_from_val(env: &E, v: &Val) -> Result<Self, Self::Error> {
         let v = *v;
@@ -209,15 +204,15 @@ impl<E: Env> TryFromVal<E, Val> for i128 {
             Ok(so.into())
         } else {
             let obj = v.try_into()?;
-            let hi = env.obj_to_i128_hi64(obj).map_err(|_| ConversionError)?;
-            let lo = env.obj_to_i128_lo64(obj).map_err(|_| ConversionError)?;
+            let hi = env.obj_to_i128_hi64(obj).map_err(Into::into)?;
+            let lo = env.obj_to_i128_lo64(obj).map_err(Into::into)?;
             Ok(int128_helpers::i128_from_pieces(hi, lo))
         }
     }
 }
 
 impl<E: Env> TryFromVal<E, i128> for Val {
-    type Error = ConversionError;
+    type Error = crate::Error;
 
     fn try_from_val(env: &E, v: &i128) -> Result<Self, Self::Error> {
         Ok(I128Val::try_from_val(env, v)?.to_val())
@@ -225,7 +220,7 @@ impl<E: Env> TryFromVal<E, i128> for Val {
 }
 
 impl<E: Env> TryFromVal<E, i128> for I128Val {
-    type Error = ConversionError;
+    type Error = crate::Error;
 
     fn try_from_val(env: &E, v: &i128) -> Result<Self, Self::Error> {
         let v = *v;
@@ -234,7 +229,7 @@ impl<E: Env> TryFromVal<E, i128> for I128Val {
         } else {
             Ok(env
                 .obj_from_i128_pieces(int128_helpers::i128_hi(v), int128_helpers::i128_lo(v))
-                .map_err(|_| ConversionError)?
+                .map_err(Into::into)?
                 .into())
         }
     }
@@ -243,7 +238,7 @@ impl<E: Env> TryFromVal<E, i128> for I128Val {
 // u128 conversions
 
 impl<E: Env> TryFromVal<E, Val> for u128 {
-    type Error = ConversionError;
+    type Error = crate::Error;
 
     fn try_from_val(env: &E, v: &Val) -> Result<Self, Self::Error> {
         let v = *v;
@@ -251,15 +246,15 @@ impl<E: Env> TryFromVal<E, Val> for u128 {
             Ok(so.into())
         } else {
             let obj = v.try_into()?;
-            let hi = env.obj_to_u128_hi64(obj).map_err(|_| ConversionError)?;
-            let lo = env.obj_to_u128_lo64(obj).map_err(|_| ConversionError)?;
+            let hi = env.obj_to_u128_hi64(obj).map_err(Into::into)?;
+            let lo = env.obj_to_u128_lo64(obj).map_err(Into::into)?;
             Ok(int128_helpers::u128_from_pieces(hi, lo))
         }
     }
 }
 
 impl<E: Env> TryFromVal<E, u128> for Val {
-    type Error = ConversionError;
+    type Error = crate::Error;
 
     fn try_from_val(env: &E, v: &u128) -> Result<Self, Self::Error> {
         Ok(U128Val::try_from_val(env, v)?.to_val())
@@ -267,7 +262,7 @@ impl<E: Env> TryFromVal<E, u128> for Val {
 }
 
 impl<E: Env> TryFromVal<E, u128> for U128Val {
-    type Error = ConversionError;
+    type Error = crate::Error;
 
     fn try_from_val(env: &E, v: &u128) -> Result<Self, Self::Error> {
         let v = *v;
@@ -276,7 +271,7 @@ impl<E: Env> TryFromVal<E, u128> for U128Val {
         } else {
             Ok(env
                 .obj_from_u128_pieces(int128_helpers::u128_hi(v), int128_helpers::u128_lo(v))
-                .map_err(|_| ConversionError)?
+                .map_err(Into::into)?
                 .into())
         }
     }
@@ -284,7 +279,7 @@ impl<E: Env> TryFromVal<E, u128> for U128Val {
 
 // i256 conversions
 impl<E: Env> TryFromVal<E, Val> for I256 {
-    type Error = ConversionError;
+    type Error = crate::Error;
 
     fn try_from_val(env: &E, v: &Val) -> Result<Self, Self::Error> {
         let v = *v;
@@ -292,17 +287,17 @@ impl<E: Env> TryFromVal<E, Val> for I256 {
             Ok(so.into())
         } else {
             let obj = v.try_into()?;
-            let hi_hi = env.obj_to_i256_hi_hi(obj).map_err(|_| ConversionError)?;
-            let hi_lo = env.obj_to_i256_hi_lo(obj).map_err(|_| ConversionError)?;
-            let lo_hi = env.obj_to_i256_lo_hi(obj).map_err(|_| ConversionError)?;
-            let lo_lo = env.obj_to_i256_lo_lo(obj).map_err(|_| ConversionError)?;
+            let hi_hi = env.obj_to_i256_hi_hi(obj).map_err(Into::into)?;
+            let hi_lo = env.obj_to_i256_hi_lo(obj).map_err(Into::into)?;
+            let lo_hi = env.obj_to_i256_lo_hi(obj).map_err(Into::into)?;
+            let lo_lo = env.obj_to_i256_lo_lo(obj).map_err(Into::into)?;
             Ok(i256_from_pieces(hi_hi, hi_lo, lo_hi, lo_lo))
         }
     }
 }
 
 impl<E: Env> TryFromVal<E, I256> for Val {
-    type Error = ConversionError;
+    type Error = crate::Error;
 
     fn try_from_val(env: &E, v: &I256) -> Result<Self, Self::Error> {
         Ok(I256Val::try_from_val(env, v)?.to_val())
@@ -310,7 +305,7 @@ impl<E: Env> TryFromVal<E, I256> for Val {
 }
 
 impl<E: Env> TryFromVal<E, I256> for I256Val {
-    type Error = ConversionError;
+    type Error = crate::Error;
 
     fn try_from_val(env: &E, v: &I256) -> Result<Self, Self::Error> {
         let v = *v;
@@ -320,7 +315,7 @@ impl<E: Env> TryFromVal<E, I256> for I256Val {
             let (hi_hi, hi_lo, lo_hi, lo_lo) = i256_into_pieces(v);
             Ok(env
                 .obj_from_i256_pieces(hi_hi, hi_lo, lo_hi, lo_lo)
-                .map_err(|_| ConversionError)?
+                .map_err(Into::into)?
                 .into())
         }
     }
@@ -328,7 +323,7 @@ impl<E: Env> TryFromVal<E, I256> for I256Val {
 
 // u256 conversions
 impl<E: Env> TryFromVal<E, Val> for U256 {
-    type Error = ConversionError;
+    type Error = crate::Error;
 
     fn try_from_val(env: &E, v: &Val) -> Result<Self, Self::Error> {
         let v = *v;
@@ -336,17 +331,17 @@ impl<E: Env> TryFromVal<E, Val> for U256 {
             Ok(so.into())
         } else {
             let obj = v.try_into()?;
-            let hi_hi = env.obj_to_u256_hi_hi(obj).map_err(|_| ConversionError)?;
-            let hi_lo = env.obj_to_u256_hi_lo(obj).map_err(|_| ConversionError)?;
-            let lo_hi = env.obj_to_u256_lo_hi(obj).map_err(|_| ConversionError)?;
-            let lo_lo = env.obj_to_u256_lo_lo(obj).map_err(|_| ConversionError)?;
+            let hi_hi = env.obj_to_u256_hi_hi(obj).map_err(Into::into)?;
+            let hi_lo = env.obj_to_u256_hi_lo(obj).map_err(Into::into)?;
+            let lo_hi = env.obj_to_u256_lo_hi(obj).map_err(Into::into)?;
+            let lo_lo = env.obj_to_u256_lo_lo(obj).map_err(Into::into)?;
             Ok(u256_from_pieces(hi_hi, hi_lo, lo_hi, lo_lo))
         }
     }
 }
 
 impl<E: Env> TryFromVal<E, U256> for Val {
-    type Error = ConversionError;
+    type Error = crate::Error;
 
     fn try_from_val(env: &E, v: &U256) -> Result<Self, Self::Error> {
         Ok(U256Val::try_from_val(env, v)?.to_val())
@@ -354,7 +349,7 @@ impl<E: Env> TryFromVal<E, U256> for Val {
 }
 
 impl<E: Env> TryFromVal<E, U256> for U256Val {
-    type Error = ConversionError;
+    type Error = crate::Error;
 
     fn try_from_val(env: &E, v: &U256) -> Result<Self, Self::Error> {
         let v = *v;
@@ -364,7 +359,7 @@ impl<E: Env> TryFromVal<E, U256> for U256Val {
             let (hi_hi, hi_lo, lo_hi, lo_lo) = u256_into_pieces(v);
             Ok(env
                 .obj_from_u256_pieces(hi_hi, hi_lo, lo_hi, lo_lo)
-                .map_err(|_| ConversionError)?
+                .map_err(Into::into)?
                 .into())
         }
     }

--- a/soroban-env-common/src/convert.rs
+++ b/soroban-env-common/src/convert.rs
@@ -23,11 +23,21 @@ pub trait Convert<F, T> {
     fn convert(&self, f: F) -> Result<T, Self::Error>;
 }
 
+/// The opposite trait to [`TryFromVal`], analogous to the way that [`TryInto`]
+/// exists as an opposite to [`TryFrom`]. Exists only for convenience of doing
+/// conversions via `.try_into_val(e)` or specifying convertability with a bound
+/// like `TryIntoVal<E,Other>`.
 pub trait TryIntoVal<E: Env, V> {
     type Error: Debug;
     fn try_into_val(&self, env: &E) -> Result<V, Self::Error>;
 }
 
+/// Trait for types that can be fallibly converted to another type `V`, analogous
+/// to the standard Rust type [`TryFrom`], but making use of the provided `Env`
+/// implementation `E` in order to convert parts of the type that require it.
+/// Mainly this exists because `Val` types that contain object handles need to
+/// delegate to the environment to look up and extract the content of those
+/// handles.
 pub trait TryFromVal<E: Env, V: ?Sized>: Sized {
     type Error: Debug;
     fn try_from_val(env: &E, v: &V) -> Result<Self, Self::Error>;

--- a/soroban-env-common/src/convert.rs
+++ b/soroban-env-common/src/convert.rs
@@ -20,7 +20,7 @@ use stellar_xdr::{
 /// General trait representing a the ability of some object to perform a
 /// (possibly unsuccessful) conversion between two other types.
 pub trait Convert<F, T> {
-    type Error: Debug;
+    type Error: Debug + Into<crate::Error> + From<crate::Error>;
     fn convert(&self, f: F) -> Result<T, Self::Error>;
 }
 
@@ -29,7 +29,7 @@ pub trait Convert<F, T> {
 /// conversions via `.try_into_val(e)` or specifying convertability with a bound
 /// like `TryIntoVal<E,Other>`.
 pub trait TryIntoVal<E: Env, V> {
-    type Error: Debug;
+    type Error: Debug + Into<crate::Error> + From<crate::Error>;
     fn try_into_val(&self, env: &E) -> Result<V, Self::Error>;
 }
 
@@ -40,7 +40,7 @@ pub trait TryIntoVal<E: Env, V> {
 /// delegate to the environment to look up and extract the content of those
 /// handles.
 pub trait TryFromVal<E: Env, V: ?Sized>: Sized {
-    type Error: Debug;
+    type Error: Debug + Into<crate::Error> + From<crate::Error>;
     fn try_from_val(env: &E, v: &V) -> Result<Self, Self::Error>;
 }
 

--- a/soroban-env-common/src/env.rs
+++ b/soroban-env-common/src/env.rs
@@ -32,7 +32,7 @@ pub trait EnvBase: Sized + Clone {
     /// environment-interface level, and then either directly handle or escalate
     /// the contained `Error` code to the user as a `Error` or `Result<>` of
     /// some other type, depending on the API.
-    type Error: core::fmt::Debug + Into<crate::Error>;
+    type Error: core::fmt::Debug + Into<crate::Error> + From<crate::Error>;
 
     /// Reject an error from the environment, turning it into a panic but on
     /// terms that the environment controls (eg. transforming or logging it).

--- a/soroban-env-common/src/env.rs
+++ b/soroban-env-common/src/env.rs
@@ -32,7 +32,7 @@ pub trait EnvBase: Sized + Clone {
     /// environment-interface level, and then either directly handle or escalate
     /// the contained `Error` code to the user as a `Error` or `Result<>` of
     /// some other type, depending on the API.
-    type Error: core::fmt::Debug;
+    type Error: core::fmt::Debug + Into<crate::Error>;
 
     /// Reject an error from the environment, turning it into a panic but on
     /// terms that the environment controls (eg. transforming or logging it).

--- a/soroban-env-common/src/error.rs
+++ b/soroban-env-common/src/error.rs
@@ -286,6 +286,12 @@ impl From<core::convert::Infallible> for crate::Error {
     }
 }
 
+impl From<crate::Error> for core::convert::Infallible {
+    fn from(_value: crate::Error) -> Self {
+        unreachable!()
+    }
+}
+
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use super::*;

--- a/soroban-env-common/src/error.rs
+++ b/soroban-env-common/src/error.rs
@@ -163,6 +163,14 @@ impl From<stellar_xdr::Error> for Error {
     }
 }
 
+// This never happens, but it's needed for some impls of TryFromVal downstream
+// in the SDK that use the xdr::Error type.
+impl From<Error> for stellar_xdr::Error {
+    fn from(_value: Error) -> Self {
+        stellar_xdr::Error::Unsupported
+    }
+}
+
 #[cfg(feature = "wasmi")]
 impl From<wasmi::core::TrapCode> for Error {
     fn from(code: wasmi::core::TrapCode) -> Self {

--- a/soroban-env-common/src/storage_type.rs
+++ b/soroban-env-common/src/storage_type.rs
@@ -1,7 +1,8 @@
+use crate::{
+    declare_wasmi_marshal_for_enum,
+    xdr::{ContractDataDurability, ScErrorCode, ScErrorType},
+};
 use num_derive::FromPrimitive;
-use stellar_xdr::ContractDataDurability;
-
-use crate::{declare_wasmi_marshal_for_enum, ConversionError};
 
 /// This is just a distinct enum local to the env interface that is used as
 /// an argument to storage functions. It doesn't correspond to any [`Val`] types,
@@ -15,13 +16,16 @@ pub enum StorageType {
 }
 
 impl TryFrom<StorageType> for ContractDataDurability {
-    type Error = ConversionError;
+    type Error = crate::Error;
 
     fn try_from(value: StorageType) -> Result<Self, Self::Error> {
         match value {
             StorageType::Temporary => Ok(ContractDataDurability::Temporary),
             StorageType::Persistent => Ok(ContractDataDurability::Persistent),
-            StorageType::Instance => Err(ConversionError {}),
+            StorageType::Instance => Err(crate::Error::from_type_and_code(
+                ScErrorType::Value,
+                ScErrorCode::InvalidInput,
+            )),
         }
     }
 }

--- a/soroban-env-common/src/string.rs
+++ b/soroban-env-common/src/string.rs
@@ -1,27 +1,32 @@
-use crate::{declare_tag_based_object_wrapper, ConversionError, Env, TryFromVal, Val};
+use crate::{declare_tag_based_object_wrapper, Env, TryFromVal, Val};
 
 #[cfg(feature = "std")]
-use crate::TryIntoVal;
+use crate::{
+    xdr::{ScErrorCode, ScErrorType},
+    TryIntoVal,
+};
 
 declare_tag_based_object_wrapper!(StringObject);
 
 #[cfg(feature = "std")]
 impl<E: Env> TryFromVal<E, StringObject> for String {
-    type Error = ConversionError;
+    type Error = crate::Error;
 
     fn try_from_val(env: &E, v: &StringObject) -> Result<Self, Self::Error> {
-        let len: u32 = env.string_len(*v).map_err(|_| ConversionError)?.into();
+        let len: u32 = env.string_len(*v).map_err(Into::into)?.into();
         let len = len as usize;
         let mut vec = std::vec![0; len];
         env.string_copy_to_slice(*v, Val::U32_ZERO, &mut vec)
-            .map_err(|_| ConversionError)?;
-        String::from_utf8(vec).map_err(|_| ConversionError)
+            .map_err(Into::into)?;
+        String::from_utf8(vec).map_err(|_| {
+            crate::Error::from_type_and_code(ScErrorType::Value, ScErrorCode::InvalidInput)
+        })
     }
 }
 
 #[cfg(feature = "std")]
 impl<E: Env> TryFromVal<E, Val> for String {
-    type Error = ConversionError;
+    type Error = crate::Error;
 
     #[inline(always)]
     fn try_from_val(env: &E, val: &Val) -> Result<Self, Self::Error> {
@@ -31,15 +36,15 @@ impl<E: Env> TryFromVal<E, Val> for String {
 }
 
 impl<E: Env> TryFromVal<E, &str> for StringObject {
-    type Error = ConversionError;
+    type Error = crate::Error;
     #[inline(always)]
     fn try_from_val(env: &E, val: &&str) -> Result<StringObject, Self::Error> {
-        env.string_new_from_slice(val).map_err(|_| ConversionError)
+        env.string_new_from_slice(val).map_err(Into::into)
     }
 }
 
 impl<E: Env> TryFromVal<E, &str> for Val {
-    type Error = ConversionError;
+    type Error = crate::Error;
     #[inline(always)]
     fn try_from_val(env: &E, val: &&str) -> Result<Val, Self::Error> {
         Ok(StringObject::try_from_val(env, val)?.into())
@@ -48,7 +53,7 @@ impl<E: Env> TryFromVal<E, &str> for Val {
 
 #[cfg(feature = "std")]
 impl<E: Env> TryFromVal<E, String> for StringObject {
-    type Error = ConversionError;
+    type Error = crate::Error;
 
     fn try_from_val(env: &E, v: &String) -> Result<Self, Self::Error> {
         v.as_str().try_into_val(env)
@@ -57,7 +62,7 @@ impl<E: Env> TryFromVal<E, String> for StringObject {
 
 #[cfg(feature = "std")]
 impl<E: Env> TryFromVal<E, String> for Val {
-    type Error = ConversionError;
+    type Error = crate::Error;
 
     fn try_from_val(env: &E, v: &String) -> Result<Self, Self::Error> {
         v.as_str().try_into_val(env)

--- a/soroban-env-common/src/val.rs
+++ b/soroban-env-common/src/val.rs
@@ -320,8 +320,15 @@ declare_tag_based_object_wrapper!(AddressObject);
 // away, the same way `()` would, while remaining a separate type to allow
 // conversion to a more-structured error code at a higher level.
 
-/// Error type indicating a failure to convert some type to another; details
-/// of the failed conversion will typically be written to the debug log.
+/// Error type indicating a failure to convert some type to another; details of
+/// the failed conversion will typically be written to the debug log.
+///
+/// This is intentionally minimal and uninformative to minimize impact of its
+/// use on wasm codesize. It converts to `Error(ScErrorType::Value,
+/// ScErrorCode::UnexpectedType)` when converted to a full `Error`, and ideally
+/// it should only be used in ubiquitous cases that will occur in wasm, like
+/// small-number or tag conversions, where code size is paramount and the
+/// information-loss from using it is not too bad.
 #[derive(Debug, Eq, PartialEq)]
 pub struct ConversionError;
 

--- a/soroban-env-common/src/val.rs
+++ b/soroban-env-common/src/val.rs
@@ -337,6 +337,12 @@ impl From<stellar_xdr::Error> for ConversionError {
     }
 }
 
+impl From<crate::Error> for ConversionError {
+    fn from(_: crate::Error) -> Self {
+        ConversionError
+    }
+}
+
 /// Trait abstracting over types that can be converted into [Val], similar to
 /// [TryFrom] but with a different signature that enables generating slightly
 /// more efficient conversion code. An implementation of `TryFrom<Val>` is also

--- a/soroban-env-common/src/val.rs
+++ b/soroban-env-common/src/val.rs
@@ -1,3 +1,6 @@
+// This permits globals prouced by derive(num_enum::TryFromPrimitive) below.
+#![cfg_attr(test, allow(non_upper_case_globals))]
+
 use crate::{
     declare_tag_based_object_wrapper, declare_tag_based_wrapper, impl_rawval_wrapper_base,
     impl_tryfroms_and_tryfromvals_delegating_to_rawvalconvertible, Compare, I32Val, SymbolSmall,

--- a/soroban-env-host/src/host/error.rs
+++ b/soroban-env-host/src/host/error.rs
@@ -29,6 +29,12 @@ pub struct HostError {
 
 impl std::error::Error for HostError {}
 
+impl Into<Error> for HostError {
+    fn into(self) -> Error {
+        self.error
+    }
+}
+
 impl Debug for HostError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // We do a little trimming here, skipping the first two frames (which

--- a/soroban-env-host/src/host/error.rs
+++ b/soroban-env-host/src/host/error.rs
@@ -352,7 +352,7 @@ where
     HostError: From<<Val as TryFromVal<Host, T>>::Error>,
 {
     fn debug_arg_maybe_expensive_or_fallible(host: &Host, arg: &Self) -> Result<Val, HostError> {
-        Val::try_from_val(host, arg).map_err(|e| e.into())
+        Val::try_from_val(host, arg).map_err(|e| HostError::from(e))
     }
 }
 

--- a/soroban-native-sdk-macros/src/derive_type.rs
+++ b/soroban-native-sdk-macros/src/derive_type.rs
@@ -153,7 +153,7 @@ pub fn derive_type_enum(ident: &Ident, data: &DataEnum) -> TokenStream2 {
         quote! {
 
             impl #ident {
-                fn discriminant_sym(&self, env: &crate::Host) -> Result<crate::Symbol, crate::ConversionError> {
+                fn discriminant_sym(&self, env: &crate::Host) -> Result<crate::Symbol, crate::Error> {
                     use soroban_env_common::TryFromVal;
                     match self {
                         #(#syms,)*


### PR DESCRIPTION
Steps in code review so far:

- Rename some variables
- Move code around for ease of review, add review markers
- Equip `Env::Error` with `: Into<crate::Error>` so that we can pass `HostError::error` through from Env conversions
- Do so in bytes.rs
- Equip `Env::Error` with `: From<crate::Error>` so that we can project `Error` into it in certain cases
- Do so in preference to an unconditional `unreachable!()` in convert, which can panic
- Fix some code in convert that does two compares back to back when walking a tuple instead of scrutinizing one compare against two cases
- Change a bunch more uses of ConversionError to Error (some need minor SDK changes, see https://github.com/stellar/rs-soroban-sdk/pull/1083)