### PR TITLE
storage code review

### DIFF
--- a/soroban-env-host/src/storage.rs
+++ b/soroban-env-host/src/storage.rs
@@ -329,7 +329,7 @@ impl Storage {
     ///
     /// This operation does not modify any ledger entries, but does change the
     /// internal storage
-    pub fn extend(
+    pub(crate) fn extend(
         &mut self,
         host: &Host,
         key: Rc<LedgerKey>,


### PR DESCRIPTION
This is the one change I'm fairly confident ought to happen in storage: factoring the `get` paths into a common funnel. Besides being duplicate code, if you look carefully the previous arrangement had inconsistent handling of `None` returns from the underlying map too: one path (correctly) treated it as an internal error since `prepare_read_only_access` shouldn't allow getting there; the other two paths either returned it as-is or merged it into the `MissingValue` path.

I'm not changing two other error codes just yet, though I was a bit tempted to. Would be interested to hear input from @dmkozh : as mentioned in conversation elsewhere, I _think_ the footprint checking paths should probably return `InvalidAction` as errors rather than `ExceededLimit`; and possibly the path in `extend` that returns an `InternalError` live-until value should be `InvalidAction` too. But I can imagine the counterarguments to these, and if you feel strongly that they're correct already I'm ok leaving them as-is.