### PR TITLE
Tighten wasm interface version checks, and do on upload. Fix #1052.

### DIFF
--- a/soroban-env-common/src/meta.rs
+++ b/soroban-env-common/src/meta.rs
@@ -45,12 +45,12 @@ soroban_env_macros::generate_env_meta_consts!(
     pre_release_version: 57,
 );
 
-pub fn get_ledger_protocol_version(interface_version: u64) -> u32 {
+pub const fn get_ledger_protocol_version(interface_version: u64) -> u32 {
     // The ledger protocol version is the high 32 bits of INTERFACE_VERSION
     (interface_version >> 32) as u32
 }
 
-pub fn get_pre_release_version(interface_version: u64) -> u32 {
+pub const fn get_pre_release_version(interface_version: u64) -> u32 {
     // The pre-release version is the low 32 bits of INTERFACE_VERSION
     interface_version as u32
 }

--- a/soroban-env-host/src/test/complex.rs
+++ b/soroban-env-host/src/test/complex.rs
@@ -12,7 +12,7 @@ use super::util::{generate_account_id, generate_bytes_array};
 #[test]
 fn run_complex() -> Result<(), HostError> {
     let info = crate::LedgerInfo {
-        protocol_version: 21,
+        protocol_version: crate::meta::get_ledger_protocol_version(crate::meta::INTERFACE_VERSION),
         sequence_number: 1234,
         timestamp: 1234,
         network_id: [7; 32],

--- a/soroban-env-host/src/test/hostile.rs
+++ b/soroban-env-host/src/test/hostile.rs
@@ -222,10 +222,11 @@ fn wasm_module_with_mem_grow(n_pages: usize) -> Vec<u8> {
 fn excessive_memory_growth() -> Result<(), HostError> {
     // not sure why calling `memory_grow(32)`, wasmi requests 33 pages of memory
     let wasm = wasm_module_with_mem_grow(32);
-    let host = Host::test_host_with_recording_footprint()
+    let host = Host::test_host_with_recording_footprint();
+    let contract_id_obj = host.register_test_contract_wasm(wasm.as_slice());
+    let host = host
         .test_budget(0, 0)
         .enable_model(ContractCostType::WasmMemAlloc, 0, 0, 1, 0);
-    let contract_id_obj = host.register_test_contract_wasm(wasm.as_slice());
     host.set_diagnostic_level(crate::DiagnosticLevel::Debug)?;
 
     // This one should just run out of memory

--- a/soroban-env-host/src/test/invocation.rs
+++ b/soroban-env-host/src/test/invocation.rs
@@ -57,10 +57,11 @@ fn invoke_alloc() -> Result<(), HostError> {
     // So we wind up with a growth-sequence that's a bit irregular: +0x10000,
     // +0x20000, +0x30000, +0x50000, +0x90000. Total is 1 + 2 + 3 + 5 + 9 = 20
     // pages or about 1.3 MiB, plus the initial 17 pages (1.1MiB) plus some more
-    // slop from general host machinery allocations, we get around 2.5MiB. Call
-    // is "less than 3MiB".
+    // slop from general host machinery allocations, plus allocating a VM once
+    // during upload and once during execution we get around 2.5MiB. Call
+    // is "less than 4MiB".
     assert!(used_bytes > (128 * 4096));
-    assert!(used_bytes < 0x30_0000);
+    assert!(used_bytes < 0x40_0000);
     Ok(())
 }
 

--- a/soroban-env-host/src/test/ledger.rs
+++ b/soroban-env-host/src/test/ledger.rs
@@ -14,7 +14,7 @@ fn ledger_network_id() -> Result<(), HostError> {
 
     let host = Host::with_storage_and_budget(storage, budget);
     host.set_ledger_info(LedgerInfo {
-        protocol_version: 0,
+        protocol_version: crate::meta::get_ledger_protocol_version(crate::meta::INTERFACE_VERSION),
         sequence_number: 0,
         timestamp: 0,
         network_id: [7; 32],

--- a/soroban-env-host/src/test/lifecycle.rs
+++ b/soroban-env-host/src/test/lifecycle.rs
@@ -68,6 +68,7 @@ fn test_host() -> Host {
         Storage::with_enforcing_footprint_and_map(Footprint::default(), StorageMap::new());
     let host = Host::with_storage_and_budget(storage, budget);
     host.set_ledger_info(LedgerInfo {
+        protocol_version: crate::meta::get_ledger_protocol_version(crate::meta::INTERFACE_VERSION),
         network_id: generate_bytes_array(),
         ..Default::default()
     })
@@ -167,7 +168,7 @@ fn create_contract_using_parent_id_test() {
     });
 
     let child_id = sha256_hash_id_preimage(child_pre_image);
-    let child_wasm: &[u8] = b"70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4";
+    let child_wasm: &[u8] = &[];
 
     // Install the code for the child contract.
     let wasm_hash = xdr::Hash(Sha256::digest(&child_wasm).try_into().unwrap());
@@ -235,8 +236,7 @@ fn create_contract_using_parent_id_test() {
 
 #[test]
 fn create_contract_from_source_account() {
-    let code: &[u8] = b"70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4";
-    test_create_contract_from_source_account(&test_host(), code);
+    test_create_contract_from_source_account(&test_host(), &[]);
 }
 
 pub(crate) fn sha256_hash_id_preimage<T: xdr::WriteXdr>(pre_image: T) -> xdr::Hash {

--- a/soroban-env-host/src/test/metering_benchmark.rs
+++ b/soroban-env-host/src/test/metering_benchmark.rs
@@ -21,7 +21,7 @@ use super::util::{generate_account_id, generate_bytes_array};
 // RUST_TEST_THREADS=1  cargo test --release --package soroban-env-host --lib -- test::metering_benchmark  --nocapture --ignored
 
 const LEDGER_INFO: LedgerInfo = LedgerInfo {
-    protocol_version: 21,
+    protocol_version: crate::meta::get_ledger_protocol_version(crate::meta::INTERFACE_VERSION),
     sequence_number: 1234,
     timestamp: 1234,
     network_id: [7; 32],

--- a/soroban-env-host/src/test/token.rs
+++ b/soroban-env-host/src/test/token.rs
@@ -50,7 +50,9 @@ impl TokenTest {
     fn setup() -> Self {
         let host = Host::test_host_with_recording_footprint();
         host.set_ledger_info(LedgerInfo {
-            protocol_version: 20,
+            protocol_version: crate::meta::get_ledger_protocol_version(
+                crate::meta::INTERFACE_VERSION,
+            ),
             sequence_number: 123,
             timestamp: 123456,
             network_id: [5; 32],

--- a/soroban-env-host/src/test/util.rs
+++ b/soroban-env-host/src/test/util.rs
@@ -100,7 +100,9 @@ impl Host {
         let storage = Storage::with_recording_footprint(snapshot_source);
         let host = Host::with_storage_and_budget(storage, Budget::default());
         host.set_ledger_info(LedgerInfo {
-            protocol_version: 20,
+            protocol_version: crate::meta::get_ledger_protocol_version(
+                crate::meta::INTERFACE_VERSION,
+            ),
             sequence_number: 0,
             timestamp: 0,
             network_id: [0; 32],


### PR DESCRIPTION
This fixes #1052 by rejecting contracts with unsupported versions during upload (they are already rejected during instantiation/execution). It also slightly tightens the set of allowed contracts, rejecting old-protocol ones with nonzero prerelease and rejecting all future protocol versions.
