### PR TITLE
Attach the auth in recording mode to any valid tracker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1321,7 +1321,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "soroban-bench-utils"
-version = "20.0.0-rc1"
+version = "20.0.0-rc2"
 dependencies = [
  "perf-event",
  "soroban-env-common",
@@ -1330,7 +1330,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "20.0.0-rc1"
+version = "20.0.0-rc2"
 dependencies = [
  "arbitrary",
  "crate-git-revision",
@@ -1347,7 +1347,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "20.0.0-rc1"
+version = "20.0.0-rc2"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "20.0.0-rc1"
+version = "20.0.0-rc2"
 dependencies = [
  "backtrace",
  "bytes-lit",
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "20.0.0-rc1"
+version = "20.0.0-rc2"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1404,7 +1404,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-native-sdk-macros"
-version = "20.0.0-rc1"
+version = "20.0.0-rc2"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1414,7 +1414,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-synth-wasm"
-version = "20.0.0-rc1"
+version = "20.0.0-rc2"
 dependencies = [
  "expect-test",
  "soroban-env-common",
@@ -1425,7 +1425,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-test-wasms"
-version = "20.0.0-rc1"
+version = "20.0.0-rc2"
 
 [[package]]
 name = "soroban-wasmi"
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "test_no_std"
-version = "20.0.0-rc1"
+version = "20.0.0-rc2"
 dependencies = [
  "soroban-env-common",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,14 @@ members = [
 exclude = ["soroban-test-wasms/wasm-workspace"]
 
 [workspace.package]
-version = "20.0.0-rc1"
+version = "20.0.0-rc2"
 
 [workspace.dependencies]
-soroban-env-common = { version = "20.0.0-rc1", path = "soroban-env-common", default-features = false }
-soroban-env-guest = { version = "20.0.0-rc1", path = "soroban-env-guest" }
-soroban-env-host = { version = "20.0.0-rc1", path = "soroban-env-host" }
-soroban-env-macros = { version = "20.0.0-rc1", path = "soroban-env-macros" }
-soroban-native-sdk-macros = { version = "20.0.0-rc1", path = "soroban-native-sdk-macros" }
+soroban-env-common = { version = "20.0.0-rc2", path = "soroban-env-common", default-features = false }
+soroban-env-guest = { version = "20.0.0-rc2", path = "soroban-env-guest" }
+soroban-env-host = { version = "20.0.0-rc2", path = "soroban-env-host" }
+soroban-env-macros = { version = "20.0.0-rc2", path = "soroban-env-macros" }
+soroban-native-sdk-macros = { version = "20.0.0-rc2", path = "soroban-native-sdk-macros" }
 
 [workspace.dependencies.stellar-xdr]
 version = "20.0.0-rc1"

--- a/soroban-env-host/src/auth.rs
+++ b/soroban-env-host/src/auth.rs
@@ -788,6 +788,10 @@ impl AuthorizationManager {
             AuthorizationMode::Enforcing => self.require_auth_enforcing(host, address, &function),
             // metering: free for recording
             AuthorizationMode::Recording(recording_info) => {
+                // First try to find the tracker for this exact address object.
+                // This is a best-effort heuristic to come up with a reasonably
+                // looking recording tree for cases when multiple instances of
+                // the same exact address are used.
                 let address_obj_handle = address.get_handle();
                 let existing_tracker_id = recording_info
                     .try_borrow_tracker_by_address_handle(host)?
@@ -821,6 +825,35 @@ impl AuthorizationManager {
                         ));
                     }
                 }
+                // If there is no active tracker for this exact address object,
+                // try to find any matching active tracker for the address.
+                for tracker in self.try_borrow_account_trackers(host)?.iter() {
+                    if let Ok(mut tracker) = tracker.try_borrow_mut() {
+                        if !host.compare(&tracker.address, &address)?.is_eq() {
+                            continue;
+                        }
+                        // Take the first tracker that is still active (i.e. has
+                        // active authorizations in the current call stack) and
+                        // hasn't been used for this stack frame yet.
+                        if tracker.has_authorized_invocations_in_stack()
+                            && !tracker.current_frame_is_already_matched()
+                        {
+                            return tracker.record_invocation(host, function);
+                        }
+                    } else {
+                        return Err(host.err(
+                            ScErrorType::Auth,
+                            ScErrorCode::InternalError,
+                            "unexpected borrowed tracker in recording auth mode",
+                            &[],
+                        ));
+                    }
+                }
+                // At this stage there is no active tracker to which we could
+                // match the current invocation, thus we need to create a new
+                // tracker.
+                // Alert the user in `disable_non_root_auth` mode if we're not
+                // in the root stack frame.
                 if recording_info.disable_non_root_auth
                     && self.try_borrow_call_stack(host)?.len() != 1
                 {
@@ -1297,11 +1330,7 @@ impl InvocationTracker {
         host: &Host,
         function: AuthorizedFunction,
     ) -> Result<(), HostError> {
-        let frame_is_already_authorized = match self.invocation_id_in_call_stack.last() {
-            Some(Some(_)) => true,
-            _ => false,
-        };
-        if frame_is_already_authorized {
+        if self.current_frame_is_already_matched() {
             return Err(host.err(
                 ScErrorType::Auth,
                 ScErrorCode::ExistingValue,


### PR DESCRIPTION
### What

Attach the auth in recording mode to any valid tracker.

### Why

Currently only the tracker that matches with exact same object is used and otherwise a new tracker is created. This results in recording auth producing unnecessarily disjoint call trees.

This is kind of best effort and might lead to a bit weird edge-case scenarios in semantic sense (e.g. a tracker for an exact address object might be used by another instance of that address), but the end results should still fulfil the enforcing mode invariants and shouldn't compromise security.

### Known limitations

N/A
