### PR TITLE
Remove `spendable_balance` from SAC.

### DIFF
--- a/soroban-env-host/src/native_contract/token/balance.rs
+++ b/soroban-env-host/src/native_contract/token/balance.rs
@@ -55,13 +55,6 @@ pub fn read_balance(e: &Host, addr: Address) -> Result<i128, HostError> {
 }
 
 // Metering: *mostly* covered by components.
-pub fn get_spendable_balance(e: &Host, addr: Address) -> Result<i128, HostError> {
-    match addr.to_sc_address()? {
-        ScAddress::Account(acc_id) => Ok(get_classic_balance(e, acc_id)?.1.into()),
-        ScAddress::Contract(_) => read_balance(e, addr),
-    }
-}
-
 fn write_balance(e: &Host, addr: Address, balance: BalanceValue) -> Result<(), HostError> {
     let key = DataKey::Balance(addr);
     e.put_contract_data(

--- a/soroban-env-host/src/native_contract/token/contract.rs
+++ b/soroban-env-host/src/native_contract/token/contract.rs
@@ -17,7 +17,7 @@ use soroban_native_sdk_macros::contractimpl;
 use super::admin::{read_administrator, write_administrator};
 use super::asset_info::read_asset_info;
 use super::balance::{
-    check_clawbackable, get_spendable_balance, spend_balance_no_authorization_check,
+    check_clawbackable, spend_balance_no_authorization_check,
 };
 use super::metadata::{read_name, read_symbol, set_metadata, DECIMAL};
 use super::public_types::{AlphaNum12AssetInfo, AlphaNum4AssetInfo};
@@ -45,8 +45,6 @@ pub trait TokenTrait {
     ) -> Result<(), HostError>;
 
     fn balance(e: &Host, addr: Address) -> Result<i128, HostError>;
-
-    fn spendable_balance(e: &Host, addr: Address) -> Result<i128, HostError>;
 
     fn authorized(e: &Host, addr: Address) -> Result<bool, HostError>;
 
@@ -228,14 +226,6 @@ impl TokenTrait for Token {
         read_balance(e, addr)
     }
 
-    fn spendable_balance(e: &Host, addr: Address) -> Result<i128, HostError> {
-        let _span = tracy_span!("native token spendable balance");
-        e.extend_current_contract_instance_and_code(
-            INSTANCE_TTL_THRESHOLD.into(),
-            INSTANCE_EXTEND_AMOUNT.into(),
-        )?;
-        get_spendable_balance(e, addr)
-    }
 
     // Metering: covered by components
     fn authorized(e: &Host, addr: Address) -> Result<bool, HostError> {

--- a/soroban-env-host/src/native_contract/token/contract.rs
+++ b/soroban-env-host/src/native_contract/token/contract.rs
@@ -16,9 +16,7 @@ use soroban_native_sdk_macros::contractimpl;
 
 use super::admin::{read_administrator, write_administrator};
 use super::asset_info::read_asset_info;
-use super::balance::{
-    check_clawbackable, spend_balance_no_authorization_check,
-};
+use super::balance::{check_clawbackable, spend_balance_no_authorization_check};
 use super::metadata::{read_name, read_symbol, set_metadata, DECIMAL};
 use super::public_types::{AlphaNum12AssetInfo, AlphaNum4AssetInfo};
 use super::storage_types::{INSTANCE_EXTEND_AMOUNT, INSTANCE_TTL_THRESHOLD};
@@ -225,7 +223,6 @@ impl TokenTrait for Token {
         )?;
         read_balance(e, addr)
     }
-
 
     // Metering: covered by components
     fn authorized(e: &Host, addr: Address) -> Result<bool, HostError> {

--- a/soroban-env-host/src/native_contract/token/test_token.rs
+++ b/soroban-env-host/src/native_contract/token/test_token.rs
@@ -101,17 +101,6 @@ impl<'a> TestToken<'a> {
             .try_into_val(self.host)?)
     }
 
-    pub(crate) fn spendable_balance(&self, addr: Address) -> Result<i128, HostError> {
-        Ok(self
-            .host
-            .call(
-                self.address.clone().into(),
-                Symbol::try_from_val(self.host, &"spendable_balance")?,
-                host_vec![self.host, addr].into(),
-            )?
-            .try_into_val(self.host)?)
-    }
-
     pub(crate) fn authorized(&self, addr: Address) -> Result<bool, HostError> {
         Ok(self
             .host

--- a/soroban-env-host/src/test/token.rs
+++ b/soroban-env-host/src/test/token.rs
@@ -1318,7 +1318,7 @@ fn test_set_admin() {
 }
 
 #[test]
-fn test_account_spendable_balance() {
+fn test_account_balance() {
     let test = TokenTest::setup();
     let token = TestToken::new_from_asset(&test.host, Asset::Native);
     let user_acc_id = signing_key_to_account_id(&test.user_key);
@@ -1336,9 +1336,6 @@ fn test_account_spendable_balance() {
     );
 
     assert_eq!(token.balance(user_addr.clone()).unwrap(), 100_000_000);
-    // base reserve = 5_000_000
-    // signer + account = 3 base reserves
-    assert_eq!(token.spendable_balance(user_addr).unwrap(), 85_000_000);
 }
 
 #[test]
@@ -1499,10 +1496,6 @@ fn test_trustline_auth() {
         .unwrap();
 
     assert_eq!(token.balance(user.address(&test.host)).unwrap(), 490);
-    assert_eq!(
-        token.spendable_balance(user.address(&test.host)).unwrap(),
-        480
-    );
 }
 
 #[test]


### PR DESCRIPTION
### What

Remove `spendable_balance` from SAC.

### Why

Resolves https://github.com/stellar/rs-soroban-env/issues/1118

As per update to SEP-41 (https://github.com/stellar/stellar-protocol/pull/1408) we decided to remove `spendable_balance` for the time being in order to reduce potential confusion.

### Known limitations

N/A
