### PR TITLE
conversion.rs code review fixes

### DIFF
--- a/soroban-env-common/src/convert.rs
+++ b/soroban-env-common/src/convert.rs
@@ -474,6 +474,10 @@ where
 {
     type Error = ConversionError;
     fn try_from_val(env: &E, val: &ScVal) -> Result<Val, Self::Error> {
+        if !Val::can_represent_scval(val) {
+            return Err(ConversionError);
+        }
+
         if let Some(scvo) = ScValObjRef::classify(val) {
             let obj = Object::try_from_val(env, &scvo)?;
             return Ok(obj.into());
@@ -529,7 +533,8 @@ where
             }
 
             // These should all have been classified as ScValObjRef above, or are
-            // reserved ScVal types that are never passed as vals at all.
+            // reserved ScVal types Val::can_represent_scval would have returned
+            // false from above.
             ScVal::Bytes(_)
             | ScVal::String(_)
             | ScVal::Vec(_)

--- a/soroban-env-common/src/error.rs
+++ b/soroban-env-common/src/error.rs
@@ -1,6 +1,6 @@
 use crate::xdr::{ScError, ScErrorCode, ScErrorType, ScVal};
 use crate::{
-    impl_wrapper_as_and_to_rawval, impl_wrapper_tag_based_constructors,
+    impl_wrapper_as_and_to_val, impl_wrapper_tag_based_constructors,
     impl_wrapper_tag_based_valconvert, impl_wrapper_wasmi_conversions, Compare, ConversionError,
     Env, SymbolError, Val,
 };
@@ -22,7 +22,7 @@ pub struct Error(Val);
 
 impl_wrapper_tag_based_valconvert!(Error);
 impl_wrapper_tag_based_constructors!(Error);
-impl_wrapper_as_and_to_rawval!(Error);
+impl_wrapper_as_and_to_val!(Error);
 impl_wrapper_wasmi_conversions!(Error);
 
 impl Hash for Error {

--- a/soroban-env-common/src/object.rs
+++ b/soroban-env-common/src/object.rs
@@ -1,6 +1,6 @@
 use crate::xdr::{Duration, ScVal, TimePoint};
 use crate::{
-    impl_rawval_wrapper_base, num, val::ValConvert, Compare, ConversionError, Convert, Env, Tag,
+    impl_val_wrapper_base, num, val::ValConvert, Compare, ConversionError, Convert, Env, Tag,
     TryFromVal, Val,
 };
 use core::{cmp::Ordering, fmt::Debug};
@@ -11,7 +11,7 @@ use core::{cmp::Ordering, fmt::Debug};
 #[repr(transparent)]
 #[derive(Copy, Clone)]
 pub struct Object(pub(crate) Val);
-impl_rawval_wrapper_base!(Object);
+impl_val_wrapper_base!(Object);
 
 impl ValConvert for Object {
     fn is_val_type(v: Val) -> bool {

--- a/soroban-env-common/src/val.rs
+++ b/soroban-env-common/src/val.rs
@@ -3,9 +3,9 @@
 
 use crate::xdr::{ScError, ScValType};
 use crate::{
-    declare_tag_based_object_wrapper, declare_tag_based_wrapper, impl_rawval_wrapper_base,
-    impl_tryfroms_and_tryfromvals_delegating_to_valconvert, Compare, I32Val, SymbolSmall,
-    SymbolStr, U32Val,
+    declare_tag_based_object_wrapper, declare_tag_based_wrapper,
+    impl_tryfroms_and_tryfromvals_delegating_to_valconvert, impl_val_wrapper_base, Compare, I32Val,
+    SymbolSmall, SymbolStr, U32Val,
 };
 
 use super::{Env, Error, TryFromVal};
@@ -158,12 +158,12 @@ pub enum Tag {
 
 impl Tag {
     #[inline(always)]
-    pub const fn rawval_mask() -> i64 {
+    pub const fn val_mask() -> i64 {
         TAG_MASK as i64
     }
 
     #[inline(always)]
-    pub fn rawval_const(&self) -> i64 {
+    pub fn val_const(&self) -> i64 {
         *self as i64
     }
 
@@ -294,7 +294,7 @@ impl<E: Env> Compare<Void> for E {
 #[repr(transparent)]
 #[derive(Copy, Clone)]
 pub struct Bool(Val);
-impl_rawval_wrapper_base!(Bool);
+impl_val_wrapper_base!(Bool);
 
 impl From<bool> for Bool {
     fn from(value: bool) -> Self {

--- a/soroban-env-common/src/val.rs
+++ b/soroban-env-common/src/val.rs
@@ -574,6 +574,40 @@ impl From<&ScError> for Val {
 // Utility methods
 
 impl Val {
+    /// Some ScVals are not representable as Vals at all,
+    /// and only exist in the XDR to serve as special storage
+    /// system key or value payloads managed by the Host.
+    pub const fn can_represent_scval_type(scv_ty: ScValType) -> bool {
+        match scv_ty {
+            ScValType::Bool
+            | ScValType::Void
+            | ScValType::Error
+            | ScValType::U32
+            | ScValType::I32
+            | ScValType::U64
+            | ScValType::I64
+            | ScValType::Timepoint
+            | ScValType::Duration
+            | ScValType::U128
+            | ScValType::I128
+            | ScValType::U256
+            | ScValType::I256
+            | ScValType::Bytes
+            | ScValType::String
+            | ScValType::Symbol
+            | ScValType::Vec
+            | ScValType::Map
+            | ScValType::Address => true,
+            ScValType::ContractInstance
+            | ScValType::LedgerKeyContractInstance
+            | ScValType::LedgerKeyNonce => false,
+        }
+    }
+
+    pub const fn can_represent_scval(scv: &crate::xdr::ScVal) -> bool {
+        Self::can_represent_scval_type(scv.discriminant())
+    }
+
     #[inline(always)]
     pub const fn get_payload(self) -> u64 {
         self.0

--- a/soroban-env-common/src/wrapper_macros.rs
+++ b/soroban-env-common/src/wrapper_macros.rs
@@ -105,7 +105,7 @@ macro_rules! impl_wrapper_wasmi_conversions {
 
 #[doc(hidden)]
 #[macro_export]
-macro_rules! impl_wrapper_as_and_to_rawval {
+macro_rules! impl_wrapper_as_and_to_val {
     ($wrapper:ty) => {
         // AsRef / AsMut to Val.
         impl AsRef<$crate::Val> for $wrapper {
@@ -168,14 +168,14 @@ macro_rules! impl_wrapper_from_other_type {
 /// Macro for base implementation of a type wrapping a [`Val`]
 #[doc(hidden)]
 #[macro_export]
-macro_rules! impl_rawval_wrapper_base {
+macro_rules! impl_val_wrapper_base {
     ($T:ident) => {
         impl core::fmt::Debug for $T {
             fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 self.0.fmt(f)
             }
         }
-        $crate::impl_wrapper_as_and_to_rawval!($T);
+        $crate::impl_wrapper_as_and_to_val!($T);
         $crate::impl_wrapper_wasmi_conversions!($T);
         $crate::impl_tryfroms_and_tryfromvals_delegating_to_valconvert!($T);
     };
@@ -215,7 +215,7 @@ macro_rules! declare_tag_based_wrapper {
         #[derive(Copy, Clone)]
         pub struct $T($crate::Val);
 
-        $crate::impl_rawval_wrapper_base!($T);
+        $crate::impl_val_wrapper_base!($T);
         $crate::impl_wrapper_tag_based_valconvert!($T);
         $crate::impl_wrapper_tag_based_constructors!($T);
     };
@@ -272,7 +272,7 @@ macro_rules! declare_tag_based_small_and_object_wrappers {
         #[repr(transparent)]
         #[derive(Copy, Clone)]
         pub struct $GENERAL($crate::Val);
-        $crate::impl_rawval_wrapper_base!($GENERAL);
+        $crate::impl_val_wrapper_base!($GENERAL);
 
         impl $crate::val::ValConvert for $GENERAL {
             fn is_val_type(v: $crate::Val) -> bool {

--- a/soroban-env-host/benches/common/experimental/map_ops.rs
+++ b/soroban-env-host/benches/common/experimental/map_ops.rs
@@ -14,7 +14,7 @@ impl HostCostMeasurement for MapEntryMeasure {
 
     fn new_random_case(host: &Host, rng: &mut StdRng, input: u64) -> MapEntrySample {
         let input = 1 + input * Self::STEP_SIZE;
-        let mut keys: Vec<_> = util::to_rawval_u32(0..(input as u32)).collect();
+        let mut keys: Vec<_> = util::u32_iter_to_val_iter(0..(input as u32)).collect();
         let om = keys.iter().cloned().zip(keys.iter().cloned()).collect();
         let map: MeteredOrdMap<_, _, _> = MeteredOrdMap::from_map(om, host).unwrap();
         keys.shuffle(rng);

--- a/soroban-env-host/benches/common/experimental/vec_ops.rs
+++ b/soroban-env-host/benches/common/experimental/vec_ops.rs
@@ -15,7 +15,7 @@ impl HostCostMeasurement for VecEntryMeasure {
     // Random case is worst case.
     fn new_random_case(_host: &Host, rng: &mut StdRng, input: u64) -> VecEntrySample {
         let input = 1 + input * Self::STEP_SIZE;
-        let ov = util::to_rawval_u32(0..(input as u32)).collect();
+        let ov = util::u32_iter_to_val_iter(0..(input as u32)).collect();
         let vec: MeteredVector<_> = MeteredVector::from_vec(ov).unwrap();
         let mut idxs: Vec<usize> = (0..input as usize).collect();
         idxs.shuffle(rng);

--- a/soroban-env-host/benches/common/util.rs
+++ b/soroban-env-host/benches/common/util.rs
@@ -25,7 +25,7 @@ pub(crate) const TEST_WASMS: [&'static [u8]; 10] = [
     soroban_test_wasms::COMPLEX,
 ];
 
-pub(crate) fn to_rawval_u32<I: Iterator<Item = u32>>(vals: I) -> impl Iterator<Item = Val> {
+pub(crate) fn u32_iter_to_val_iter<I: Iterator<Item = u32>>(vals: I) -> impl Iterator<Item = Val> {
     vals.map(move |v| Val::from_u32(v).into())
 }
 

--- a/soroban-env-host/src/auth.rs
+++ b/soroban-env-host/src/auth.rs
@@ -364,7 +364,7 @@ impl AuthorizedFunction {
                 AuthorizedFunction::ContractFn(ContractFunction {
                     contract_address: host.add_host_object(xdr_contract_fn.contract_address)?,
                     function_name: Symbol::try_from_val(host, &xdr_contract_fn.function_name)?,
-                    args: host.scvals_to_rawvals(xdr_contract_fn.args.as_slice())?,
+                    args: host.scvals_to_val_vec(xdr_contract_fn.args.as_slice())?,
                 })
             }
             SorobanAuthorizedFunction::CreateContractHostFn(xdr_args) => {
@@ -391,7 +391,7 @@ impl AuthorizedFunction {
                 Ok(SorobanAuthorizedFunction::ContractFn(InvokeContractArgs {
                     contract_address: host.scaddress_from_address(contract_fn.contract_address)?,
                     function_name,
-                    args: host.rawvals_to_sc_val_vec(contract_fn.args.as_slice())?,
+                    args: host.vals_to_scval_vec(contract_fn.args.as_slice())?,
                 }))
             }
             AuthorizedFunction::CreateContractHostFn(create_contract_args) => {
@@ -413,7 +413,7 @@ impl AuthorizedFunction {
                         })?,
                     function_name: contract_fn.function_name.try_into_val(host)?,
                     // why is this intentionally non-metered? the visit_obj above is metered.
-                    args: host.rawvals_to_sc_val_vec_non_metered(contract_fn.args.as_slice())?,
+                    args: host.vals_to_scval_vec_non_metered(contract_fn.args.as_slice())?,
                 }))
             }
             AuthorizedFunction::CreateContractHostFn(create_contract_args) => Ok(

--- a/soroban-env-host/src/events/internal.rs
+++ b/soroban-env-host/src/events/internal.rs
@@ -25,7 +25,7 @@ pub struct InternalContractEvent {
 impl InternalContractEvent {
     // Metering: covered by components
     pub fn to_xdr(&self, host: &Host) -> Result<xdr::ContractEvent, HostError> {
-        let topics = host.call_args_to_sc_val_vec(self.topics)?;
+        let topics = host.vecobject_to_scval_vec(self.topics)?;
         let data = host.from_host_val(self.data)?;
         let contract_id = match self.contract_id {
             Some(id) => Some(host.hash_from_bytesobj_input("contract_id", id)?),

--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -1619,7 +1619,7 @@ impl VmCallerEnv for Host {
         self.check_val_integrity(k)?;
         let res = match t {
             StorageType::Temporary | StorageType::Persistent => {
-                let key = self.storage_key_from_rawval(k, t.try_into()?)?;
+                let key = self.storage_key_from_val(k, t.try_into()?)?;
                 self.try_borrow_storage_mut()?
                     .has(&key, self.as_budget())
                     .map_err(|e| self.decorate_contract_data_storage_error(e, k))?
@@ -1642,7 +1642,7 @@ impl VmCallerEnv for Host {
         self.check_val_integrity(k)?;
         match t {
             StorageType::Temporary | StorageType::Persistent => {
-                let key = self.storage_key_from_rawval(k, t.try_into()?)?;
+                let key = self.storage_key_from_val(k, t.try_into()?)?;
                 let entry = self
                     .try_borrow_storage_mut()?
                     .get(&key, self.as_budget())
@@ -1683,7 +1683,7 @@ impl VmCallerEnv for Host {
         self.check_val_integrity(k)?;
         match t {
             StorageType::Temporary | StorageType::Persistent => {
-                let key = self.contract_data_key_from_rawval(k, t.try_into()?)?;
+                let key = self.contract_data_key_from_val(k, t.try_into()?)?;
                 self.try_borrow_storage_mut()?
                     .del(&key, self.as_budget())
                     .map_err(|e| self.decorate_contract_data_storage_error(e, k))?;
@@ -1719,7 +1719,7 @@ impl VmCallerEnv for Host {
                 &[],
             ))?;
         }
-        let key = self.contract_data_key_from_rawval(k, t.try_into()?)?;
+        let key = self.contract_data_key_from_val(k, t.try_into()?)?;
         self.try_borrow_storage_mut()?
             .extend(self, key, threshold.into(), extend_to.into())
             .map_err(|e| self.decorate_contract_data_storage_error(e, k))?;

--- a/soroban-env-host/src/host/comparison.rs
+++ b/soroban-env-host/src/host/comparison.rs
@@ -589,24 +589,24 @@ mod tests {
     #[test]
     fn compare_obj_to_small() {
         let host = Host::default();
-        let rawvals: Vec<Val> = all_tags()
+        let vals: Vec<Val> = all_tags()
             .into_iter()
             .map(|t| example_for_tag(&host, t))
             .collect();
-        let scvals: Vec<ScVal> = rawvals
+        let scvals: Vec<ScVal> = vals
             .iter()
             .map(|r| ScVal::try_from_val(&host, r).expect("scval"))
             .collect();
 
-        let rawval_pairs = rawvals.iter().cartesian_product(&rawvals);
+        let val_pairs = vals.iter().cartesian_product(&vals);
         let scval_pairs = scvals.iter().cartesian_product(&scvals);
 
-        let pair_pairs = rawval_pairs.zip(scval_pairs);
+        let pair_pairs = val_pairs.zip(scval_pairs);
 
-        for ((rawval1, rawval2), (scval1, scval2)) in pair_pairs {
-            let rawval_cmp = host.compare(rawval1, rawval2).expect("compare");
+        for ((val1, val2), (scval1, scval2)) in pair_pairs {
+            let val_cmp = host.compare(val1, val2).expect("compare");
             let scval_cmp = scval1.cmp(scval2);
-            assert_eq!(rawval_cmp, scval_cmp);
+            assert_eq!(val_cmp, scval_cmp);
         }
     }
 

--- a/soroban-env-host/src/host/comparison.rs
+++ b/soroban-env-host/src/host/comparison.rs
@@ -246,7 +246,7 @@ impl Compare<ScVal> for Budget {
             (Map(Some(a)), Map(Some(b))) => self.compare(a, b),
 
             (Vec(None), _) | (_, Vec(None)) | (Map(None), _) | (_, Map(None)) => {
-                Err((ScErrorType::Object, ScErrorCode::MissingValue).into())
+                Err((ScErrorType::Value, ScErrorCode::InvalidInput).into())
             }
 
             (Bytes(a), Bytes(b)) => {

--- a/soroban-env-host/src/host/conversion.rs
+++ b/soroban-env-host/src/host/conversion.rs
@@ -69,6 +69,7 @@ impl Host {
         name: &'static str,
         hash: BytesObject,
     ) -> Result<Hash, HostError> {
+        static_assertions::assert_eq_size!([u8; 32], Hash);
         self.fixed_length_bytes_from_bytesobj_input::<Hash, 32>(name, hash)
     }
 
@@ -77,6 +78,7 @@ impl Host {
         name: &'static str,
         u256: BytesObject,
     ) -> Result<Uint256, HostError> {
+        static_assertions::assert_eq_size!([u8; 32], Uint256);
         self.fixed_length_bytes_from_bytesobj_input::<Uint256, 32>(name, u256)
     }
 

--- a/soroban-env-host/src/host/conversion.rs
+++ b/soroban-env-host/src/host/conversion.rs
@@ -57,7 +57,7 @@ impl Host {
             Ok(v) => Ok(v),
             Err(_) => Err(self.err(
                 ScErrorType::Value,
-                ScErrorCode::InvalidInput,
+                ScErrorCode::ArithDomain,
                 "expecting U32Val less than 256",
                 &[r.to_val(), name.try_into_val(self)?],
             )),

--- a/soroban-env-host/src/host/conversion.rs
+++ b/soroban-env-host/src/host/conversion.rs
@@ -203,18 +203,12 @@ impl Host {
     }
 
     // Metering: covered by rawvals_to_vec
-    pub(crate) fn call_args_to_sc_val_vec(
-        &self,
-        args: VecObject,
-    ) -> Result<VecM<ScVal>, HostError> {
-        self.visit_obj(args, |hv: &HostVec| {
-            self.rawvals_to_sc_val_vec(hv.as_slice())
-        })
+    pub(crate) fn vecobject_to_scval_vec(&self, args: VecObject) -> Result<VecM<ScVal>, HostError> {
+        self.visit_obj(args, |hv: &HostVec| self.vals_to_scval_vec(hv.as_slice()))
     }
 
-    pub(crate) fn rawvals_to_sc_val_vec(&self, raw_vals: &[Val]) -> Result<VecM<ScVal>, HostError> {
-        raw_vals
-            .iter()
+    pub(crate) fn vals_to_scval_vec(&self, vals: &[Val]) -> Result<VecM<ScVal>, HostError> {
+        vals.iter()
             .map(|v| self.from_host_val(*v))
             .metered_collect::<Result<Vec<ScVal>, HostError>>(self)??
             .try_into()
@@ -223,17 +217,16 @@ impl Host {
                     self,
                     (ScErrorType::Object, ScErrorCode::ExceededLimit),
                     "vector size limit exceeded",
-                    raw_vals.len()
+                    vals.len()
                 )
             })
     }
 
-    pub(crate) fn rawvals_to_sc_val_vec_non_metered(
+    pub(crate) fn vals_to_scval_vec_non_metered(
         &self,
-        raw_vals: &[Val],
+        vals: &[Val],
     ) -> Result<VecM<ScVal>, HostError> {
-        raw_vals
-            .iter()
+        vals.iter()
             .map(|v| self.from_host_val(*v))
             .collect::<Result<Vec<ScVal>, HostError>>()?
             .try_into()
@@ -242,13 +235,13 @@ impl Host {
                     self,
                     (ScErrorType::Object, ScErrorCode::ExceededLimit),
                     "vector size limit exceeded",
-                    raw_vals.len()
+                    vals.len()
                 )
             })
     }
 
-    pub(crate) fn scvals_to_rawvals(&self, sc_vals: &[ScVal]) -> Result<Vec<Val>, HostError> {
-        sc_vals
+    pub(crate) fn scvals_to_val_vec(&self, scvals: &[ScVal]) -> Result<Vec<Val>, HostError> {
+        scvals
             .iter()
             .map(|scv| self.to_host_val(scv))
             .metered_collect::<Result<Vec<Val>, HostError>>(self)?

--- a/soroban-env-host/src/host/conversion.rs
+++ b/soroban-env-host/src/host/conversion.rs
@@ -177,11 +177,11 @@ impl Host {
     /// Converts a binary search result into a u64. `res` is `Some(index)` if
     /// the value was found at `index`, or `Err(index)` if the value was not
     /// found and would've needed to be inserted at `index`. Returns a
-    /// Some(res_u64) where :
-    /// - the high 32 bits is 0x0000_0001 if element existed or 0x0000_0000 if
+    /// Some(res_u64) where:
+    /// - The high 32 bits is 0x0000_0001 if element existed or 0x0000_0000 if
     ///   it didn't
-    /// - the low 32 bits contains the u32 representation of the `index` Err(_)
-    /// if the `index` fails to be converted to an u32.
+    /// - The low 32 bits contains the u32 representation of the `index` Err(_)
+    ///   if the `index` fails to be converted to an u32.
     pub(crate) fn u64_from_binary_search_result(
         &self,
         res: Result<usize, usize>,
@@ -445,7 +445,7 @@ impl Host {
                     HostObject::Bytes(b) => ScVal::Bytes(b.metered_clone(self)?),
                     HostObject::String(s) => ScVal::String(s.metered_clone(self)?),
                     HostObject::Symbol(s) => ScVal::Symbol(s.metered_clone(self)?),
-                    HostObject::Address(addr) => ScVal::Address(addr.metered_clone(self)?), // For any future `HostObject` types we add, make sure to add some metering.
+                    HostObject::Address(addr) => ScVal::Address(addr.metered_clone(self)?),
                 };
                 Ok(ScValObject::unchecked_from_val(val))
             })
@@ -458,7 +458,7 @@ impl Host {
         match val {
             // Here we have to make sure host object conversion is charged in each variant
             // below. There is no otherwise ubiquitous metering for ScVal->Val conversion,
-            // since most of them happens in the "common" crate with no access to the host.
+            // since most of them happen in the "common" crate with no access to the host.
             ScVal::Vec(Some(v)) => {
                 Vec::<Val>::charge_bulk_init_cpy(v.len() as u64, self)?;
                 let mut vv = Vec::with_capacity(v.len());
@@ -539,7 +539,7 @@ impl Host {
                 (ScErrorType::Object, ScErrorCode::InvalidInput),
                 "converting unsupported value to object",
                 *val
-            )), // For any future `HostObject` types we add, make sure to add some metering.
+            )),
         }
     }
 }

--- a/soroban-env-host/src/host/conversion.rs
+++ b/soroban-env-host/src/host/conversion.rs
@@ -462,15 +462,15 @@ impl Host {
                 Ok(self.add_host_object(HostMap::from_map(mm, self)?)?.into())
             }
             ScVal::Vec(None) => Err(self.err(
-                ScErrorType::Object,
-                ScErrorCode::MissingValue,
-                "vector body missing",
+                ScErrorType::Value,
+                ScErrorCode::InvalidInput,
+                "ScVal::Vec body missing",
                 &[],
             )),
             ScVal::Map(None) => Err(self.err(
-                ScErrorType::Object,
-                ScErrorCode::MissingValue,
-                "map body missing",
+                ScErrorType::Value,
+                ScErrorCode::InvalidInput,
+                "ScVal::Map body missing",
                 &[],
             )),
             ScVal::U64(u) => {

--- a/soroban-env-host/src/host/conversion.rs
+++ b/soroban-env-host/src/host/conversion.rs
@@ -511,6 +511,9 @@ impl Host {
             ScVal::String(s) => Ok(self.add_host_object(s.metered_clone(self)?)?.into()),
             ScVal::Symbol(s) => Ok(self.add_host_object(s.metered_clone(self)?)?.into()),
             ScVal::Address(addr) => Ok(self.add_host_object(addr.metered_clone(self)?)?.into()),
+
+            // None of the following cases should have made it into this function, they
+            // are excluded by the ScValObjRef::classify function.
             ScVal::Bool(_)
             | ScVal::Void
             | ScVal::Error(_)
@@ -520,8 +523,8 @@ impl Host {
             | ScVal::ContractInstance(_)
             | ScVal::LedgerKeyContractInstance => Err(err!(
                 self,
-                (ScErrorType::Object, ScErrorCode::InvalidInput),
-                "converting unsupported value to object",
+                (ScErrorType::Value, ScErrorCode::InternalError),
+                "converting ScValObjRef on non-object ScVal type",
                 *val
             )),
         }

--- a/soroban-env-host/src/host/conversion.rs
+++ b/soroban-env-host/src/host/conversion.rs
@@ -189,7 +189,7 @@ impl Host {
         match res {
             Ok(u) => {
                 let v = self.usize_to_u32(u)?;
-                Ok(u64::from(v) | (1 << u32::BITS))
+                Ok(u64::from(v) | (1_u64 << u32::BITS))
             }
             Err(u) => {
                 let v = self.usize_to_u32(u)?;

--- a/soroban-env-host/src/host/conversion.rs
+++ b/soroban-env-host/src/host/conversion.rs
@@ -140,13 +140,13 @@ impl Host {
 
     pub(crate) fn storage_key_for_address(
         &self,
-        contract_address: ScAddress,
+        contract: ScAddress,
         key: ScVal,
         durability: ContractDataDurability,
     ) -> Result<Rc<LedgerKey>, HostError> {
         Rc::metered_new(
             LedgerKey::ContractData(LedgerKeyContractData {
-                contract: contract_address,
+                contract,
                 key,
                 durability,
             }),

--- a/soroban-env-host/src/host/conversion.rs
+++ b/soroban-env-host/src/host/conversion.rs
@@ -234,7 +234,7 @@ impl Host {
     ) -> Result<VecM<ScVal>, HostError> {
         raw_vals
             .iter()
-            .map(|v| v.try_into_val(self)?)
+            .map(|v| self.from_host_val(*v))
             .collect::<Result<Vec<ScVal>, HostError>>()?
             .try_into()
             .map_err(|_| {

--- a/soroban-env-host/src/host/conversion.rs
+++ b/soroban-env-host/src/host/conversion.rs
@@ -130,7 +130,7 @@ impl Host {
     /// Converts a [`Val`] to an [`ScVal`] and combines it with the currently-executing
     /// [`ContractID`] to produce a [`Key`], that can be used to access ledger [`Storage`].
     // Notes on metering: covered by components.
-    pub fn storage_key_from_rawval(
+    pub fn storage_key_from_val(
         &self,
         k: Val,
         durability: ContractDataDurability,
@@ -164,7 +164,7 @@ impl Host {
     }
 
     // Notes on metering: covered by components.
-    pub(crate) fn contract_data_key_from_rawval(
+    pub(crate) fn contract_data_key_from_val(
         &self,
         k: Val,
         durability: ContractDataDurability,
@@ -202,7 +202,7 @@ impl Host {
         self.visit_obj(args, |hv: &HostVec| hv.to_vec(self.as_budget()))
     }
 
-    // Metering: covered by rawvals_to_vec
+    // Metering: covered by vals_to_vec
     pub(crate) fn vecobject_to_scval_vec(&self, args: VecObject) -> Result<VecM<ScVal>, HostError> {
         self.visit_obj(args, |hv: &HostVec| self.vals_to_scval_vec(hv.as_slice()))
     }

--- a/soroban-env-host/src/host/data_helper.rs
+++ b/soroban-env-host/src/host/data_helper.rs
@@ -452,7 +452,7 @@ impl Host {
         t: StorageType,
     ) -> Result<(), HostError> {
         let durability: ContractDataDurability = t.try_into()?;
-        let key = self.contract_data_key_from_rawval(k, durability)?;
+        let key = self.contract_data_key_from_val(k, durability)?;
         // Currently the storage stores the whole ledger entries, while this
         // operation might only modify only the internal `ScVal` value. Thus we
         // need to only overwrite the value in case if there is already an

--- a/soroban-env-host/src/host/frame.rs
+++ b/soroban-env-host/src/host/frame.rs
@@ -670,7 +670,7 @@ impl Host {
                         ));
                     };
                     let function_name: Symbol = invoke_args.function_name.try_into_val(self)?;
-                    let args = self.scvals_to_rawvals(invoke_args.args.as_slice())?;
+                    let args = self.scvals_to_val_vec(invoke_args.args.as_slice())?;
                     // since the `HostFunction` frame must be the bottom of the call stack,
                     // reentry is irrelevant, we always pass in `ContractReentryMode::Prohibited`.
                     self.call_n_internal(

--- a/soroban-env-host/src/host/frame.rs
+++ b/soroban-env-host/src/host/frame.rs
@@ -391,9 +391,12 @@ impl Host {
         if let Some(id) = self.get_current_contract_id_opt_internal()? {
             Ok(id)
         } else {
+            // This should only ever happen if we try to access the contract ID
+            // from a HostFunction frame (meaning before a contract is running).
+            // Doing so is a logic bug on our part.
             Err(self.err(
                 ScErrorType::Context,
-                ScErrorCode::MissingValue,
+                ScErrorCode::InternalError,
                 "Current context has no contract ID",
                 &[],
             ))

--- a/soroban-env-host/src/host/frame.rs
+++ b/soroban-env-host/src/host/frame.rs
@@ -574,9 +574,9 @@ impl Host {
                     let res: Result<Option<Val>, PanicVal> =
                         testutils::call_with_suppressed_panic_hook(closure);
                     match res {
-                        Ok(Some(rawval)) => {
-                            self.fn_return_diagnostics(id, &func, &rawval)?;
-                            Ok(rawval)
+                        Ok(Some(val)) => {
+                            self.fn_return_diagnostics(id, &func, &val)?;
+                            Ok(val)
                         }
                         Ok(None) => Err(self.err(
                             ScErrorType::Context,

--- a/soroban-env-host/src/host/metered_clone.rs
+++ b/soroban-env-host/src/host/metered_clone.rs
@@ -325,7 +325,7 @@ impl MeteredClone for ScVal {
                 ScVal::Vec(Some(v)) => ScVec::charge_for_substructure(v, budget),
                 ScVal::Map(Some(m)) => ScMap::charge_for_substructure(m, budget),
                 ScVal::Vec(None) | ScVal::Map(None) => {
-                    Err((ScErrorType::Value, ScErrorCode::MissingValue).into())
+                    Err((ScErrorType::Value, ScErrorCode::InvalidInput).into())
                 }
                 ScVal::Bytes(b) => BytesM::charge_for_substructure(b, budget),
                 ScVal::String(s) => StringM::charge_for_substructure(s, budget),

--- a/soroban-env-host/src/native_contract/testutils.rs
+++ b/soroban-env-host/src/native_contract/testutils.rs
@@ -166,7 +166,7 @@ pub(crate) fn authorize_single_invocation_with_nonce(
         function: SorobanAuthorizedFunction::ContractFn(InvokeContractArgs {
             contract_address: contract_address.to_sc_address().unwrap(),
             function_name: ScSymbol(function_name.try_into().unwrap()),
-            args: host.call_args_to_sc_val_vec(args.into()).unwrap(),
+            args: host.vecobject_to_scval_vec(args.into()).unwrap(),
         }),
         sub_invocations: Default::default(),
     };

--- a/soroban-env-host/src/test/auth.rs
+++ b/soroban-env-host/src/test/auth.rs
@@ -244,7 +244,7 @@ impl AuthTest {
                         nonce,
                         signature: ScVal::Vec(Some(
                             self.host
-                                .call_args_to_sc_val_vec(signature_args.into())
+                                .vecobject_to_scval_vec(signature_args.into())
                                 .unwrap()
                                 .into(),
                         )),
@@ -1305,7 +1305,7 @@ fn test_out_of_order_auth() {
                     &test.contracts[1],
                     Symbol::try_from_small_str("do_auth").unwrap(),
                     test.host
-                        .call_args_to_sc_val_vec(
+                        .vecobject_to_scval_vec(
                             host_vec![&test.host, test.key_to_address(&test.keys[0]), 10_u32]
                                 .into(),
                         )
@@ -1320,7 +1320,7 @@ fn test_out_of_order_auth() {
                     &test.contracts[0],
                     Symbol::try_from_small_str("order_fn").unwrap(),
                     test.host
-                        .call_args_to_sc_val_vec(
+                        .vecobject_to_scval_vec(
                             host_vec![
                                 &test.host,
                                 test.key_to_address(&test.keys[0]),
@@ -1346,7 +1346,7 @@ fn test_out_of_order_auth() {
                 &test.contracts[0],
                 Symbol::try_from_small_str("order_fn").unwrap(),
                 test.host
-                    .call_args_to_sc_val_vec(
+                    .vecobject_to_scval_vec(
                         host_vec![
                             &test.host,
                             test.key_to_address(&test.keys[0]),
@@ -1361,7 +1361,7 @@ fn test_out_of_order_auth() {
                 &test.contracts[1],
                 Symbol::try_from_small_str("do_auth").unwrap(),
                 test.host
-                    .call_args_to_sc_val_vec(
+                    .vecobject_to_scval_vec(
                         host_vec![&test.host, test.key_to_address(&test.keys[0]), 10_u32].into(),
                     )
                     .unwrap(),
@@ -1380,7 +1380,7 @@ fn test_out_of_order_auth() {
             &test.contracts[0],
             Symbol::try_from_small_str("order_fn").unwrap(),
             test.host
-                .call_args_to_sc_val_vec(
+                .vecobject_to_scval_vec(
                     host_vec![
                         &test.host,
                         test.key_to_address(&test.keys[0]),
@@ -1393,7 +1393,7 @@ fn test_out_of_order_auth() {
                 &test.contracts[1],
                 Symbol::try_from_small_str("do_auth").unwrap(),
                 test.host
-                    .call_args_to_sc_val_vec(
+                    .vecobject_to_scval_vec(
                         host_vec![&test.host, test.key_to_address(&test.keys[0]), 10_u32].into(),
                     )
                     .unwrap(),
@@ -1686,7 +1686,7 @@ fn test_require_auth_within_check_auth() {
             nonce: 4444,
             signature: ScVal::Vec(Some(
                 test.host
-                    .call_args_to_sc_val_vec(signature_args.clone().into())
+                    .vecobject_to_scval_vec(signature_args.clone().into())
                     .unwrap()
                     .into(),
             )),
@@ -1718,7 +1718,7 @@ fn test_require_auth_within_check_auth() {
             nonce: 3333,
             signature: ScVal::Vec(Some(
                 test.host
-                    .call_args_to_sc_val_vec(signature_args.into())
+                    .vecobject_to_scval_vec(signature_args.into())
                     .unwrap()
                     .into(),
             )),

--- a/soroban-env-host/src/test/depth_limit.rs
+++ b/soroban-env-host/src/test/depth_limit.rs
@@ -23,7 +23,10 @@ fn deep_scval_to_host_val() -> Result<(), HostError> {
     }
 
     let res = host.to_host_val(&ScVal::from(v));
-    let code = (ScErrorType::Value, ScErrorCode::InternalError);
+    // NB: this error code is not great, it's a consequence of
+    // bug https://github.com/stellar/rs-soroban-env/issues/1046
+    // where the TryIntoVal impl in common eats HostErrors
+    let code = (ScErrorType::Value, ScErrorCode::UnexpectedType);
     assert!(HostError::result_matches_err(res, code));
     Ok(())
 }
@@ -39,7 +42,10 @@ fn deep_host_val_to_scval() -> Result<(), HostError> {
         hv = host.vec_push_back(vv, hv.to_val())?;
     }
     let res = host.from_host_obj(hv);
-    let code = (ScErrorType::Value, ScErrorCode::InvalidInput);
+    // NB: this error code is not great, it's a consequence of
+    // bug https://github.com/stellar/rs-soroban-env/issues/1046
+    // where the TryIntoVal impl in common eats HostErrors
+    let code = (ScErrorType::Value, ScErrorCode::UnexpectedType);
     assert!(HostError::result_matches_err(res, code));
     Ok(())
 }

--- a/soroban-env-host/src/test/num.rs
+++ b/soroban-env-host/src/test/num.rs
@@ -134,7 +134,7 @@ fn test_num_scval_roundtrips() {
 }
 
 #[test]
-fn test_num_rawval_scval_roundtrip_ordering() {
+fn test_num_val_scval_roundtrip_ordering() {
     let host = Host::default();
     let input_vec = vec![
         0_i128,

--- a/soroban-env-host/src/test/token.rs
+++ b/soroban-env-host/src/test/token.rs
@@ -2893,7 +2893,7 @@ fn test_recording_auth_for_token() {
                 function: SorobanAuthorizedFunction::ContractFn(InvokeContractArgs {
                     contract_address: token.address.to_sc_address().unwrap(),
                     function_name: ScSymbol("mint".try_into().unwrap()),
-                    args: test.host.call_args_to_sc_val_vec(args.into()).unwrap()
+                    args: test.host.vecobject_to_scval_vec(args.into()).unwrap()
                 }),
                 sub_invocations: Default::default()
             }

--- a/soroban-env-host/src/test/util.rs
+++ b/soroban-env-host/src/test/util.rs
@@ -188,8 +188,8 @@ impl Host {
 
     pub(crate) fn test_bin_obj(&self, vals: &[u8]) -> Result<BytesObject, HostError> {
         let scval: ScVal = self.test_bin_scobj(vals)?;
-        let rawval: Val = self.to_host_val(&scval)?;
-        Ok(rawval.try_into()?)
+        let val: Val = self.to_host_val(&scval)?;
+        Ok(val.try_into()?)
     }
 
     // Registers a contract with provided Wasm code and returns the registered

--- a/soroban-env-host/src/vm/dispatch.rs
+++ b/soroban-env-host/src/vm/dispatch.rs
@@ -166,7 +166,7 @@ macro_rules! generate_dispatch_functions {
                     // The odd / seemingly-redundant use of `wasmi::Value` here
                     // as intermediates -- rather than just passing Vals --
                     // has to do with the fact that some host functions are
-                    // typed as receiving or returning plain _non-Rawval_ i64 or
+                    // typed as receiving or returning plain _non-val_ i64 or
                     // u64 values. So the call here has to be able to massage
                     // both types into and out of i64, and `wasmi::Value`
                     // happens to be a natural switching point for that: we have

--- a/soroban-synth-wasm/src/func_emitter.rs
+++ b/soroban-synth-wasm/src/func_emitter.rs
@@ -173,9 +173,9 @@ impl FuncEmitter {
     /// trapping if not. Consumes the top of stack value, so you might need to
     /// call [`FuncEmitter::dup_via`] first.
     pub fn assert_val_tag(&mut self, tag: Tag) -> &mut Self {
-        self.i64_const(Tag::rawval_mask())
+        self.i64_const(Tag::val_mask())
             .i64_and()
-            .i64_const(tag.rawval_const())
+            .i64_const(tag.val_const())
             .i64_ne()
             .if_then_trap()
     }


### PR DESCRIPTION
Nothing deeply complicated in here, just a bunch of error plumbing, error code and check consolidation, double checks of internal logic, renames and comment gardening.

The most annoying parts of this PR are the bad errors we get from "anything going wrong during ScVal conversion" which is already noted as bug #1046 which I would love to fix but we probably don't have time; or at least last time I tried I gave up because it required too much SDK proc-macro hacking and error routing. Maybe I can try again sometime?