### PR TITLE
Budget fiddling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1359,6 +1359,7 @@ dependencies = [
  "soroban-wasmi",
  "static_assertions",
  "stellar-xdr",
+ "tracy-client",
 ]
 
 [[package]]

--- a/soroban-bench-utils/src/tracker.rs
+++ b/soroban-bench-utils/src/tracker.rs
@@ -128,34 +128,45 @@ pub struct HostTracker<'a> {
     mem_tracker: MemTracker,
     start_time: Instant,
     alloc_guard: Option<AllocationGuard<'a>>,
+    #[cfg(feature = "tracy")]
+    tracy_span: Option<tracy_client::Span>,
 }
 
 impl<'a> HostTracker<'a> {
-    pub fn start(token: Option<&'a mut AllocationGroupToken>) -> Self {
+    pub fn new() -> Self {
         // Setup the instrumentation
-        let mut cpu_insn_counter = cpu::InstructionCounter::new();
+        let cpu_insn_counter = cpu::InstructionCounter::new();
         let mem_tracker = MemTracker(Arc::new(AtomicU64::new(0)));
         AllocationRegistry::set_global_tracker(mem_tracker.clone())
             .expect("no other global tracker should be set yet");
         AllocationRegistry::enable_tracking();
 
-        // start the cpu and mem measurement
-        mem_tracker.0.store(0, Ordering::SeqCst);
-        let alloc_guard: Option<AllocationGuard> = if let Some(t) = token {
+        HostTracker {
+            cpu_insn_counter,
+            mem_tracker,
+            start_time: Instant::now(),
+            alloc_guard: None,
+            #[cfg(feature = "tracy")]
+            tracy_span: None,
+        }
+    }
+
+    pub fn start(&mut self, token: Option<&'a mut AllocationGroupToken>) {
+        // start the mem measurement
+        #[cfg(feature = "tracy")]
+        {
+            self.tracy_span = Some(tracy_span!("tracker active"));
+        }
+        self.mem_tracker.0.store(0, Ordering::SeqCst);
+        self.alloc_guard = if let Some(t) = token {
             Some(t.enter())
         } else {
             None
         };
 
-        let start_time = Instant::now();
-        cpu_insn_counter.begin();
-
-        HostTracker {
-            cpu_insn_counter,
-            mem_tracker,
-            start_time,
-            alloc_guard,
-        }
+        // start the cpu measurement
+        self.start_time = Instant::now();
+        self.cpu_insn_counter.begin();
     }
 
     pub fn stop(mut self) -> (u64, u64, u64) {
@@ -165,10 +176,13 @@ impl<'a> HostTracker<'a> {
         if let Some(g) = self.alloc_guard {
             drop(g)
         }
-
         let mem_bytes = self.mem_tracker.0.load(Ordering::SeqCst);
         let time_nsecs = stop_time.duration_since(self.start_time).as_nanos() as u64;
-
+        self.alloc_guard = None;
+        #[cfg(feature = "tracy")]
+        {
+            self.tracy_span = None
+        }
         AllocationRegistry::disable_tracking();
         unsafe {
             AllocationRegistry::clear_global_tracker();

--- a/soroban-bench-utils/src/tracker.rs
+++ b/soroban-bench-utils/src/tracker.rs
@@ -63,7 +63,15 @@ mod cpu {
         }
         pub fn end_and_count(&mut self) -> u64 {
             self.0.disable().expect("perf_event::Counter::disable");
-            self.0.read().expect("perf_event::Counter::read")
+            let tandc = self
+                .0
+                .read_count_and_time()
+                .expect("perf_event::Counter::read_count_and_time");
+            if tandc.time_enabled == tandc.time_running {
+                tandc.count
+            } else {
+                panic!("time enabled != time running")
+            }
         }
     }
 }

--- a/soroban-env-common/Cargo.toml
+++ b/soroban-env-common/Cargo.toml
@@ -24,6 +24,9 @@ arbitrary = { version = "1.3.0", features = ["derive"], optional = true }
 num-traits = {version = "0.2.15", default-features = false}
 num-derive = "0.4.0"
 
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+tracy-client = { version = "=0.15.2", features = ["enable", "timer-fallback"], default-features = false, optional = true }
+
 [dev-dependencies]
 num_enum = "0.7.0"
 num-traits = "0.2.15"
@@ -34,6 +37,7 @@ serde = ["dep:serde", "stellar-xdr/serde"]
 wasmi = ["dep:wasmi"]
 testutils = ["dep:arbitrary", "stellar-xdr/arbitrary"]
 next = ["stellar-xdr/next", "soroban-env-macros/next"]
+tracy = ["dep:tracy-client"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/soroban-env-common/src/lib.rs
+++ b/soroban-env-common/src/lib.rs
@@ -18,6 +18,28 @@
 //! [Val] type and XDR types, and re-exports the XDR definitions from
 //! [stellar_xdr] under the module [xdr].
 
+#[allow(unused_macros)]
+#[cfg(all(not(target_family = "wasm"), feature = "tracy"))]
+macro_rules! tracy_span {
+    () => {
+        tracy_client::span!()
+    };
+    ($name:expr) => {
+        tracy_client::span!($name)
+    };
+}
+
+#[allow(unused_macros)]
+#[cfg(any(target_family = "wasm", not(feature = "tracy")))]
+macro_rules! tracy_span {
+    () => {
+        ()
+    };
+    ($name:expr) => {
+        ()
+    };
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Version<'a> {

--- a/soroban-env-common/src/vmcaller_env.rs
+++ b/soroban-env-common/src/vmcaller_env.rs
@@ -177,6 +177,8 @@ macro_rules! vmcaller_none_function_helper {
         // that didn't have an Env on hand when creating the error. This will at
         // least localize the error to a given Env call.
         fn $fn_id(&self, $($arg:$type),*) -> Result<$ret, Self::Error> {
+            #[cfg(all(not(target_family = "wasm"), feature = "tracy"))]
+            let _span = tracy_span!(core::stringify!($fn_id));
             self.augment_err_result(<Self as VmCallerEnv>::$fn_id(self, &mut VmCaller::none(), $($arg),*))
         }
     };

--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -55,7 +55,7 @@ pretty_assertions = "1.4.0"
 [features]
 testutils = ["soroban-env-common/testutils"]
 next = ["soroban-env-common/next", "soroban-test-wasms/next", "soroban-synth-wasm/next", "soroban-bench-utils/next"]
-tracy = ["dep:tracy-client"]
+tracy = ["dep:tracy-client", "soroban-env-common/tracy"]
 
 [[bench]]
 required-features = ["testutils"]

--- a/soroban-env-host/benches/common/cost_types/host_mem_cpy.rs
+++ b/soroban-env-host/benches/common/cost_types/host_mem_cpy.rs
@@ -1,6 +1,6 @@
 use crate::common::HostCostMeasurement;
 use rand::{rngs::StdRng, RngCore};
-use soroban_env_host::{cost_runner::HostMemCpyRun, Host};
+use soroban_env_host::{budget::COST_MODEL_LIN_TERM_SCALE_BITS, cost_runner::HostMemCpyRun, Host};
 
 // Measures the cost of copying a chunk of memory in the host (no allocation).
 // The input value is the number of bytes copied.
@@ -9,7 +9,14 @@ pub(crate) struct HostMemCpyMeasure;
 impl HostCostMeasurement for HostMemCpyMeasure {
     type Runner = HostMemCpyRun;
 
-    const STEP_SIZE: u64 = 4096;
+    // Rust and LLVM will conspire to optimize the heck out of a large memcpy.
+    // This will cause us to gather completely wrong numbers for the cost of a
+    // small memcpy, which almost all our memcpys are (they're not even likely
+    // to be calls to memcpy, they're just "byte moving in the abstract sense",
+    // usually only a few dozen or hundred at a time). So we use the smallest
+    // number here we're allowed to use: the linear scale factor, which
+    // STEP_SIZE literally isn't allowed to be smaller than.
+    const STEP_SIZE: u64 = 1 << COST_MODEL_LIN_TERM_SCALE_BITS;
 
     fn new_random_case(_host: &Host, rng: &mut StdRng, input: u64) -> (Vec<u8>, Vec<u8>) {
         let len = 1 + input * Self::STEP_SIZE;

--- a/soroban-env-host/benches/common/measure.rs
+++ b/soroban-env-host/benches/common/measure.rs
@@ -349,6 +349,7 @@ where
         &mut Vec<<<HCM as HostCostMeasurement>::Runner as CostRunner>::RecycledType>,
     ),
 {
+    assert!(HCM::STEP_SIZE >= (1 << COST_MODEL_LIN_TERM_SCALE_BITS));
     let mut recycled_samples = Vec::with_capacity(samples.len());
     host.as_budget().reset_unlimited().unwrap();
 

--- a/soroban-env-host/benches/common/measure.rs
+++ b/soroban-env-host/benches/common/measure.rs
@@ -353,7 +353,8 @@ where
     let mut recycled_samples = Vec::with_capacity(samples.len());
     host.as_budget().reset_unlimited().unwrap();
 
-    let ht = HostTracker::start(alloc_group_token);
+    let mut ht = HostTracker::new();
+    ht.start(alloc_group_token);
 
     runner(host, samples, &mut recycled_samples);
 

--- a/soroban-env-host/benches/variation_histograms.rs
+++ b/soroban-env-host/benches/variation_histograms.rs
@@ -7,6 +7,7 @@ struct LinearModelTables;
 impl Benchmark for LinearModelTables {
     fn bench<HCM: HostCostMeasurement>() -> std::io::Result<(FPCostModel, FPCostModel)> {
         let mut measurements = measure_cost_variation::<HCM>(100)?;
+        measurements.check_range_against_baseline(HCM::Runner::COST_TYPE)?;
         measurements.preprocess();
         measurements.report_histogram("cpu", |m| m.cpu_insns);
         measurements.report_histogram("mem", |m| m.mem_bytes);

--- a/soroban-env-host/benches/worst_case_linear_models.rs
+++ b/soroban-env-host/benches/worst_case_linear_models.rs
@@ -4,7 +4,10 @@
 // $ cargo bench --features wasmi,testutils --bench worst_case_linear_models -- VecNew I64Rotr --nocapture
 mod common;
 use common::*;
-use soroban_env_host::{cost_runner::WasmInsnType, xdr::ContractCostType};
+use soroban_env_host::{
+    cost_runner::{CostRunner, WasmInsnType},
+    xdr::ContractCostType,
+};
 use std::{collections::BTreeMap, fmt::Debug, io::Write};
 use tabwriter::{Alignment, TabWriter};
 
@@ -12,7 +15,7 @@ struct WorstCaseLinearModels;
 impl Benchmark for WorstCaseLinearModels {
     fn bench<HCM: HostCostMeasurement>() -> std::io::Result<(FPCostModel, FPCostModel)> {
         let mut measurements = measure_worst_case_costs::<HCM>(1..20)?;
-
+        measurements.check_range_against_baseline(HCM::Runner::COST_TYPE)?;
         measurements.preprocess();
         measurements.report_table();
         let cpu_model = measurements.fit_model_to_cpu();

--- a/soroban-env-host/src/budget.rs
+++ b/soroban-env-host/src/budget.rs
@@ -140,7 +140,7 @@ impl HostCostModel for MeteredCostComponent {
 }
 
 #[derive(Clone)]
-pub struct BudgetDimension {
+struct BudgetDimension {
     /// A set of cost models that map input values (eg. event counts, object
     /// sizes) from some CostType to whatever concrete resource type is being
     /// tracked by this dimension (eg. cpu or memory). CostType enum values are
@@ -177,7 +177,7 @@ impl Debug for BudgetDimension {
 }
 
 impl BudgetDimension {
-    pub fn new() -> Self {
+    fn new() -> Self {
         let mut bd = Self {
             cost_models: Default::default(),
             limit: Default::default(),
@@ -194,7 +194,7 @@ impl BudgetDimension {
         bd
     }
 
-    pub fn try_from_config(cost_params: ContractCostParams) -> Result<Self, HostError> {
+    fn try_from_config(cost_params: ContractCostParams) -> Result<Self, HostError> {
         let cost_models = cost_params
             .0
             .iter()
@@ -217,23 +217,15 @@ impl BudgetDimension {
         &mut self.cost_models[ty as usize]
     }
 
-    pub fn get_count(&self, ty: ContractCostType) -> u64 {
-        self.counts[ty as usize]
-    }
-
-    pub fn get_total_count(&self) -> u64 {
+    fn get_total_count(&self) -> u64 {
         self.total_count
     }
 
-    pub fn get_limit(&self) -> u64 {
-        self.limit
-    }
-
-    pub fn get_remaining(&self) -> u64 {
+    fn get_remaining(&self) -> u64 {
         self.limit.saturating_sub(self.total_count)
     }
 
-    pub fn reset(&mut self, limit: u64) {
+    fn reset(&mut self, limit: u64) {
         self.limit = limit;
         self.total_count = 0;
         for v in &mut self.counts {
@@ -250,7 +242,7 @@ impl BudgetDimension {
     /// input, assuming all batched units have the same input size. If input
     /// is `None`, the input is ignored and the model is treated as a constant
     /// model, and amount charged is iterations * const_term.
-    pub fn charge(
+    fn charge(
         &mut self,
         ty: ContractCostType,
         iterations: u64,
@@ -359,8 +351,8 @@ impl MeterTracker {
 
 #[derive(Clone)]
 pub(crate) struct BudgetImpl {
-    pub cpu_insns: BudgetDimension,
-    pub mem_bytes: BudgetDimension,
+    cpu_insns: BudgetDimension,
+    mem_bytes: BudgetDimension,
     /// For the purpose o calibration and reporting; not used for budget-limiting per se.
     tracker: MeterTracker,
     enabled: bool,

--- a/soroban-env-host/src/budget.rs
+++ b/soroban-env-host/src/budget.rs
@@ -512,13 +512,26 @@ impl Default for BudgetImpl {
                     cpu.const_term = 1141;
                     cpu.lin_term = ScaledU64(1);
                 }
+                // We don't use a calibrated number for this because sending a
+                // large calibration-buffer to memcpy hits an optimized
+                // large-memcpy path in the stdlib, which has both a large
+                // overhead and a small per-byte cost. But large buffers aren't
+                // really how byte-copies usually get used in metered code. Most
+                // calls have to do with small copies of a few tens or hundreds
+                // of bytes. So instead we just "reason it out": we can probably
+                // copy 8 bytes per instruction on a 64-bit machine, and that
+                // therefore a 1-byte copy is considered 1/8th of an
+                // instruction. We also add in a nonzero constant overhead, to
+                // avoid having anything that can be zero cost and approximate
+                // whatever function call, arg-shuffling, spills, reloads or
+                // other flotsam accumulates around a typical memory copy.
                 ContractCostType::HostMemCpy => {
-                    cpu.const_term = 39;
-                    cpu.lin_term = ScaledU64(24);
+                    cpu.const_term = 250;
+                    cpu.lin_term = ScaledU64((1 << COST_MODEL_LIN_TERM_SCALE_BITS) / 8);
                 }
                 ContractCostType::HostMemCmp => {
-                    cpu.const_term = 20;
-                    cpu.lin_term = ScaledU64(64);
+                    cpu.const_term = 250;
+                    cpu.lin_term = ScaledU64((1 << COST_MODEL_LIN_TERM_SCALE_BITS) / 8);
                 }
                 ContractCostType::DispatchHostFunction => {
                     cpu.const_term = 263;
@@ -529,12 +542,12 @@ impl Default for BudgetImpl {
                     cpu.lin_term = ScaledU64(0);
                 }
                 ContractCostType::ValSer => {
-                    cpu.const_term = 591;
-                    cpu.lin_term = ScaledU64(69);
+                    cpu.const_term = 1000;
+                    cpu.lin_term = ScaledU64((1 << COST_MODEL_LIN_TERM_SCALE_BITS) / 8);
                 }
                 ContractCostType::ValDeser => {
-                    cpu.const_term = 1112;
-                    cpu.lin_term = ScaledU64(34);
+                    cpu.const_term = 1000;
+                    cpu.lin_term = ScaledU64((1 << COST_MODEL_LIN_TERM_SCALE_BITS) / 8);
                 }
                 ContractCostType::ComputeSha256Hash => {
                     cpu.const_term = 2924;
@@ -545,24 +558,24 @@ impl Default for BudgetImpl {
                     cpu.lin_term = ScaledU64(0);
                 }
                 ContractCostType::MapEntry => {
-                    cpu.const_term = 53;
-                    cpu.lin_term = ScaledU64(0);
+                    cpu.const_term = 250;
+                    cpu.lin_term = ScaledU64((1 << COST_MODEL_LIN_TERM_SCALE_BITS) / 8);
                 }
                 ContractCostType::VecEntry => {
-                    cpu.const_term = 0;
-                    cpu.lin_term = ScaledU64(0);
+                    cpu.const_term = 250;
+                    cpu.lin_term = ScaledU64((1 << COST_MODEL_LIN_TERM_SCALE_BITS) / 8);
                 }
                 ContractCostType::VerifyEd25519Sig => {
                     cpu.const_term = 376877;
                     cpu.lin_term = ScaledU64(2747);
                 }
                 ContractCostType::VmMemRead => {
-                    cpu.const_term = 182;
-                    cpu.lin_term = ScaledU64(24);
+                    cpu.const_term = 1000;
+                    cpu.lin_term = ScaledU64((1 << COST_MODEL_LIN_TERM_SCALE_BITS) / 8);
                 }
                 ContractCostType::VmMemWrite => {
-                    cpu.const_term = 182;
-                    cpu.lin_term = ScaledU64(24);
+                    cpu.const_term = 1000;
+                    cpu.lin_term = ScaledU64((1 << COST_MODEL_LIN_TERM_SCALE_BITS) / 8);
                 }
                 ContractCostType::VmInstantiation => {
                     cpu.const_term = 967154;

--- a/soroban-env-host/src/host/mem_helper.rs
+++ b/soroban-env-host/src/host/mem_helper.rs
@@ -397,7 +397,9 @@ impl Host {
         dest: &mut [T],
     ) -> Result<(), HostError> {
         self.charge_budget(ContractCostType::HostMemCpy, Some(src.len() as u64))?;
-        dest.copy_from_slice(src);
+        for (s, d) in src.iter().zip(dest.iter_mut()) {
+            *d = *s
+        }
         Ok(())
     }
 }

--- a/soroban-env-host/src/test/budget_metering.rs
+++ b/soroban-env-host/src/test/budget_metering.rs
@@ -358,26 +358,26 @@ fn total_amount_charged_from_random_inputs() -> Result<(), HostError> {
     let actual = format!("{:?}", host.as_budget());
     expect![[r#"
         =====================================================================================================================================================================
-        Cpu limit: 100000000; used: 10120240
+        Cpu limit: 100000000; used: 10218283
         Mem limit: 41943040; used: 276044
         =====================================================================================================================================================================
         CostType                 iterations     input          cpu_insns      mem_bytes      const_term_cpu      lin_term_cpu        const_term_mem      lin_term_mem        
         WasmInsnExec             246            None           1476           0              6                   0                   0                   0                   
         WasmMemAlloc             184            None           0              184            0                   0                   1                   0                   
         HostMemAlloc             1              Some(152)      1142           168            1141                1                   16                  128                 
-        HostMemCpy               1              Some(65)       51             0              39                  24                  0                   0                   
-        HostMemCmp               1              Some(74)       57             0              20                  64                  0                   0                   
+        HostMemCpy               1              Some(65)       258            0              250                 16                  0                   0                   
+        HostMemCmp               1              Some(74)       259            0              250                 16                  0                   0                   
         DispatchHostFunction     176            None           46288          0              263                 0                   0                   0                   
         VisitObject              97             None           10476          0              108                 0                   0                   0                   
-        ValSer                   1              Some(49)       617            165            591                 69                  18                  384                 
-        ValDeser                 1              Some(103)      1139           119            1112                34                  16                  128                 
+        ValSer                   1              Some(49)       1006           165            1000                16                  18                  384                 
+        ValDeser                 1              Some(103)      1012           119            1000                16                  16                  128                 
         ComputeSha256Hash        1              Some(193)      9179           40             2924                4149                40                  0                   
         ComputeEd25519PubKey     226            None           5781984        0              25584               0                   0                   0                   
-        MapEntry                 250            None           13250          0              53                  0                   0                   0                   
-        VecEntry                 186            None           0              0              0                   0                   0                   0                   
+        MapEntry                 250            None           62500          0              250                 16                  0                   0                   
+        VecEntry                 186            None           46500          0              250                 16                  0                   0                   
         VerifyEd25519Sig         1              Some(227)      381748         0              376877              2747                0                   0                   
-        VmMemRead                1              Some(69)       194            0              182                 24                  0                   0                   
-        VmMemWrite               1              Some(160)      212            0              182                 24                  0                   0                   
+        VmMemRead                1              Some(69)       1008           0              1000                16                  0                   0                   
+        VmMemWrite               1              Some(160)      1020           0              1000                16                  0                   0                   
         VmInstantiation          1              Some(147)      1047534        136937         967154              69991               131103              5080                
         VmCachedInstantiation    1              Some(147)      1047534        136937         967154              69991               131103              5080                
         InvokeVmFunction         47             None           52875          658            1125                0                   14                  0                   

--- a/soroban-env-host/src/test/metering_benchmark.rs
+++ b/soroban-env-host/src/test/metering_benchmark.rs
@@ -34,6 +34,11 @@ const LEDGER_INFO: LedgerInfo = LedgerInfo {
 #[ignore]
 #[test]
 fn run_add_i32() -> Result<(), HostError> {
+    #[cfg(feature = "tracy")]
+    tracy_client::Client::start();
+
+    let _test_span = tracy_span!("run_add_i32 test");
+
     let account_id = generate_account_id();
     let salt = generate_bytes_array();
     let a = 4i32;
@@ -41,6 +46,7 @@ fn run_add_i32() -> Result<(), HostError> {
 
     // Run 1: record footprint, emulating "preflight".
     let foot = {
+        let _run_span = tracy_span!("add_i32 run 1: recording footprint");
         let host = Host::test_host_with_recording_footprint();
         host.set_ledger_info(LEDGER_INFO.clone())?;
         let contract_id_obj =
@@ -55,6 +61,7 @@ fn run_add_i32() -> Result<(), HostError> {
     };
     // Run 2: enforce preflight footprint
     {
+        let _run_span = tracy_span!("add_i32 run 2: enforcing footprint");
         let store = Storage::with_enforcing_footprint_and_map(
             Footprint::default(),
             MeteredOrdMap::default(),
@@ -70,17 +77,25 @@ fn run_add_i32() -> Result<(), HostError> {
             host.test_vec_obj(&[a, b])?,
         )?;
     }
+    // Give tracy a little time to extract data.
+    #[cfg(feature = "tracy")]
+    std::thread::sleep(std::time::Duration::from_secs(2));
     Ok(())
 }
 
 #[ignore]
 #[test]
 fn run_complex() -> Result<(), HostError> {
+    #[cfg(feature = "tracy")]
+    tracy_client::Client::start();
+
+    let _test_span = tracy_span!("run_complex test");
     let account_id = generate_account_id();
     let salt = generate_bytes_array();
 
     // Run 1: record footprint, emulating "preflight".
     let foot = {
+        let _run_span = tracy_span!("complex run 1: recording footprint");
         let host = Host::test_host_with_recording_footprint();
         host.set_ledger_info(LEDGER_INFO.clone())?;
         let contract_id_obj =
@@ -96,6 +111,7 @@ fn run_complex() -> Result<(), HostError> {
 
     // Run 2: enforce preflight footprint, with empty map -- contract should only write.
     {
+        let _run_span = tracy_span!("complex run 2: enforcing footprint");
         let store = Storage::with_enforcing_footprint_and_map(
             Footprint::default(),
             MeteredOrdMap::default(),
@@ -111,5 +127,8 @@ fn run_complex() -> Result<(), HostError> {
             host.add_host_object(HostVec::new())?,
         )?;
     }
+    // Give tracy a little time to extract data.
+    #[cfg(feature = "tracy")]
+    std::thread::sleep(std::time::Duration::from_secs(2));
     Ok(())
 }

--- a/soroban-env-host/src/test/util.rs
+++ b/soroban-env-host/src/test/util.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, rc::Rc};
+use std::{cell::RefCell, collections::BTreeMap, rc::Rc};
 
 use rand::{thread_rng, RngCore};
 use soroban_env_common::{
@@ -12,6 +12,7 @@ use soroban_synth_wasm::{Arity, ModEmitter, Operand};
 
 use crate::{
     budget::{AsBudget, Budget},
+    host::HostLifecycleEvent,
     storage::{SnapshotSource, Storage},
     xdr, Error, Host, HostError, LedgerInfo,
 };
@@ -202,6 +203,7 @@ impl Host {
         account: AccountId,
         salt: [u8; 32],
     ) -> AddressObject {
+        let _span = tracy_span!("register_test_contract_wasm_from_source_account");
         // Use source account-based auth in order to avoid using nonces which
         // won't work well with enforcing ledger footprint.
         let prev_source_account = self.source_account_id().unwrap();
@@ -246,11 +248,31 @@ impl Host {
         func: Symbol,
         args: VecObject,
     ) -> Result<Val, HostError> {
+        let _span = tracy_span!("measured_call");
         let budget = self.as_budget();
         budget.reset_unlimited()?;
-        let ht = HostTracker::start(None);
+        let ht = Rc::new(RefCell::new(HostTracker::new()));
 
+        if std::env::var("EXCLUDE_VM_INSTANTIATION").is_ok() {
+            let ht2 = ht.clone();
+            let budget2 = budget.clone();
+            self.set_lifecycle_event_hook(Some(Rc::new(move |evt| {
+                match evt {
+                    HostLifecycleEvent::VmInstantiated => {
+                        budget2.reset_unlimited()?;
+                        ht2.borrow_mut().start(None);
+                    }
+                }
+                Ok(())
+            })))?;
+        } else {
+            ht.borrow_mut().start(None);
+        }
         let val = self.call(contract, func, args);
+        self.set_lifecycle_event_hook(None)?;
+
+        let (cpu_actual, mem_actual, time_nsecs) = Rc::into_inner(ht).unwrap().into_inner().stop();
+
         let cpu_metered = budget
             .get_cpu_insns_consumed()
             .expect("unable to retrieve cpu consumed");
@@ -258,7 +280,6 @@ impl Host {
             .get_mem_bytes_consumed()
             .expect("unable to retrieve mem consumed");
 
-        let (cpu_actual, mem_actual, time_nsecs) = ht.stop();
         let cpu_diff = (cpu_metered - cpu_actual) as i64;
         let cpu_metered_diff_percent = 100 * cpu_diff / (cpu_metered as i64).max(1);
         let mem_diff = (mem_metered - mem_actual) as i64;

--- a/soroban-env-host/src/test/util.rs
+++ b/soroban-env-host/src/test/util.rs
@@ -265,21 +265,23 @@ impl Host {
         let mem_metered_diff_percent = 100 * mem_diff / (mem_metered as i64).max(1);
         let metered_insn_nsecs_ratio: f64 = (cpu_metered as f64) / (time_nsecs as f64).max(1.0);
         let actual_insn_nsecs_ratio: f64 = (cpu_actual as f64) / (time_nsecs as f64).max(1.0);
+
         println!();
         println!(
-            "metered cpu insns: {}, actual cpu insns {}, diff: {} ({}%) \n",
+            "metered cpu insns: {}, actual cpu insns {}, diff: {} ({:.3}%)",
             cpu_metered, cpu_actual, cpu_diff, cpu_metered_diff_percent
         );
         println!(
-            "metered mem bytes: {}, actual mem bytes {}, diff: {} ({}%) \n",
+            "metered mem bytes: {}, actual mem bytes {}, diff: {} ({:.3}%)",
             mem_metered, mem_actual, mem_diff, mem_metered_diff_percent
         );
+        println!("time_nsecs: {}", time_nsecs);
         println!(
-            "metered cpu_insn/time_nsecs ratio: {} \n",
+            "metered cpu_insn/time_nsecs ratio: {:.3}",
             metered_insn_nsecs_ratio
         );
         println!(
-            "actual cpu_insn/time_nsecs ratio: {} \n",
+            "actual cpu_insn/time_nsecs ratio: {:.3}",
             actual_insn_nsecs_ratio
         );
         println!();

--- a/soroban-env-host/src/vm.rs
+++ b/soroban-env-host/src/vm.rs
@@ -258,7 +258,8 @@ impl Vm {
         // Here we do _not_ supply the store with any fuel. Fuel is supplied
         // right before the VM is being run, i.e., before crossing the host->VM
         // boundary.
-        // Missing metering for the Rc, but this is once per Vm so should be okay
+        #[cfg(any(test, feature = "testutils"))]
+        host.call_any_lifecycle_hook(crate::host::HostLifecycleEvent::VmInstantiated)?;
         Ok(Rc::new(Self {
             contract_id,
             module,

--- a/soroban-env-host/src/vm/dispatch.rs
+++ b/soroban-env-host/src/vm/dispatch.rs
@@ -139,7 +139,7 @@ macro_rules! generate_dispatch_functions {
                 pub(crate) fn $fn_id(mut caller: wasmi::Caller<Host>, $($arg:i64),*) ->
                     Result<(i64,), Trap>
                 {
-                    let _span = tracy_span!(std::stringify!($fn_id));
+                    let _span = tracy_span!(core::stringify!($fn_id));
 
                     let host = caller.data().clone();
 


### PR DESCRIPTION
A bunch of exploration of minor issues discovered in budget calibration, ostensibly about #1020 but also involving some tracy markup, some internal cleanup, machinery to allow excluding the overwhelming VM instantiation cost center, and some attempts at setting budget costs more from first principles.