### PR TITLE
Decorate error for nonce missing from the footprint.

### DIFF
--- a/soroban-env-host/src/host_object.rs
+++ b/soroban-env-host/src/host_object.rs
@@ -379,7 +379,7 @@ impl Host {
             Err(self.err(
                 ScErrorType::Object,
                 ScErrorCode::MissingValue,
-                "unknown object reference",
+                "unknown object reference, is it coming from a different environment?",
                 &[payload_val],
             ))
         }


### PR DESCRIPTION
### What

Decorate error for nonce missing from the footprint.

### Why

Improving error diagnostics

### Known limitations

N/A
