### PR TITLE
Extend upgrade contract from 30 to 60 days

### DIFF
--- a/soroban-test-wasms/wasm-workspace/write_upgrade_bytes/src/lib.rs
+++ b/soroban-test-wasms/wasm-workspace/write_upgrade_bytes/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 use soroban_sdk::{contract, contractimpl, Env, Bytes, BytesN};
 
-pub(crate) const EXTEND_AMOUNT: u32 = 518400; // 30 days
+pub(crate) const EXTEND_AMOUNT: u32 = 1036800; // 60 days
 pub(crate) const BALANCE_TTL_THRESHOLD: u32 = EXTEND_AMOUNT;
 
 #[contract]


### PR DESCRIPTION
### What

Leave enough time for validators to inspect upgrades. It's important to note that the initial MAXIMUM_ENTRY_LIFETIME in core is 31 days, so that should be increased if this PR is accepted.