### PR TITLE
Add redundant "next" dependencies

### DIFF
--- a/soroban-env-common/Cargo.toml
+++ b/soroban-env-common/Cargo.toml
@@ -33,7 +33,7 @@ std = ["stellar-xdr/std", "stellar-xdr/base64"]
 serde = ["dep:serde", "stellar-xdr/serde"]
 wasmi = ["dep:wasmi"]
 testutils = ["dep:arbitrary", "stellar-xdr/arbitrary"]
-next = ["stellar-xdr/next"]
+next = ["stellar-xdr/next", "soroban-env-macros/next"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -54,7 +54,7 @@ pretty_assertions = "1.4.0"
 
 [features]
 testutils = ["soroban-env-common/testutils"]
-next = ["soroban-env-common/next", "soroban-test-wasms/next"]
+next = ["soroban-env-common/next", "soroban-test-wasms/next", "soroban-synth-wasm/next", "soroban-bench-utils/next"]
 tracy = ["dep:tracy-client"]
 
 [[bench]]


### PR DESCRIPTION
### What

Some crates have not exhaustively listed all its "feature=next" dependencies. 
Even if some of those "next" are redundant, i.e., they may only underneath differ by `stellar-xdr`'s `curr/next`, which is already covered by `soroban-env-common`. I think it's still good to list them out explicitly, since it's possible those dependencies may have more divergence between their curr and next in the future.

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
