### PR TITLE
Review fixes for declared_size and metered_clone

### DIFF
--- a/soroban-env-host/src/events/internal.rs
+++ b/soroban-env-host/src/events/internal.rs
@@ -43,9 +43,9 @@ impl InternalContractEvent {
 /// Internal representation of a structured debug message which is logically
 /// similar to an InternalContractEvent (and will project to a ContractEvent the
 /// same way when we externalize it to XDR) but internally is different: it
-/// stores "plain" rust data values -- String and Vec as well as XDR types like
-/// ScVal -- capturing the input to diagnostics, rather than interacting with
-/// the host object system. It does this for two reasons:
+/// stores more "plain" rust data values -- Vec as well as XDR types like ScVal
+/// -- capturing the input to diagnostics, rather than interacting with the host
+/// object system. It does this for two reasons:
 ///
 ///   1. to avoid to avoid perturbing object numbering when debug-mode is
 ///      enabled -- this could potentially cause hosts running on watcher nodes

--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -821,7 +821,7 @@ impl VmCallerEnv for Host {
         Ok(self.max_live_until_ledger()?.into())
     }
 
-    // endregion "context" module functions
+    // endregion: "context" module functions
 
     // region: "int" module functions
 
@@ -1080,7 +1080,7 @@ impl VmCallerEnv for Host {
     impl_bignum_host_fns_rhs_u32!(i256_shl, checked_shl, I256, I256Val, Int256Shift);
     impl_bignum_host_fns_rhs_u32!(i256_shr, checked_shr, I256, I256Val, Int256Shift);
 
-    // endregion "int" module functions
+    // endregion: "int" module functions
     // region: "map" module functions
 
     fn map_new(&self, _vmcaller: &mut VmCaller<Host>) -> Result<MapObject, HostError> {
@@ -1321,7 +1321,7 @@ impl VmCallerEnv for Host {
         Ok(Val::VOID)
     }
 
-    // endregion "map" module functions
+    // endregion: "map" module functions
     // region: "vec" module functions
 
     fn vec_new(&self, _vmcaller: &mut VmCaller<Host>) -> Result<VecObject, HostError> {
@@ -1583,7 +1583,7 @@ impl VmCallerEnv for Host {
         Ok(Val::VOID)
     }
 
-    // endregion "vec" module functions
+    // endregion: "vec" module functions
     // region: "ledger" module functions
 
     // Notes on metering: covered by components
@@ -1851,7 +1851,7 @@ impl VmCallerEnv for Host {
         Ok(Val::VOID)
     }
 
-    // endregion "ledger" module functions
+    // endregion: "ledger" module functions
     // region: "call" module functions
 
     // Notes on metering: here covers the args unpacking. The actual VM work is changed at lower layers.
@@ -1940,7 +1940,7 @@ impl VmCallerEnv for Host {
         }
     }
 
-    // endregion "call" module functions
+    // endregion: "call" module functions
     // region: "buf" module functions
 
     // Notes on metering: covered by components
@@ -2331,7 +2331,7 @@ impl VmCallerEnv for Host {
         self.add_host_object(self.scbytes_from_vec(vnew)?)
     }
 
-    // endregion "buf" module functions
+    // endregion: "buf" module functions
     // region: "crypto" module functions
 
     // Notes on metering: covered by components.
@@ -2383,14 +2383,14 @@ impl VmCallerEnv for Host {
         self.recover_key_ecdsa_secp256k1_internal(&hash, &sig, rid)
     }
 
-    // endregion "crypto" module functions
+    // endregion: "crypto" module functions
     // region: "test" module functions
 
     fn dummy0(&self, _vmcaller: &mut VmCaller<Self::VmUserState>) -> Result<Val, Self::Error> {
         Ok(().into())
     }
 
-    // endregion "test" module functions
+    // endregion: "test" module functions
     // region: "address" module functions
 
     fn require_auth_for_args(
@@ -2544,7 +2544,7 @@ impl VmCallerEnv for Host {
         self.add_host_object(sc_addr)
     }
 
-    // endregion "address" module functions
+    // endregion: "address" module functions
     // region: "prng" module functions
 
     fn prng_reseed(
@@ -2608,7 +2608,7 @@ impl VmCallerEnv for Host {
         })?;
         self.add_host_object(vnew)
     }
-    // endregion "prng" module functions
+    // endregion: "prng" module functions
 }
 
 #[cfg(any(test, feature = "testutils"))]

--- a/soroban-env-host/src/host/declared_size.rs
+++ b/soroban-env-host/src/host/declared_size.rs
@@ -11,12 +11,12 @@ use crate::{
     xdr::{
         AccountEntry, AccountId, Asset, BytesM, ContractCodeEntry, ContractDataDurability,
         ContractEvent, ContractExecutable, ContractIdPreimage, CreateContractArgs, Duration,
-        ExtensionPoint, Hash, Int128Parts, Int256Parts, LedgerEntry, LedgerEntryExt, LedgerKey,
-        LedgerKeyAccount, LedgerKeyContractCode, LedgerKeyTrustLine, PublicKey, ScAddress, ScBytes,
-        ScContractInstance, ScError, ScMap, ScMapEntry, ScNonceKey, ScString, ScSymbol, ScVal,
-        ScVec, Signer, SorobanAuthorizationEntry, SorobanAuthorizedInvocation, StringM, TimePoint,
-        TrustLineAsset, TrustLineEntry, TtlEntry, UInt128Parts, UInt256Parts, Uint256,
-        SCSYMBOL_LIMIT,
+        ExtensionPoint, Hash, Int128Parts, Int256Parts, InvokeContractArgs, LedgerEntry,
+        LedgerEntryExt, LedgerKey, LedgerKeyAccount, LedgerKeyContractCode, LedgerKeyTrustLine,
+        PublicKey, ScAddress, ScBytes, ScContractInstance, ScError, ScMap, ScMapEntry, ScNonceKey,
+        ScString, ScSymbol, ScVal, ScVec, Signer, SorobanAuthorizationEntry,
+        SorobanAuthorizedFunction, SorobanAuthorizedInvocation, StringM, TimePoint, TrustLineAsset,
+        TrustLineEntry, TtlEntry, UInt128Parts, UInt256Parts, Uint256, SCSYMBOL_LIMIT,
     },
     AddressObject, Bool, BytesObject, DurationObject, DurationSmall, DurationVal, Error, HostError,
     I128Object, I128Small, I128Val, I256Object, I256Small, I256Val, I32Val, I64Object, I64Small,
@@ -44,6 +44,9 @@ macro_rules! impl_declared_size_type {
     };
 }
 
+// NB: if you add any entries to these lists, you should update the _two_ tests below that check
+// that the actual size is as expected, and that the declared size is >= the actual size.
+
 // Primitive types
 impl_declared_size_type!(bool, 1);
 impl_declared_size_type!(u8, 1);
@@ -54,6 +57,7 @@ impl_declared_size_type!(i64, 8);
 impl_declared_size_type!(u128, 16);
 impl_declared_size_type!(i128, 16);
 impl_declared_size_type!(usize, 8);
+
 // Val-wrapping types
 impl_declared_size_type!(Val, 8);
 impl_declared_size_type!(Void, 8);
@@ -95,7 +99,8 @@ impl_declared_size_type!(Symbol, 8);
 impl_declared_size_type!(SymbolSmall, 8);
 impl_declared_size_type!(SymbolObject, 8);
 impl_declared_size_type!(Value, 16);
-// other common types
+
+// other env types
 impl_declared_size_type!(SymbolStr, SCSYMBOL_LIMIT);
 impl_declared_size_type!(SymbolSmallIter, 8);
 impl_declared_size_type!(U256, 32);
@@ -104,6 +109,21 @@ impl_declared_size_type!(HostObject, 48);
 impl_declared_size_type!(HostError, 16);
 impl_declared_size_type!(Context, 512);
 impl_declared_size_type!(Address, 16);
+
+impl_declared_size_type!(AccessType, 1);
+impl_declared_size_type!(InternalContractEvent, 40);
+impl_declared_size_type!(HostEvent, 136);
+impl_declared_size_type!(Events, 24);
+impl_declared_size_type!(InternalEvent, 40);
+impl_declared_size_type!(EventError, 1);
+
+impl_declared_size_type!(ContractInvocation, 16);
+impl_declared_size_type!(AuthorizedInvocation, 136);
+impl_declared_size_type!(AuthorizedInvocationSnapshot, 32);
+impl_declared_size_type!(AccountAuthorizationTracker, 232);
+impl_declared_size_type!(AccountAuthorizationTrackerSnapshot, 40);
+impl_declared_size_type!(InvokerContractAuthorizationTracker, 192);
+
 // xdr types
 impl_declared_size_type!(TimePoint, 8);
 impl_declared_size_type!(Duration, 8);
@@ -114,23 +134,21 @@ impl_declared_size_type!(ScVec, 24);
 impl_declared_size_type!(ScMap, 24);
 impl_declared_size_type!(Hash, 32);
 impl_declared_size_type!(Uint256, 32);
+impl_declared_size_type!(Int128Parts, 16);
+impl_declared_size_type!(UInt128Parts, 16);
+impl_declared_size_type!(Int256Parts, 32);
+impl_declared_size_type!(UInt256Parts, 32);
 impl_declared_size_type!(ContractExecutable, 33);
 impl_declared_size_type!(AccountId, 32);
 impl_declared_size_type!(ScAddress, 33);
 impl_declared_size_type!(ScNonceKey, 33);
 impl_declared_size_type!(PublicKey, 32);
+impl_declared_size_type!(Asset, 45);
 impl_declared_size_type!(TrustLineAsset, 45);
 impl_declared_size_type!(Signer, 72);
-
-impl_declared_size_type!(Int128Parts, 16);
-impl_declared_size_type!(UInt128Parts, 16);
-impl_declared_size_type!(Int256Parts, 32);
-impl_declared_size_type!(UInt256Parts, 32);
-
 impl_declared_size_type!(LedgerKeyAccount, 32);
 impl_declared_size_type!(LedgerKeyTrustLine, 77);
 impl_declared_size_type!(LedgerKeyContractCode, 36);
-
 impl_declared_size_type!(LedgerEntryExt, 33);
 impl_declared_size_type!(AccountEntry, 216);
 impl_declared_size_type!(TrustLineEntry, 128);
@@ -138,35 +156,22 @@ impl_declared_size_type!(ContractCodeEntry, 64);
 // TtlEntry must be declared as it's used in e2e to build
 // The TtlEntryMap, but is not otherwise cloned anywhere.
 impl_declared_size_type!(TtlEntry, 36);
-
 impl_declared_size_type!(LedgerKey, 120);
 impl_declared_size_type!(LedgerEntry, 256);
-
-impl_declared_size_type!(AccessType, 1);
-impl_declared_size_type!(InternalContractEvent, 40);
 impl_declared_size_type!(ContractEvent, 128);
-impl_declared_size_type!(HostEvent, 136);
-impl_declared_size_type!(Events, 24);
-impl_declared_size_type!(InternalEvent, 40);
-impl_declared_size_type!(EventError, 1);
 impl_declared_size_type!(ScBytes, 24);
 impl_declared_size_type!(ScString, 24);
 impl_declared_size_type!(ScSymbol, 24);
 impl_declared_size_type!(ScError, 8);
 impl_declared_size_type!(CreateContractArgs, 98);
+impl_declared_size_type!(InvokeContractArgs, 88);
 impl_declared_size_type!(ContractIdPreimage, 65);
 impl_declared_size_type!(ContractDataDurability, 4);
 impl_declared_size_type!(ExtensionPoint, 0);
 impl_declared_size_type!(ScContractInstance, 64);
 impl_declared_size_type!(SorobanAuthorizationEntry, 240);
 impl_declared_size_type!(SorobanAuthorizedInvocation, 128);
-impl_declared_size_type!(AuthorizedInvocation, 136);
-impl_declared_size_type!(AuthorizedInvocationSnapshot, 32);
-impl_declared_size_type!(AccountAuthorizationTracker, 232);
-impl_declared_size_type!(InvokerContractAuthorizationTracker, 192);
-impl_declared_size_type!(AccountAuthorizationTrackerSnapshot, 40);
-impl_declared_size_type!(ContractInvocation, 16);
-impl_declared_size_type!(Asset, 45);
+impl_declared_size_type!(SorobanAuthorizedFunction, 104);
 
 // composite types
 
@@ -249,6 +254,7 @@ mod test {
         expect!["16"].assert_eq(size_of::<u128>().to_string().as_str());
         expect!["16"].assert_eq(size_of::<i128>().to_string().as_str());
         expect!["8"].assert_eq(size_of::<usize>().to_string().as_str());
+
         // Val-wrapping types
         expect!["8"].assert_eq(size_of::<Val>().to_string().as_str());
         expect!["8"].assert_eq(size_of::<Void>().to_string().as_str());
@@ -290,7 +296,8 @@ mod test {
         expect!["8"].assert_eq(size_of::<SymbolSmall>().to_string().as_str());
         expect!["8"].assert_eq(size_of::<SymbolObject>().to_string().as_str());
         expect!["16"].assert_eq(size_of::<Value>().to_string().as_str());
-        // other common types
+
+        // other env types
         expect!["32"].assert_eq(size_of::<SymbolStr>().to_string().as_str());
         expect!["8"].assert_eq(size_of::<SymbolSmallIter>().to_string().as_str());
         expect!["32"].assert_eq(size_of::<U256>().to_string().as_str());
@@ -305,6 +312,37 @@ mod test {
         #[cfg(target_arch = "aarch64")]
         expect!["496"].assert_eq(size_of::<Context>().to_string().as_str());
         expect!["16"].assert_eq(size_of::<Address>().to_string().as_str());
+
+        expect!["1"].assert_eq(size_of::<AccessType>().to_string().as_str());
+        expect!["40"].assert_eq(size_of::<InternalContractEvent>().to_string().as_str());
+        expect!["136"].assert_eq(size_of::<HostEvent>().to_string().as_str());
+        expect!["24"].assert_eq(size_of::<Events>().to_string().as_str());
+        expect!["40"].assert_eq(size_of::<InternalEvent>().to_string().as_str());
+        expect!["1"].assert_eq(size_of::<EventError>().to_string().as_str());
+
+        expect!["16"].assert_eq(size_of::<ContractInvocation>().to_string().as_str());
+        expect!["136"].assert_eq(size_of::<AuthorizedInvocation>().to_string().as_str());
+        expect!["32"].assert_eq(
+            size_of::<AuthorizedInvocationSnapshot>()
+                .to_string()
+                .as_str(),
+        );
+        expect!["232"].assert_eq(
+            size_of::<AccountAuthorizationTracker>()
+                .to_string()
+                .as_str(),
+        );
+        expect!["40"].assert_eq(
+            size_of::<AccountAuthorizationTrackerSnapshot>()
+                .to_string()
+                .as_str(),
+        );
+        expect!["192"].assert_eq(
+            size_of::<InvokerContractAuthorizationTracker>()
+                .to_string()
+                .as_str(),
+        );
+
         // xdr types
         expect!["8"].assert_eq(size_of::<TimePoint>().to_string().as_str());
         expect!["8"].assert_eq(size_of::<Duration>().to_string().as_str());
@@ -324,6 +362,7 @@ mod test {
         expect!["33"].assert_eq(size_of::<ScAddress>().to_string().as_str());
         expect!["8"].assert_eq(size_of::<ScNonceKey>().to_string().as_str());
         expect!["32"].assert_eq(size_of::<PublicKey>().to_string().as_str());
+        expect!["45"].assert_eq(size_of::<Asset>().to_string().as_str());
         expect!["45"].assert_eq(size_of::<TrustLineAsset>().to_string().as_str());
         expect!["72"].assert_eq(size_of::<Signer>().to_string().as_str());
         expect!["32"].assert_eq(size_of::<LedgerKeyAccount>().to_string().as_str());
@@ -336,50 +375,27 @@ mod test {
         expect!["36"].assert_eq(size_of::<TtlEntry>().to_string().as_str());
         expect!["112"].assert_eq(size_of::<LedgerKey>().to_string().as_str());
         expect!["256"].assert_eq(size_of::<LedgerEntry>().to_string().as_str());
-        expect!["1"].assert_eq(size_of::<AccessType>().to_string().as_str());
-        expect!["40"].assert_eq(size_of::<InternalContractEvent>().to_string().as_str());
         expect!["128"].assert_eq(size_of::<ContractEvent>().to_string().as_str());
-        expect!["136"].assert_eq(size_of::<HostEvent>().to_string().as_str());
-        expect!["24"].assert_eq(size_of::<Events>().to_string().as_str());
-        expect!["40"].assert_eq(size_of::<InternalEvent>().to_string().as_str());
-        expect!["1"].assert_eq(size_of::<EventError>().to_string().as_str());
         expect!["24"].assert_eq(size_of::<ScBytes>().to_string().as_str());
         expect!["24"].assert_eq(size_of::<ScString>().to_string().as_str());
         expect!["24"].assert_eq(size_of::<ScSymbol>().to_string().as_str());
         expect!["8"].assert_eq(size_of::<ScError>().to_string().as_str());
         expect!["98"].assert_eq(size_of::<CreateContractArgs>().to_string().as_str());
+        expect!["88"].assert_eq(size_of::<InvokeContractArgs>().to_string().as_str());
         expect!["65"].assert_eq(size_of::<ContractIdPreimage>().to_string().as_str());
         expect!["4"].assert_eq(size_of::<ContractDataDurability>().to_string().as_str());
         expect!["0"].assert_eq(size_of::<ExtensionPoint>().to_string().as_str());
+        expect!["64"].assert_eq(size_of::<ScContractInstance>().to_string().as_str());
+        expect!["240"].assert_eq(size_of::<SorobanAuthorizationEntry>().to_string().as_str());
         expect!["128"].assert_eq(
             size_of::<SorobanAuthorizedInvocation>()
                 .to_string()
                 .as_str(),
         );
-        expect!["136"].assert_eq(size_of::<AuthorizedInvocation>().to_string().as_str());
-        expect!["32"].assert_eq(
-            size_of::<AuthorizedInvocationSnapshot>()
-                .to_string()
-                .as_str(),
-        );
-        expect!["232"].assert_eq(
-            size_of::<AccountAuthorizationTracker>()
-                .to_string()
-                .as_str(),
-        );
-        expect!["192"].assert_eq(
-            size_of::<InvokerContractAuthorizationTracker>()
-                .to_string()
-                .as_str(),
-        );
-        expect!["40"].assert_eq(
-            size_of::<AccountAuthorizationTrackerSnapshot>()
-                .to_string()
-                .as_str(),
-        );
-        expect!["16"].assert_eq(size_of::<ContractInvocation>().to_string().as_str());
-        expect!["45"].assert_eq(size_of::<Asset>().to_string().as_str());
+        expect!["104"].assert_eq(size_of::<SorobanAuthorizedFunction>().to_string().as_str());
+
         // composite types
+        expect!["8"].assert_eq(size_of::<Rc<ScVal>>().to_string().as_str());
         expect!["16"].assert_eq(size_of::<&[ScVal]>().to_string().as_str());
         expect!["72"].assert_eq(size_of::<(Val, ScVal)>().to_string().as_str());
         expect!["320"].assert_eq(size_of::<[ScVal; 5]>().to_string().as_str());
@@ -387,9 +403,7 @@ mod test {
         expect!["24"].assert_eq(size_of::<StringM<10000>>().to_string().as_str());
         expect!["24"].assert_eq(size_of::<Vec<ScVal>>().to_string().as_str());
         expect!["8"].assert_eq(size_of::<Box<ScVal>>().to_string().as_str());
-        expect!["8"].assert_eq(size_of::<Rc<ScVal>>().to_string().as_str());
         expect!["64"].assert_eq(size_of::<Option<ScVal>>().to_string().as_str());
-        expect!["64"].assert_eq(size_of::<ScContractInstance>().to_string().as_str());
     }
 
     // This is the actual test.
@@ -418,6 +432,7 @@ mod test {
         assert_mem_size_le_declared_size!(u128);
         assert_mem_size_le_declared_size!(i128);
         assert_mem_size_le_declared_size!(usize);
+
         // Val-wrapping types
         assert_mem_size_le_declared_size!(Val);
         assert_mem_size_le_declared_size!(Void);
@@ -459,7 +474,8 @@ mod test {
         assert_mem_size_le_declared_size!(SymbolSmall);
         assert_mem_size_le_declared_size!(SymbolObject);
         assert_mem_size_le_declared_size!(Value);
-        // other common types
+
+        // other env types
         assert_mem_size_le_declared_size!(SymbolStr);
         assert_mem_size_le_declared_size!(SymbolSmallIter);
         assert_mem_size_le_declared_size!(U256);
@@ -468,6 +484,21 @@ mod test {
         assert_mem_size_le_declared_size!(HostError);
         assert_mem_size_le_declared_size!(Context);
         assert_mem_size_le_declared_size!(Address);
+
+        assert_mem_size_le_declared_size!(AccessType);
+        assert_mem_size_le_declared_size!(InternalContractEvent);
+        assert_mem_size_le_declared_size!(HostEvent);
+        assert_mem_size_le_declared_size!(Events);
+        assert_mem_size_le_declared_size!(InternalEvent);
+        assert_mem_size_le_declared_size!(EventError);
+
+        assert_mem_size_le_declared_size!(ContractInvocation);
+        assert_mem_size_le_declared_size!(AuthorizedInvocation);
+        assert_mem_size_le_declared_size!(AuthorizedInvocationSnapshot);
+        assert_mem_size_le_declared_size!(AccountAuthorizationTracker);
+        assert_mem_size_le_declared_size!(AccountAuthorizationTrackerSnapshot);
+        assert_mem_size_le_declared_size!(InvokerContractAuthorizationTracker);
+
         // xdr types
         assert_mem_size_le_declared_size!(TimePoint);
         assert_mem_size_le_declared_size!(Duration);
@@ -487,6 +518,7 @@ mod test {
         assert_mem_size_le_declared_size!(ScAddress);
         assert_mem_size_le_declared_size!(ScNonceKey);
         assert_mem_size_le_declared_size!(PublicKey);
+        assert_mem_size_le_declared_size!(Asset);
         assert_mem_size_le_declared_size!(TrustLineAsset);
         assert_mem_size_le_declared_size!(Signer);
         assert_mem_size_le_declared_size!(LedgerKeyAccount);
@@ -499,29 +531,23 @@ mod test {
         assert_mem_size_le_declared_size!(TtlEntry);
         assert_mem_size_le_declared_size!(LedgerKey);
         assert_mem_size_le_declared_size!(LedgerEntry);
-        assert_mem_size_le_declared_size!(AccessType);
-        assert_mem_size_le_declared_size!(InternalContractEvent);
         assert_mem_size_le_declared_size!(ContractEvent);
-        assert_mem_size_le_declared_size!(HostEvent);
-        assert_mem_size_le_declared_size!(Events);
-        assert_mem_size_le_declared_size!(InternalEvent);
         assert_mem_size_le_declared_size!(ScBytes);
         assert_mem_size_le_declared_size!(ScString);
         assert_mem_size_le_declared_size!(ScSymbol);
         assert_mem_size_le_declared_size!(ScError);
         assert_mem_size_le_declared_size!(CreateContractArgs);
+        assert_mem_size_le_declared_size!(InvokeContractArgs);
+        assert_mem_size_le_declared_size!(ContractIdPreimage);
         assert_mem_size_le_declared_size!(ContractDataDurability);
         assert_mem_size_le_declared_size!(ExtensionPoint);
-        assert_mem_size_le_declared_size!(SorobanAuthorizedInvocation);
+        assert_mem_size_le_declared_size!(ScContractInstance);
         assert_mem_size_le_declared_size!(SorobanAuthorizationEntry);
-        assert_mem_size_le_declared_size!(AuthorizedInvocation);
-        assert_mem_size_le_declared_size!(AuthorizedInvocationSnapshot);
-        assert_mem_size_le_declared_size!(AccountAuthorizationTracker);
-        assert_mem_size_le_declared_size!(InvokerContractAuthorizationTracker);
-        assert_mem_size_le_declared_size!(AccountAuthorizationTrackerSnapshot);
-        assert_mem_size_le_declared_size!(ContractInvocation);
-        assert_mem_size_le_declared_size!(Asset);
+        assert_mem_size_le_declared_size!(SorobanAuthorizedInvocation);
+        assert_mem_size_le_declared_size!(SorobanAuthorizedFunction);
+
         // composite types
+        assert_mem_size_le_declared_size!(Rc<ScVal>);
         assert_mem_size_le_declared_size!(&[ScVal]);
         assert_mem_size_le_declared_size!((Val, ScVal));
         assert_mem_size_le_declared_size!([ScVal; 5]);
@@ -530,6 +556,5 @@ mod test {
         assert_mem_size_le_declared_size!(Vec<ScVal>);
         assert_mem_size_le_declared_size!(Box<ScVal>);
         assert_mem_size_le_declared_size!(Option<ScVal>);
-        assert_mem_size_le_declared_size!(Rc<ScVal>);
     }
 }

--- a/soroban-env-host/src/host/metered_clone.rs
+++ b/soroban-env-host/src/host/metered_clone.rs
@@ -22,7 +22,6 @@ use crate::{
     budget::AsBudget,
     events::{EventError, HostEvent, InternalContractEvent, InternalEvent},
     host::Events,
-    host_object::HostObject,
     native_contract::base_types::Address,
     storage::AccessType,
     xdr::{
@@ -284,7 +283,6 @@ impl MeteredClone for SymbolStr {}
 impl MeteredClone for SymbolSmallIter {}
 impl MeteredClone for U256 {}
 impl MeteredClone for I256 {}
-impl MeteredClone for HostObject {}
 impl MeteredClone for Address {}
 impl MeteredClone for AccessType {}
 impl MeteredClone for InternalContractEvent {}

--- a/soroban-env-host/src/host/metered_clone.rs
+++ b/soroban-env-host/src/host/metered_clone.rs
@@ -24,13 +24,12 @@ use crate::{
     storage::AccessType,
     xdr::{
         AccountEntry, AccountId, Asset, BytesM, ContractCodeEntry, ContractCostType,
-        ContractExecutable, ContractIdPreimage,
-        CreateContractArgs, DepthLimiter, Duration, Hash, InvokeContractArgs, LedgerEntry,
-        LedgerEntryData, LedgerEntryExt, LedgerKey, LedgerKeyAccount, LedgerKeyContractCode,
-        LedgerKeyTrustLine, PublicKey, ScAddress, ScBytes, ScContractInstance, ScErrorCode,
-        ScErrorType, ScMap, ScMapEntry, ScNonceKey, ScString, ScSymbol, ScVal, ScVec, Signer,
-        SorobanAuthorizationEntry, SorobanAuthorizedFunction, SorobanAuthorizedInvocation, StringM,
-        TimePoint, TrustLineAsset, TrustLineEntry, Uint256,
+        ContractExecutable, ContractIdPreimage, CreateContractArgs, DepthLimiter, Duration, Hash,
+        InvokeContractArgs, LedgerEntry, LedgerEntryData, LedgerEntryExt, LedgerKey,
+        LedgerKeyAccount, LedgerKeyContractCode, LedgerKeyTrustLine, PublicKey, ScAddress, ScBytes,
+        ScContractInstance, ScErrorCode, ScErrorType, ScMap, ScMapEntry, ScNonceKey, ScString,
+        ScSymbol, ScVal, ScVec, Signer, SorobanAuthorizationEntry, SorobanAuthorizedFunction,
+        SorobanAuthorizedInvocation, StringM, TimePoint, TrustLineAsset, TrustLineEntry, Uint256,
     },
     AddressObject, Bool, BytesObject, DurationObject, DurationSmall, DurationVal, Error, HostError,
     I128Object, I128Small, I128Val, I256Object, I256Small, I256Val, I32Val, I64Object, I64Small,
@@ -539,12 +538,8 @@ impl MeteredClone for LedgerEntry {
                 d.val.charge_for_substructure(budget.clone())?;
                 d.key.charge_for_substructure(budget)
             }
-            ContractCode(c) => {
-                c.charge_for_substructure(budget)
-            }
-            Account(ae) => {
-                ae.charge_for_substructure(budget)
-            }
+            ContractCode(c) => c.charge_for_substructure(budget),
+            Account(ae) => ae.charge_for_substructure(budget),
             Trustline(_) => Ok(()),
 
             Offer(_) | Data(_) | ClaimableBalance(_) | LiquidityPool(_) | ConfigSetting(_)

--- a/soroban-env-host/src/host/metered_clone.rs
+++ b/soroban-env-host/src/host/metered_clone.rs
@@ -101,7 +101,8 @@ impl<T: DeclaredSizeForMetering> MeteredAlloc<T> for Rc<T> {
 }
 
 /// Represents a collection type which can be created from an iterator, and provides
-/// a method for bulk charging its creation cost.
+/// a method for bulk charging its creation cost. This does not clone elements from
+/// the iterator, just moves them into the container, so only charges shallow copies.
 pub trait MeteredContainer: FromIterator<Self::Item> + DeclaredSizeForMetering
 where
     Self: Sized,

--- a/soroban-env-host/src/host/metered_clone.rs
+++ b/soroban-env-host/src/host/metered_clone.rs
@@ -540,12 +540,10 @@ impl MeteredClone for LedgerEntry {
                 d.key.charge_for_substructure(budget)
             }
             ContractCode(c) => {
-                c.charge_for_substructure(budget)?;
-                Ok(())
+                c.charge_for_substructure(budget)
             }
             Account(ae) => {
-                ae.signers.charge_for_substructure(budget.clone())?;
-                Ok(())
+                ae.charge_for_substructure(budget)
             }
             Trustline(_) => Ok(()),
 


### PR DESCRIPTION
Fair amount of churn here:

- Removed several dead impls, cleaned up comments, added missing testcases, reordered stuff for consistency
- Reclassified and removed incorrectly-classified shallow types. This is fairly serious: we weren't counting the substructure cloning cost of much of the auth system as well as the wasm code of a contractcode entry, or the signers of an account entry.

One interesting part of this is that, as far as I can tell, everything in the events system doesn't use `metered_clone` anymore at all. I think this is good because it previously _errored_ when trying to `metered_clone` a diagnostic event, which is "just as observable" as `metered_cloning`-something-that-should-be-free would have been. Luckily it looks like we only "accumulate events", don't clone them, and then externalize them when done, charging the cost of emitting them outside and ignoring the cost of externalizing. I think! @jayz22 and @sisuresh I would appreciate a second pair of eyes on this understanding.