### PR TITLE
Setup bench framework to run experiments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,6 +1376,7 @@ version = "20.0.0-rc2"
 dependencies = [
  "backtrace",
  "bytes-lit",
+ "curve25519-dalek",
  "ed25519-dalek",
  "expect-test",
  "getrandom",

--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -32,6 +32,9 @@ k256 = {version = "0.13.1", features=["ecdsa", "arithmetic"]}
 # is needed to build the host for wasm (a rare but supported config).
 getrandom = { version = "0.2", features=["js"] }
 sha3 = "0.10.8"
+# NB: this must match the same curve25519-dalek version used by ed25519-dalek above
+# used only for calibration
+curve25519-dalek = { version = "4", default-features = false, features = ["digest"]}
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 tracy-client = { version = "=0.15.2", features = ["enable", "timer-fallback"], default-features = false, optional = true }

--- a/soroban-env-host/benches/common/experimental/ed25519_scalar_mul.rs
+++ b/soroban-env-host/benches/common/experimental/ed25519_scalar_mul.rs
@@ -1,0 +1,62 @@
+use crate::common::HostCostMeasurement;
+use curve25519_dalek::{constants, edwards, scalar};
+use rand::{rngs::StdRng, Rng, RngCore};
+use soroban_env_host::{
+    cost_runner::{Ed25519ScalarMulRun, Ed25519ScalarMulSample},
+    Host,
+};
+
+// This measures the costs of doing an Ed25519 scalar multiply, which is a
+// component of signature verification and is the only part advertised as
+// variable time. The input value is ignored. The underlying operation is
+// nonlinear and the point of this measurement is to investigate how wide the
+// variation is in the histogram.
+#[allow(non_snake_case)]
+pub(crate) struct Ed25519ScalarMulMeasure {
+    a: scalar::Scalar,
+    A: edwards::EdwardsPoint,
+    b: scalar::Scalar,
+}
+#[allow(non_snake_case)]
+impl HostCostMeasurement for Ed25519ScalarMulMeasure {
+    type Runner = Ed25519ScalarMulRun;
+
+    fn new_best_case(_host: &Host, _rng: &mut StdRng) -> Ed25519ScalarMulSample {
+        let a = scalar::Scalar::ONE;
+        let b = scalar::Scalar::ONE;
+        let A = constants::ED25519_BASEPOINT_COMPRESSED
+            .decompress()
+            .unwrap();
+        Ed25519ScalarMulSample { a, b, A }
+    }
+
+    fn new_worst_case(_host: &Host, _rng: &mut StdRng, _input: u64) -> Ed25519ScalarMulSample {
+        let a = scalar::Scalar::from_bytes_mod_order([0xff; 32]);
+        let b = a.clone();
+        let A = constants::ED25519_BASEPOINT_COMPRESSED
+            .decompress()
+            .unwrap();
+        Ed25519ScalarMulSample { a, b, A }
+    }
+
+    fn new_random_case(_host: &Host, rng: &mut StdRng, _input: u64) -> Ed25519ScalarMulSample {
+        fn random_scalar(rng: &mut StdRng) -> scalar::Scalar {
+            let mut buf: [u8; 32] = [0; 32];
+            rng.fill_bytes(&mut buf);
+            // Here we zero-out some number of bits from the top, making the scalar
+            // smaller and thus the work less. It's not really plausible for natural
+            // occurrences here to have more than a handful of contiguous zeroes here
+            // but for thoroughness we'll let it go up to 64 (8 bytes).
+            for i in 0..rng.gen_range(0..9) {
+                buf[31 - i] = 0
+            }
+            scalar::Scalar::from_bytes_mod_order(buf)
+        }
+        let a = random_scalar(rng);
+        let b = random_scalar(rng);
+        let A = constants::ED25519_BASEPOINT_COMPRESSED
+            .decompress()
+            .unwrap();
+        Ed25519ScalarMulSample { a, b, A }
+    }
+}

--- a/soroban-env-host/benches/common/experimental/mod.rs
+++ b/soroban-env-host/benches/common/experimental/mod.rs
@@ -1,0 +1,3 @@
+mod ed25519_scalar_mul;
+
+pub(crate) use ed25519_scalar_mul::*;

--- a/soroban-env-host/benches/common/measure.rs
+++ b/soroban-env-host/benches/common/measure.rs
@@ -452,19 +452,19 @@ pub fn measure_worst_case_costs<HCM: HostCostMeasurement>(
 }
 
 /// Measure the cost variation of a HCM. `sweep_input` specifies whether the input
-/// is fixed or randomized. 
+/// is fixed or randomized.
 ///     if true - input is randomized, with `large_input` specifying the upperbound
 ///               of the input size
 ///     if false - input size is fixed at `large_input`
 /// `iteration` specifies number of iterations to run the measurement
 /// `include_best_case` specifies whether best case is included. Often the best case
-/// is a trivial case that isn't too relevant (and never hit). So if one is more 
+/// is a trivial case that isn't too relevant (and never hit). So if one is more
 /// interested in the worst/average analysis, it might be useful to throw it away.
 pub fn measure_cost_variation<HCM: HostCostMeasurement>(
     large_input: u64,
     iterations: u64,
     sweep_input: bool,
-    include_best_case: bool,    
+    include_best_case: bool,
 ) -> Result<Measurements, std::io::Error> {
     let mut i = 0;
     let mut rng = StdRng::from_seed([0xff; 32]);
@@ -493,15 +493,15 @@ pub fn measure_cost_variation<HCM: HostCostMeasurement>(
                 large_input
             };
             match i {
-                1 => if include_best_case {
-                    Some(HCM::new_best_case(host, &mut rng))
-                } else {
-                    Some(HCM::new_random_case(host, &mut rng, input))
-                }                
-                2 => Some(HCM::new_worst_case(host, &mut rng, large_input)),
-                n if n < iterations => {
-                    Some(HCM::new_random_case(host, &mut rng, input))
+                1 => {
+                    if include_best_case {
+                        Some(HCM::new_best_case(host, &mut rng))
+                    } else {
+                        Some(HCM::new_random_case(host, &mut rng, input))
+                    }
                 }
+                2 => Some(HCM::new_worst_case(host, &mut rng, large_input)),
+                n if n < iterations => Some(HCM::new_random_case(host, &mut rng, input)),
                 _ => None,
             }
         },

--- a/soroban-env-host/benches/common/measure.rs
+++ b/soroban-env-host/benches/common/measure.rs
@@ -451,10 +451,21 @@ pub fn measure_worst_case_costs<HCM: HostCostMeasurement>(
     })
 }
 
+/// Measure the cost variation of a HCM. `sweep_input` specifies whether the input
+/// is fixed or randomized. 
+///     if true - input is randomized, with `large_input` specifying the upperbound
+///               of the input size
+///     if false - input size is fixed at `large_input`
+/// `iteration` specifies number of iterations to run the measurement
+/// `include_best_case` specifies whether best case is included. Often the best case
+/// is a trivial case that isn't too relevant (and never hit). So if one is more 
+/// interested in the worst/average analysis, it might be useful to throw it away.
 pub fn measure_cost_variation<HCM: HostCostMeasurement>(
     large_input: u64,
+    iterations: u64,
+    sweep_input: bool,
+    include_best_case: bool,    
 ) -> Result<Measurements, std::io::Error> {
-    let count = 100;
     let mut i = 0;
     let mut rng = StdRng::from_seed([0xff; 32]);
 
@@ -476,11 +487,19 @@ pub fn measure_cost_variation<HCM: HostCostMeasurement>(
     let measurements = measure_costs_inner::<HCM, _, _>(
         |host| {
             i += 1;
+            let input = if sweep_input {
+                rng.gen_range(1..=2 + large_input)
+            } else {
+                large_input
+            };
             match i {
-                1 => Some(HCM::new_best_case(host, &mut rng)),
+                1 => if include_best_case {
+                    Some(HCM::new_best_case(host, &mut rng))
+                } else {
+                    Some(HCM::new_random_case(host, &mut rng, input))
+                }                
                 2 => Some(HCM::new_worst_case(host, &mut rng, large_input)),
-                n if n < count => {
-                    let input = rng.gen_range(1..=2 + large_input);
+                n if n < iterations => {
                     Some(HCM::new_random_case(host, &mut rng, input))
                 }
                 _ => None,

--- a/soroban-env-host/benches/common/mod.rs
+++ b/soroban-env-host/benches/common/mod.rs
@@ -1,16 +1,19 @@
 #![allow(dead_code)]
 
 mod cost_types;
+mod experimental;
 mod measure;
 mod modelfit;
 mod util;
 
 use cost_types::*;
+use experimental::*;
 pub use measure::*;
 pub use modelfit::*;
 
+use soroban_env_common::xdr::Name;
 use soroban_env_host::{
-    cost_runner::{CostRunner, WasmInsnType},
+    cost_runner::{CostRunner, CostType, WasmInsnType},
     xdr::ContractCostType,
 };
 use std::collections::BTreeMap;
@@ -29,20 +32,7 @@ fn get_explicit_bench_names() -> Option<Vec<String>> {
 
 fn should_run<HCM: HostCostMeasurement>() -> bool {
     if let Some(bench_names) = get_explicit_bench_names() {
-        let name = format!("{:?}", <HCM::Runner as CostRunner>::COST_TYPE)
-            .split("::")
-            .last()
-            .unwrap()
-            .to_string();
-        bench_names.iter().any(|arg| *arg == name)
-    } else {
-        true
-    }
-}
-
-fn should_run_wasm_insn(ty: WasmInsnType) -> bool {
-    if let Some(bench_names) = get_explicit_bench_names() {
-        let name = format!("{:?}", ty).split("::").last().unwrap().to_string();
+        let name = <HCM::Runner as CostRunner>::COST_TYPE.name();
         bench_names.iter().any(|arg| *arg == name)
     } else {
         true
@@ -50,7 +40,7 @@ fn should_run_wasm_insn(ty: WasmInsnType) -> bool {
 }
 
 fn call_bench<B: Benchmark, HCM: HostCostMeasurement>(
-    params: &mut BTreeMap<ContractCostType, (FPCostModel, FPCostModel)>,
+    params: &mut BTreeMap<CostType, (FPCostModel, FPCostModel)>,
 ) -> std::io::Result<()> {
     if should_run::<HCM>() {
         params.insert(<HCM::Runner as CostRunner>::COST_TYPE, B::bench::<HCM>()?);
@@ -58,11 +48,16 @@ fn call_bench<B: Benchmark, HCM: HostCostMeasurement>(
     Ok(())
 }
 
-pub(crate) fn for_each_host_cost_measurement<B: Benchmark>(
-) -> std::io::Result<BTreeMap<ContractCostType, (FPCostModel, FPCostModel)>> {
-    let mut params: BTreeMap<ContractCostType, (FPCostModel, FPCostModel)> = BTreeMap::new();
+pub(crate) fn for_each_experimental_cost_measurement<B: Benchmark>(
+) -> std::io::Result<(FPCostModel, FPCostModel)> {
+    B::bench::<Ed25519ScalarMulMeasure>()?;
+    B::bench::<VerifyEd25519SigMeasure>()
+}
 
-    // call_bench::<B, ComputeEcdsaSecp256k1PubKeyMeasure>(&mut params)?;
+pub(crate) fn for_each_host_cost_measurement<B: Benchmark>(
+) -> std::io::Result<BTreeMap<CostType, (FPCostModel, FPCostModel)>> {
+    let mut params: BTreeMap<CostType, (FPCostModel, FPCostModel)> = BTreeMap::new();
+
     call_bench::<B, ComputeEcdsaSecp256k1SigMeasure>(&mut params)?;
     call_bench::<B, ComputeEd25519PubKeyMeasure>(&mut params)?;
     call_bench::<B, ComputeKeccak256HashMeasure>(&mut params)?;
@@ -70,13 +65,9 @@ pub(crate) fn for_each_host_cost_measurement<B: Benchmark>(
     call_bench::<B, RecoverEcdsaSecp256k1KeyMeasure>(&mut params)?;
     call_bench::<B, VerifyEd25519SigMeasure>(&mut params)?;
     call_bench::<B, VmInstantiationMeasure>(&mut params)?;
-    // call_bench::<B, VmMemReadMeasure>(&mut params)?;
-    // call_bench::<B, VmMemWriteMeasure>(&mut params)?;
     call_bench::<B, VisitObjectMeasure>(&mut params)?;
     call_bench::<B, ValSerMeasure>(&mut params)?;
     call_bench::<B, ValDeserMeasure>(&mut params)?;
-    // call_bench::<B, MapEntryMeasure>(&mut params)?;
-    // call_bench::<B, VecEntryMeasure>(&mut params)?;
     call_bench::<B, MemCmpMeasure>(&mut params)?;
     call_bench::<B, InvokeVmFunctionMeasure>(&mut params)?;
     call_bench::<B, InvokeHostFunctionMeasure>(&mut params)?;
@@ -91,7 +82,7 @@ pub(crate) fn for_each_host_cost_measurement<B: Benchmark>(
 
     if get_explicit_bench_names().is_none() {
         for cost in ContractCostType::variants() {
-            if !params.contains_key(&cost) {
+            if !params.contains_key(&CostType::Contract(cost)) {
                 eprintln!("warning: missing cost measurement for {:?}", cost);
             }
         }
@@ -101,20 +92,17 @@ pub(crate) fn for_each_host_cost_measurement<B: Benchmark>(
 
 macro_rules! run_wasm_insn_measurement {
     ( $($HCM: ident),* ) => {
-        pub(crate) fn for_each_wasm_insn_measurement<B: Benchmark>() -> std::io::Result<BTreeMap<WasmInsnType, (FPCostModel, FPCostModel)>> {
-            let mut params: BTreeMap<WasmInsnType, (FPCostModel, FPCostModel)> = BTreeMap::new();
+        pub(crate) fn for_each_wasm_insn_measurement<B: Benchmark>() -> std::io::Result<BTreeMap<CostType, (FPCostModel, FPCostModel)>> {
+            let mut params: BTreeMap<CostType, (FPCostModel, FPCostModel)> = BTreeMap::new();
             $(
-                let ty = <$HCM as HostCostMeasurement>::Runner::INSN_TYPE;
-                if should_run_wasm_insn(ty) {
-                    eprintln!(
-                        "\nMeasuring costs for WasmInsnType::{:?}\n", ty);
-                    params.insert(ty, B::bench::<$HCM>()?);
+                if should_run::<$HCM>() {
+                    params.insert(<$HCM as HostCostMeasurement>::Runner::COST_TYPE, B::bench::<$HCM>()?);
                 }
             )*
 
             if get_explicit_bench_names().is_none() {
                 for insn in WasmInsnType::variants() {
-                    if !params.contains_key(insn) {
+                    if !params.contains_key(&CostType::Wasm(*insn)) {
                         eprintln!("warning: missing cost measurement for {:?}", insn);
                     }
                 }

--- a/soroban-env-host/benches/variation_histograms.rs
+++ b/soroban-env-host/benches/variation_histograms.rs
@@ -1,5 +1,5 @@
 // Run this with
-// $ cargo bench --features wasmi,testutils --bench variation_histograms -- --nocapture
+// $ cargo bench --features testutils --bench variation_histograms -- --nocapture
 mod common;
 use common::*;
 use soroban_env_host::cost_runner::CostRunner;
@@ -8,7 +8,7 @@ struct LinearModelTables;
 impl Benchmark for LinearModelTables {
     fn bench<HCM: HostCostMeasurement>() -> std::io::Result<(FPCostModel, FPCostModel)> {
         let mut measurements = measure_cost_variation::<HCM>(100)?;
-        measurements.check_range_against_baseline(HCM::Runner::COST_TYPE)?;
+        measurements.check_range_against_baseline(&HCM::Runner::COST_TYPE)?;
         measurements.preprocess();
         measurements.report_histogram("cpu", |m| m.cpu_insns);
         measurements.report_histogram("mem", |m| m.mem_bytes);
@@ -18,6 +18,6 @@ impl Benchmark for LinearModelTables {
 
 #[cfg(all(test, any(target_os = "linux", target_os = "macos")))]
 fn main() -> std::io::Result<()> {
-    for_each_host_cost_measurement::<LinearModelTables>()?;
+    for_each_experimental_cost_measurement::<LinearModelTables>()?;
     Ok(())
 }

--- a/soroban-env-host/benches/variation_histograms.rs
+++ b/soroban-env-host/benches/variation_histograms.rs
@@ -7,7 +7,7 @@ use soroban_env_host::cost_runner::CostRunner;
 struct LinearModelTables;
 impl Benchmark for LinearModelTables {
     fn bench<HCM: HostCostMeasurement>() -> std::io::Result<(FPCostModel, FPCostModel)> {
-        let mut measurements = measure_cost_variation::<HCM>(100)?;
+        let mut measurements = measure_cost_variation::<HCM>(100, 1000, false, false)?;
         measurements.check_range_against_baseline(&HCM::Runner::COST_TYPE)?;
         measurements.preprocess();
         measurements.report_histogram("cpu", |m| m.cpu_insns);

--- a/soroban-env-host/src/cost_runner/cost_types/compute_ecdsa_secp256k1_sig.rs
+++ b/soroban-env-host/src/cost_runner/cost_types/compute_ecdsa_secp256k1_sig.rs
@@ -2,12 +2,15 @@ use std::hint::black_box;
 
 use k256::ecdsa::Signature;
 
-use crate::{cost_runner::CostRunner, xdr::ContractCostType};
+use crate::{
+    cost_runner::{CostRunner, CostType},
+    xdr::ContractCostType::ComputeEcdsaSecp256k1Sig,
+};
 
 pub struct ComputeEcdsaSecp256k1SigRun;
 
 impl CostRunner for ComputeEcdsaSecp256k1SigRun {
-    const COST_TYPE: ContractCostType = ContractCostType::ComputeEcdsaSecp256k1Sig;
+    const COST_TYPE: CostType = CostType::Contract(ComputeEcdsaSecp256k1Sig);
 
     type SampleType = Vec<u8>;
 
@@ -26,7 +29,7 @@ impl CostRunner for ComputeEcdsaSecp256k1SigRun {
         _iter: u64,
         sample: Self::SampleType,
     ) -> Self::RecycledType {
-        black_box(host.charge_budget(Self::COST_TYPE, None).unwrap());
+        black_box(host.charge_budget(ComputeEcdsaSecp256k1Sig, None).unwrap());
         black_box((None, sample))
     }
 }

--- a/soroban-env-host/src/cost_runner/cost_types/compute_ed25519_pubkey.rs
+++ b/soroban-env-host/src/cost_runner/cost_types/compute_ed25519_pubkey.rs
@@ -2,12 +2,15 @@ use std::hint::black_box;
 
 use ed25519_dalek::VerifyingKey;
 
-use crate::{cost_runner::CostRunner, xdr::ContractCostType};
+use crate::{
+    cost_runner::{CostRunner, CostType},
+    xdr::ContractCostType::ComputeEd25519PubKey,
+};
 
 pub struct ComputeEd25519PubKeyRun;
 
 impl CostRunner for ComputeEd25519PubKeyRun {
-    const COST_TYPE: ContractCostType = ContractCostType::ComputeEd25519PubKey;
+    const COST_TYPE: CostType = CostType::Contract(ComputeEd25519PubKey);
 
     type SampleType = Vec<u8>;
 
@@ -26,7 +29,7 @@ impl CostRunner for ComputeEd25519PubKeyRun {
         _iter: u64,
         sample: Self::SampleType,
     ) -> Self::RecycledType {
-        black_box(host.charge_budget(Self::COST_TYPE, None).unwrap());
+        black_box(host.charge_budget(ComputeEd25519PubKey, None).unwrap());
         black_box((None, sample))
     }
 }

--- a/soroban-env-host/src/cost_runner/cost_types/compute_keccak256_hash.rs
+++ b/soroban-env-host/src/cost_runner/cost_types/compute_keccak256_hash.rs
@@ -1,11 +1,14 @@
 use std::hint::black_box;
 
-use crate::{cost_runner::CostRunner, xdr::ContractCostType};
+use crate::{
+    cost_runner::{CostRunner, CostType},
+    xdr::ContractCostType::ComputeKeccak256Hash,
+};
 
 pub struct ComputeKeccak256HashRun;
 
 impl CostRunner for ComputeKeccak256HashRun {
-    const COST_TYPE: ContractCostType = ContractCostType::ComputeKeccak256Hash;
+    const COST_TYPE: CostType = CostType::Contract(ComputeKeccak256Hash);
 
     type SampleType = Vec<u8>;
 
@@ -24,7 +27,7 @@ impl CostRunner for ComputeKeccak256HashRun {
         _iter: u64,
         sample: Self::SampleType,
     ) -> Self::RecycledType {
-        black_box(host.charge_budget(Self::COST_TYPE, Some(0)).unwrap());
+        black_box(host.charge_budget(ComputeKeccak256Hash, Some(0)).unwrap());
         black_box((None, sample))
     }
 }

--- a/soroban-env-host/src/cost_runner/cost_types/compute_sha256_hash.rs
+++ b/soroban-env-host/src/cost_runner/cost_types/compute_sha256_hash.rs
@@ -1,11 +1,15 @@
 use std::hint::black_box;
 
-use crate::{cost_runner::CostRunner, host::crypto::sha256_hash_from_bytes, xdr::ContractCostType};
+use crate::{
+    cost_runner::{CostRunner, CostType},
+    host::crypto::sha256_hash_from_bytes,
+    xdr::ContractCostType::ComputeSha256Hash,
+};
 
 pub struct ComputeSha256HashRun;
 
 impl CostRunner for ComputeSha256HashRun {
-    const COST_TYPE: ContractCostType = ContractCostType::ComputeSha256Hash;
+    const COST_TYPE: CostType = CostType::Contract(ComputeSha256Hash);
 
     type SampleType = Vec<u8>;
 
@@ -21,7 +25,7 @@ impl CostRunner for ComputeSha256HashRun {
         _iter: u64,
         sample: Self::SampleType,
     ) -> Self::RecycledType {
-        black_box(host.charge_budget(Self::COST_TYPE, Some(0)).unwrap());
+        black_box(host.charge_budget(ComputeSha256Hash, Some(0)).unwrap());
         black_box((None, sample))
     }
 }

--- a/soroban-env-host/src/cost_runner/cost_types/host_mem_alloc.rs
+++ b/soroban-env-host/src/cost_runner/cost_types/host_mem_alloc.rs
@@ -1,11 +1,16 @@
 use std::hint::black_box;
 
-use crate::{budget::AsBudget, cost_runner::CostRunner, xdr::ContractCostType, MeteredVector};
+use crate::{
+    budget::AsBudget,
+    cost_runner::{CostRunner, CostType},
+    xdr::ContractCostType::MemAlloc,
+    MeteredVector,
+};
 
 pub struct MemAllocRun;
 
 impl CostRunner for MemAllocRun {
-    const COST_TYPE: ContractCostType = ContractCostType::MemAlloc;
+    const COST_TYPE: CostType = CostType::Contract(MemAlloc);
 
     type SampleType = u64;
 
@@ -24,7 +29,7 @@ impl CostRunner for MemAllocRun {
         _iter: u64,
         _sample: Self::SampleType,
     ) -> Self::RecycledType {
-        black_box(host.charge_budget(Self::COST_TYPE, Some(0)).unwrap());
+        black_box(host.charge_budget(MemAlloc, Some(0)).unwrap());
         black_box(None)
     }
 }

--- a/soroban-env-host/src/cost_runner/cost_types/host_mem_cmp.rs
+++ b/soroban-env-host/src/cost_runner/cost_types/host_mem_cmp.rs
@@ -2,11 +2,15 @@ use std::{cmp::Ordering, hint::black_box};
 
 use soroban_env_common::Compare;
 
-use crate::{budget::AsBudget, cost_runner::CostRunner, xdr::ContractCostType};
+use crate::{
+    budget::AsBudget,
+    cost_runner::{CostRunner, CostType},
+    xdr::ContractCostType::MemCmp,
+};
 
 pub struct MemCmpRun;
 impl CostRunner for MemCmpRun {
-    const COST_TYPE: ContractCostType = ContractCostType::MemCmp;
+    const COST_TYPE: CostType = CostType::Contract(MemCmp);
 
     type SampleType = (Vec<u8>, Vec<u8>);
 
@@ -26,7 +30,7 @@ impl CostRunner for MemCmpRun {
         _iter: u64,
         sample: Self::SampleType,
     ) -> Self::RecycledType {
-        black_box(host.charge_budget(Self::COST_TYPE, Some(0)).unwrap());
+        black_box(host.charge_budget(MemCmp, Some(0)).unwrap());
         black_box((None, sample))
     }
 }

--- a/soroban-env-host/src/cost_runner/cost_types/host_mem_cpy.rs
+++ b/soroban-env-host/src/cost_runner/cost_types/host_mem_cpy.rs
@@ -1,11 +1,14 @@
 use std::hint::black_box;
 
-use crate::{cost_runner::CostRunner, xdr::ContractCostType};
+use crate::{
+    cost_runner::{CostRunner, CostType},
+    xdr::ContractCostType::MemCpy,
+};
 
 pub struct MemCpyRun;
 
 impl CostRunner for MemCpyRun {
-    const COST_TYPE: ContractCostType = ContractCostType::MemCpy;
+    const COST_TYPE: CostType = CostType::Contract(MemCpy);
 
     type SampleType = (Vec<u8>, Vec<u8>);
 
@@ -24,7 +27,7 @@ impl CostRunner for MemCpyRun {
         _iter: u64,
         sample: Self::SampleType,
     ) -> Self::RecycledType {
-        black_box(host.charge_budget(Self::COST_TYPE, Some(0)).unwrap());
+        black_box(host.charge_budget(MemCpy, Some(0)).unwrap());
         black_box(sample)
     }
 }

--- a/soroban-env-host/src/cost_runner/cost_types/invoke.rs
+++ b/soroban-env-host/src/cost_runner/cost_types/invoke.rs
@@ -1,7 +1,10 @@
 use soroban_env_common::ConversionError;
 
 use crate::{
-    cost_runner::CostRunner, vm::dummy0, xdr::ContractCostType, HostError, Symbol, Val, Vm,
+    cost_runner::{CostRunner, CostType},
+    vm::dummy0,
+    xdr::ContractCostType::{DispatchHostFunction, InvokeVmFunction},
+    HostError, Symbol, Val, Vm,
 };
 use std::{hint::black_box, rc::Rc};
 
@@ -13,7 +16,7 @@ const TEST_SYM: Symbol = match Symbol::try_from_small_str("test") {
 };
 
 impl CostRunner for InvokeVmFunctionRun {
-    const COST_TYPE: ContractCostType = ContractCostType::InvokeVmFunction;
+    const COST_TYPE: CostType = CostType::Contract(InvokeVmFunction);
 
     type SampleType = Rc<Vm>;
 
@@ -31,7 +34,7 @@ impl CostRunner for InvokeVmFunctionRun {
         _iter: u64,
         sample: Self::SampleType,
     ) -> Self::RecycledType {
-        black_box(host.charge_budget(Self::COST_TYPE, None).unwrap());
+        black_box(host.charge_budget(InvokeVmFunction, None).unwrap());
         black_box((None, sample))
     }
 }
@@ -39,7 +42,7 @@ impl CostRunner for InvokeVmFunctionRun {
 pub struct InvokeHostFunctionRun;
 
 impl CostRunner for InvokeHostFunctionRun {
-    const COST_TYPE: ContractCostType = ContractCostType::DispatchHostFunction;
+    const COST_TYPE: CostType = CostType::Contract(DispatchHostFunction);
 
     const RUN_ITERATIONS: u64 = 1000;
 
@@ -61,7 +64,7 @@ impl CostRunner for InvokeHostFunctionRun {
         _iter: u64,
         sample: Self::SampleType,
     ) -> Self::RecycledType {
-        black_box(host.charge_budget(Self::COST_TYPE, None).unwrap());
+        black_box(host.charge_budget(DispatchHostFunction, None).unwrap());
         black_box(sample)
     }
 }

--- a/soroban-env-host/src/cost_runner/cost_types/num_ops.rs
+++ b/soroban-env-host/src/cost_runner/cost_types/num_ops.rs
@@ -1,13 +1,17 @@
 use std::hint::black_box;
 
-use crate::{cost_runner::CostRunner, xdr::ContractCostType, Env, I256Val, U32Val};
+use crate::{
+    cost_runner::{CostRunner, CostType},
+    xdr::ContractCostType::{Int256AddSub, Int256Div, Int256Mul, Int256Pow, Int256Shift},
+    Env, I256Val, U32Val,
+};
 
 macro_rules! impl_int256_cost_runner {
     ($runner:ident, $method:ident, $cost:ident, $sample_type: ty) => {
         pub struct $runner;
 
         impl CostRunner for $runner {
-            const COST_TYPE: ContractCostType = ContractCostType::$cost;
+            const COST_TYPE: CostType = CostType::Contract($cost);
 
             type SampleType = $sample_type;
 
@@ -27,7 +31,7 @@ macro_rules! impl_int256_cost_runner {
                 _iter: u64,
                 _sample: Self::SampleType,
             ) -> Self::RecycledType {
-                black_box(host.charge_budget(Self::COST_TYPE, None).unwrap());
+                black_box(host.charge_budget($cost, None).unwrap());
                 black_box(None)
             }
         }

--- a/soroban-env-host/src/cost_runner/cost_types/prng.rs
+++ b/soroban-env-host/src/cost_runner/cost_types/prng.rs
@@ -2,12 +2,16 @@ use std::hint::black_box;
 
 use rand_chacha::ChaCha20Rng;
 
-use crate::{cost_runner::CostRunner, host::crypto::chacha20_fill_bytes, xdr::ContractCostType};
+use crate::{
+    cost_runner::{CostRunner, CostType},
+    host::crypto::chacha20_fill_bytes,
+    xdr::ContractCostType::ChaCha20DrawBytes,
+};
 
 pub struct ChaCha20DrawBytesRun;
 
 impl CostRunner for ChaCha20DrawBytesRun {
-    const COST_TYPE: ContractCostType = ContractCostType::ChaCha20DrawBytes;
+    const COST_TYPE: CostType = CostType::Contract(ChaCha20DrawBytes);
 
     type SampleType = (ChaCha20Rng, Vec<u8>);
 
@@ -30,7 +34,7 @@ impl CostRunner for ChaCha20DrawBytesRun {
         _iter: u64,
         sample: Self::SampleType,
     ) -> Self::RecycledType {
-        black_box(host.charge_budget(Self::COST_TYPE, Some(0)).unwrap());
+        black_box(host.charge_budget(ChaCha20DrawBytes, Some(0)).unwrap());
         black_box(sample)
     }
 }

--- a/soroban-env-host/src/cost_runner/cost_types/recover_ecdsa_secp256k1_key.rs
+++ b/soroban-env-host/src/cost_runner/cost_types/recover_ecdsa_secp256k1_key.rs
@@ -1,8 +1,8 @@
 use std::hint::black_box;
 
 use crate::{
-    cost_runner::CostRunner,
-    xdr::{ContractCostType, Hash},
+    cost_runner::{CostRunner, CostType},
+    xdr::{ContractCostType::RecoverEcdsaSecp256k1Key, Hash},
 };
 use k256::ecdsa::{RecoveryId, Signature};
 
@@ -16,7 +16,7 @@ pub struct RecoverEcdsaSecp256k1KeySample {
 }
 
 impl CostRunner for RecoverEcdsaSecp256k1KeyRun {
-    const COST_TYPE: ContractCostType = ContractCostType::RecoverEcdsaSecp256k1Key;
+    const COST_TYPE: CostType = CostType::Contract(RecoverEcdsaSecp256k1Key);
 
     type SampleType = RecoverEcdsaSecp256k1KeySample;
 
@@ -35,7 +35,7 @@ impl CostRunner for RecoverEcdsaSecp256k1KeyRun {
         _iter: u64,
         sample: Self::SampleType,
     ) -> Self::RecycledType {
-        black_box(host.charge_budget(Self::COST_TYPE, None).unwrap());
+        black_box(host.charge_budget(RecoverEcdsaSecp256k1Key, None).unwrap());
         black_box(sample)
     }
 }

--- a/soroban-env-host/src/cost_runner/cost_types/val_deser.rs
+++ b/soroban-env-host/src/cost_runner/cost_types/val_deser.rs
@@ -1,11 +1,15 @@
 use std::hint::black_box;
 
-use crate::{cost_runner::CostRunner, xdr::ContractCostType, xdr::ScVal};
+use crate::{
+    cost_runner::{CostRunner, CostType},
+    xdr::ContractCostType::ValDeser,
+    xdr::ScVal,
+};
 
 pub struct ValDeserRun;
 
 impl CostRunner for ValDeserRun {
-    const COST_TYPE: ContractCostType = ContractCostType::ValDeser;
+    const COST_TYPE: CostType = CostType::Contract(ValDeser);
 
     type SampleType = Vec<u8>;
 
@@ -21,7 +25,7 @@ impl CostRunner for ValDeserRun {
         _iter: u64,
         sample: Self::SampleType,
     ) -> Self::RecycledType {
-        black_box(host.charge_budget(Self::COST_TYPE, Some(0)).unwrap());
+        black_box(host.charge_budget(ValDeser, Some(0)).unwrap());
         black_box((None, sample))
     }
 }

--- a/soroban-env-host/src/cost_runner/cost_types/val_ser.rs
+++ b/soroban-env-host/src/cost_runner/cost_types/val_ser.rs
@@ -1,14 +1,16 @@
 use std::hint::black_box;
 
 use crate::{
-    cost_runner::CostRunner, host::metered_xdr::metered_write_xdr, xdr::ContractCostType,
+    cost_runner::{CostRunner, CostType},
+    host::metered_xdr::metered_write_xdr,
+    xdr::ContractCostType::ValSer,
     xdr::ScVal,
 };
 
 pub struct ValSerRun;
 
 impl CostRunner for ValSerRun {
-    const COST_TYPE: ContractCostType = ContractCostType::ValSer;
+    const COST_TYPE: CostType = CostType::Contract(ValSer);
 
     // In ValSerMeasure, we are already duplicating the byte array 10 times at each level,
     // and every level (100 of them) contains a duplication of the same bytes with the same input.
@@ -36,7 +38,7 @@ impl CostRunner for ValSerRun {
         _iter: u64,
         sample: Self::SampleType,
     ) -> Self::RecycledType {
-        black_box(host.charge_budget(Self::COST_TYPE, Some(0)).unwrap());
+        black_box(host.charge_budget(ValSer, Some(0)).unwrap());
         black_box(sample)
     }
 }

--- a/soroban-env-host/src/cost_runner/cost_types/verify_ed25519_sig.rs
+++ b/soroban-env-host/src/cost_runner/cost_types/verify_ed25519_sig.rs
@@ -1,6 +1,9 @@
 use std::hint::black_box;
 
-use crate::{cost_runner::CostRunner, xdr::ContractCostType};
+use crate::{
+    cost_runner::{CostRunner, CostType},
+    xdr::ContractCostType::VerifyEd25519Sig,
+};
 use ed25519_dalek::{Signature, VerifyingKey};
 
 pub struct VerifyEd25519SigRun;
@@ -13,7 +16,7 @@ pub struct VerifyEd25519SigSample {
 }
 
 impl CostRunner for VerifyEd25519SigRun {
-    const COST_TYPE: ContractCostType = ContractCostType::VerifyEd25519Sig;
+    const COST_TYPE: CostType = CostType::Contract(VerifyEd25519Sig);
 
     type SampleType = VerifyEd25519SigSample;
 
@@ -32,7 +35,7 @@ impl CostRunner for VerifyEd25519SigRun {
         _iter: u64,
         sample: Self::SampleType,
     ) -> Self::RecycledType {
-        black_box(host.charge_budget(Self::COST_TYPE, Some(0)).unwrap());
+        black_box(host.charge_budget(VerifyEd25519Sig, Some(0)).unwrap());
         black_box(sample)
     }
 }

--- a/soroban-env-host/src/cost_runner/cost_types/visit_object.rs
+++ b/soroban-env-host/src/cost_runner/cost_types/visit_object.rs
@@ -1,11 +1,16 @@
 use std::hint::black_box;
 
-use crate::{cost_runner::CostRunner, host_object::HostObject, xdr::ContractCostType, Object};
+use crate::{
+    cost_runner::{CostRunner, CostType},
+    host_object::HostObject,
+    xdr::ContractCostType::VisitObject,
+    Object,
+};
 
 pub struct VisitObjectRun;
 
 impl CostRunner for VisitObjectRun {
-    const COST_TYPE: ContractCostType = ContractCostType::VisitObject;
+    const COST_TYPE: CostType = CostType::Contract(VisitObject);
 
     const RUN_ITERATIONS: u64 = 1000;
 
@@ -29,7 +34,7 @@ impl CostRunner for VisitObjectRun {
         _iter: u64,
         sample: Self::SampleType,
     ) -> Self::RecycledType {
-        black_box(host.charge_budget(Self::COST_TYPE, None).unwrap());
+        black_box(host.charge_budget(VisitObject, None).unwrap());
         black_box(sample)
     }
 }

--- a/soroban-env-host/src/cost_runner/cost_types/vm_ops.rs
+++ b/soroban-env-host/src/cost_runner/cost_types/vm_ops.rs
@@ -1,4 +1,9 @@
-use crate::{cost_runner::CostRunner, xdr::ContractCostType, xdr::Hash, Vm};
+use crate::{
+    cost_runner::{CostRunner, CostType},
+    xdr::ContractCostType::VmInstantiation,
+    xdr::Hash,
+    Vm,
+};
 use std::{hint::black_box, rc::Rc};
 
 pub struct VmInstantiationRun;
@@ -10,7 +15,7 @@ pub struct VmInstantiationSample {
 }
 
 impl CostRunner for VmInstantiationRun {
-    const COST_TYPE: ContractCostType = ContractCostType::VmInstantiation;
+    const COST_TYPE: CostType = CostType::Contract(VmInstantiation);
 
     const RUN_ITERATIONS: u64 = 10;
 
@@ -28,7 +33,7 @@ impl CostRunner for VmInstantiationRun {
         _iter: u64,
         sample: Self::SampleType,
     ) -> Self::RecycledType {
-        black_box(host.charge_budget(Self::COST_TYPE, Some(0)).unwrap());
+        black_box(host.charge_budget(VmInstantiation, Some(0)).unwrap());
         black_box((None, sample.wasm))
     }
 }

--- a/soroban-env-host/src/cost_runner/cost_types/wasm_insn_exec.rs
+++ b/soroban-env-host/src/cost_runner/cost_types/wasm_insn_exec.rs
@@ -1,5 +1,9 @@
-use crate::{cost_runner::CostRunner, xdr::ContractCostType, xdr::ScVec, Symbol, Val, Vm};
-use std::{hint::black_box, rc::Rc};
+use crate::{
+    cost_runner::{CostRunner, CostType},
+    xdr::{Name, ScVec},
+    Symbol, Val, Vm,
+};
+use std::{fmt, hint::black_box, rc::Rc};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// This is a subset of WASM instructions we are interested in for calibration.
@@ -118,6 +122,69 @@ impl WasmInsnType {
     }
 }
 
+impl Name for WasmInsnType {
+    fn name(&self) -> &'static str {
+        match self {
+            WasmInsnType::LocalGet => "LocalGet",
+            WasmInsnType::LocalSet => "LocalSet",
+            WasmInsnType::LocalTee => "LocalTee",
+            WasmInsnType::Br => "Br",
+            WasmInsnType::BrIfEqz => "BrIfEqz",
+            WasmInsnType::BrIfNez => "BrIfNez",
+            WasmInsnType::ReturnIfNez => "ReturnIfNez",
+            WasmInsnType::BrTable => "BrTable",
+            WasmInsnType::Unreachable => "Unreachable",
+            WasmInsnType::Return => "Return",
+            WasmInsnType::CallLocal => "CallLocal",
+            WasmInsnType::CallImport => "CallImport",
+            WasmInsnType::CallIndirect => "CallIndirect",
+            WasmInsnType::Drop => "Drop",
+            WasmInsnType::Select => "Select",
+            WasmInsnType::GlobalGet => "GlobalGet",
+            WasmInsnType::GlobalSet => "GlobalSet",
+            WasmInsnType::I64Load => "I64Load",
+            WasmInsnType::I64Load8S => "I64Load8S",
+            WasmInsnType::I64Load16S => "I64Load16S",
+            WasmInsnType::I64Load32S => "I64Load32S",
+            WasmInsnType::I64Store => "I64Store",
+            WasmInsnType::I64Store8 => "I64Store8",
+            WasmInsnType::I64Store16 => "I64Store16",
+            WasmInsnType::I64Store32 => "I64Store32",
+            WasmInsnType::MemorySize => "MemorySize",
+            WasmInsnType::MemoryGrow => "MemoryGrow",
+            WasmInsnType::Const => "Const",
+            WasmInsnType::I64Eqz => "I64Eqz",
+            WasmInsnType::I64Eq => "I64Eq",
+            WasmInsnType::I64Ne => "I64Ne",
+            WasmInsnType::I64LtS => "I64LtS",
+            WasmInsnType::I64GtS => "I64GtS",
+            WasmInsnType::I64LeS => "I64LeS",
+            WasmInsnType::I64GeS => "I64GeS",
+            WasmInsnType::I64Clz => "I64Clz",
+            WasmInsnType::I64Ctz => "I64Ctz",
+            WasmInsnType::I64Popcnt => "I64Popcnt",
+            WasmInsnType::I64Add => "I64Add",
+            WasmInsnType::I64Sub => "I64Sub",
+            WasmInsnType::I64Mul => "I64Mul",
+            WasmInsnType::I64DivS => "I64DivS",
+            WasmInsnType::I64RemS => "I64RemS",
+            WasmInsnType::I64And => "I64And",
+            WasmInsnType::I64Or => "I64Or",
+            WasmInsnType::I64Xor => "I64Xor",
+            WasmInsnType::I64Shl => "I64Shl",
+            WasmInsnType::I64ShrS => "I64ShrS",
+            WasmInsnType::I64Rotl => "I64Rotl",
+            WasmInsnType::I64Rotr => "I64Rotr",
+        }
+    }
+}
+
+impl fmt::Display for WasmInsnType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.name())
+    }
+}
+
 #[derive(Clone)]
 pub struct WasmInsnSample {
     pub vm: Rc<Vm>,
@@ -140,12 +207,8 @@ macro_rules! impl_wasm_insn_runner {
     ($runner:ident, $insn:ident) => {
         pub struct $runner;
 
-        impl $runner {
-            pub const INSN_TYPE: WasmInsnType = WasmInsnType::$insn;
-        }
-
         impl CostRunner for $runner {
-            const COST_TYPE: ContractCostType = ContractCostType::WasmInsnExec;
+            const COST_TYPE: CostType = CostType::Wasm(WasmInsnType::$insn);
             type SampleType = WasmInsnSample;
             type RecycledType = (Option<Val>, Self::SampleType);
 

--- a/soroban-env-host/src/cost_runner/experimental/ed25519_scalar_mut.rs
+++ b/soroban-env-host/src/cost_runner/experimental/ed25519_scalar_mut.rs
@@ -1,0 +1,46 @@
+use std::hint::black_box;
+
+use crate::cost_runner::{CostRunner, CostType};
+use curve25519_dalek::{edwards, scalar};
+
+use super::ExperimentalCostType;
+
+pub struct Ed25519ScalarMulRun;
+
+#[allow(non_snake_case)]
+#[derive(Clone)]
+pub struct Ed25519ScalarMulSample {
+    pub a: scalar::Scalar,
+    pub A: edwards::EdwardsPoint,
+    pub b: scalar::Scalar,
+}
+
+impl CostRunner for Ed25519ScalarMulRun {
+    const COST_TYPE: CostType =
+        CostType::Experimental(ExperimentalCostType::EdwardsPointCurve25519ScalarMul);
+
+    const RUN_ITERATIONS: u64 = 100;
+
+    type SampleType = Ed25519ScalarMulSample;
+
+    type RecycledType = Self::SampleType;
+
+    fn run_iter(_host: &crate::Host, _iter: u64, sample: Self::SampleType) -> Self::RecycledType {
+        black_box(edwards::EdwardsPoint::vartime_double_scalar_mul_basepoint(
+            &sample.a, &sample.A, &sample.b,
+        ));
+        black_box(sample)
+    }
+
+    fn get_tracker(_host: &crate::Host) -> (u64, Option<u64>) {
+        (Self::RUN_ITERATIONS, None)
+    }
+
+    fn run_baseline_iter(
+        _host: &crate::Host,
+        _iter: u64,
+        sample: Self::SampleType,
+    ) -> Self::RecycledType {
+        black_box(sample)
+    }
+}

--- a/soroban-env-host/src/cost_runner/experimental/mod.rs
+++ b/soroban-env-host/src/cost_runner/experimental/mod.rs
@@ -1,0 +1,27 @@
+mod ed25519_scalar_mut;
+
+pub use ed25519_scalar_mut::*;
+
+use crate::xdr::Name;
+use core::fmt;
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ExperimentalCostType {
+    EdwardsPointCurve25519ScalarMul,
+}
+
+impl Name for ExperimentalCostType {
+    fn name(&self) -> &'static str {
+        match self {
+            ExperimentalCostType::EdwardsPointCurve25519ScalarMul => {
+                "EdwardsPointCurve25519ScalarMul"
+            }
+        }
+    }
+}
+
+impl fmt::Display for ExperimentalCostType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.name())
+    }
+}

--- a/soroban-env-host/src/cost_runner/mod.rs
+++ b/soroban-env-host/src/cost_runner/mod.rs
@@ -1,6 +1,34 @@
 #![allow(clippy::unit_arg)]
 mod cost_types;
+mod experimental;
 mod runner;
 
 pub use cost_types::*;
+pub use experimental::*;
 pub use runner::CostRunner;
+
+use crate::xdr::Name;
+use core::fmt;
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum CostType {
+    Contract(crate::xdr::ContractCostType),
+    Experimental(experimental::ExperimentalCostType),
+    Wasm(WasmInsnType),
+}
+
+impl Name for CostType {
+    fn name(&self) -> &'static str {
+        match self {
+            CostType::Contract(ct) => ct.name(),
+            CostType::Experimental(et) => et.name(),
+            CostType::Wasm(wt) => wt.name(),
+        }
+    }
+}
+
+impl fmt::Display for CostType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.name())
+    }
+}


### PR DESCRIPTION
### What

Setup bench framework to run experiments 
- Experimental bench code is located in `experimental` (`benches/common` and `src/cost_runner` dirs)
- Aggregate `ContractCostType`, `WasmInsnType` and a new  **`ExperimentalCostType`** into top level `CostType`

Resolves #1030 
- Bring back `EdwardsPointCurve25519ScalarMul` as a experimental cost type and run variation histogram on it. 

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
