### PR TITLE
Use Address for `call_account_contract_check_auth` test helper.

### DIFF
--- a/soroban-env-host/src/auth.rs
+++ b/soroban-env-host/src/auth.rs
@@ -1866,12 +1866,11 @@ impl Host {
     /// of `require_auth[_for_args]` calls.
     pub fn call_account_contract_check_auth(
         &self,
-        contract: BytesObject,
+        contract: AddressObject,
         args: VecObject,
     ) -> Result<Val, HostError> {
         use crate::native_contract::account_contract::ACCOUNT_CONTRACT_CHECK_AUTH_FN_NAME;
-
-        let contract_id = self.hash_from_bytesobj_input("contract", contract)?;
+        let contract_id = self.contract_id_from_address(contract)?;
         let args_vec = self.call_args_from_obj(args)?;
         let res = self.call_n_internal(
             &contract_id,

--- a/soroban-env-host/src/auth.rs
+++ b/soroban-env-host/src/auth.rs
@@ -1856,7 +1856,7 @@ impl Host {
 }
 
 #[cfg(any(test, feature = "testutils"))]
-use crate::{host::frame::ContractReentryMode, xdr::SorobanAuthorizedInvocation, BytesObject};
+use crate::{host::frame::ContractReentryMode, xdr::SorobanAuthorizedInvocation};
 #[cfg(any(test, feature = "testutils"))]
 impl Host {
     /// Invokes the reserved `__check_auth` function on a provided contract.


### PR DESCRIPTION
### What

Use Address for `call_account_contract_check_auth` test helper.

### Why

This is one of the functions that has been overlooked during Bytes->Address migration. This is also needed to support https://github.com/stellar/rs-soroban-sdk/pull/1112

### Known limitations

N/A
