### PR TITLE
Update wasmi to 0.31.0-soroban

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1429,8 +1429,8 @@ version = "0.0.17"
 
 [[package]]
 name = "soroban-wasmi"
-version = "0.30.0-soroban"
-source = "git+https://github.com/stellar/wasmi?rev=284c963ba080703061797e2a3cba0853edee0dd4#284c963ba080703061797e2a3cba0853edee0dd4"
+version = "0.31.0-soroban"
+source = "git+https://github.com/stellar/wasmi?rev=fe21912143c1ec43b8fada4221253fc96520655c#fe21912143c1ec43b8fada4221253fc96520655c"
 dependencies = [
  "smallvec",
  "spin",
@@ -1911,12 +1911,12 @@ dependencies = [
 [[package]]
 name = "wasmi_arena"
 version = "0.4.0"
-source = "git+https://github.com/stellar/wasmi?rev=284c963ba080703061797e2a3cba0853edee0dd4#284c963ba080703061797e2a3cba0853edee0dd4"
+source = "git+https://github.com/stellar/wasmi?rev=fe21912143c1ec43b8fada4221253fc96520655c#fe21912143c1ec43b8fada4221253fc96520655c"
 
 [[package]]
 name = "wasmi_core"
-version = "0.12.0"
-source = "git+https://github.com/stellar/wasmi?rev=284c963ba080703061797e2a3cba0853edee0dd4#284c963ba080703061797e2a3cba0853edee0dd4"
+version = "0.13.0"
+source = "git+https://github.com/stellar/wasmi?rev=fe21912143c1ec43b8fada4221253fc96520655c#fe21912143c1ec43b8fada4221253fc96520655c"
 dependencies = [
  "downcast-rs",
  "libm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,9 @@ default-features = false
 
 [workspace.dependencies.wasmi]
 package = "soroban-wasmi"
-version = "0.30.0-soroban"
+version = "0.31.0-soroban"
 git = "https://github.com/stellar/wasmi"
-rev = "284c963ba080703061797e2a3cba0853edee0dd4"
+rev = "fe21912143c1ec43b8fada4221253fc96520655c"
 
 [workspace.dependencies.stellar-strkey]
 version = "0.0.7"


### PR DESCRIPTION
### What

Update wasmi dependency to https://github.com/stellar/wasmi/tree/soroban-wasmi-v0.31

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
