### PR TITLE
tighten up handling of debug mode

### DIFF
--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -26,7 +26,7 @@ rand_chacha = "0.3.1"
 num-traits = "0.2.15"
 num-integer = "0.1.45"
 num-derive = "0.4.0"
-backtrace = "0.3"
+backtrace = { version = "0.3", optional = true }
 k256 = {version = "0.13.1", features=["ecdsa", "arithmetic"]}
 # NB: getrandom is a transitive dependency of k256 which we're not using directly
 # but we have to specify it here in order to enable its 'js' feature which
@@ -55,9 +55,10 @@ expect-test = "1.4.0"
 more-asserts = "0.3.1"
 linregress = "0.5.1"
 pretty_assertions = "1.4.0"
+backtrace = "0.3"
 
 [features]
-testutils = ["soroban-env-common/testutils", "soroban-synth-wasm/testutils", "recording_auth"]
+testutils = ["soroban-env-common/testutils", "soroban-synth-wasm/testutils", "recording_auth", "dep:backtrace"]
 next = ["soroban-env-common/next", "soroban-synth-wasm/next", "soroban-bench-utils/next"]
 tracy = ["dep:tracy-client", "soroban-env-common/tracy"]
 recording_auth = []

--- a/soroban-env-host/src/budget/dimension.rs
+++ b/soroban-env-host/src/budget/dimension.rs
@@ -116,8 +116,8 @@ impl BudgetDimension {
         self.shadow_total_count = 0;
     }
 
-    pub(crate) fn check_budget_limit(&self, is_shadow: bool) -> Result<(), HostError> {
-        let over_limit = if is_shadow {
+    pub(crate) fn check_budget_limit(&self, is_shadow: IsShadowMode) -> Result<(), HostError> {
+        let over_limit = if is_shadow.0 {
             self.shadow_total_count > self.shadow_limit
         } else {
             self.total_count > self.limit
@@ -163,7 +163,7 @@ impl BudgetDimension {
             self.total_count = self.total_count.saturating_add(amount);
         }
 
-        self.check_budget_limit(is_shadow.0)
+        self.check_budget_limit(is_shadow)
     }
 
     // Resets all model parameters to zero (so that we can override and test individual ones later).

--- a/soroban-env-host/src/events/diagnostic.rs
+++ b/soroban-env-host/src/events/diagnostic.rs
@@ -23,63 +23,40 @@ pub enum DiagnosticLevel {
 }
 
 impl Host {
-    pub fn set_diagnostic_level(&self, diagnostic_level: DiagnosticLevel) -> Result<(), HostError> {
-        *self.try_borrow_diagnostic_level_mut()? = diagnostic_level;
-        Ok(())
-    }
-
-    // As above, avoids having to import DiagnosticLevel.
-    pub fn enable_debug(&self) -> Result<(), HostError> {
-        self.set_diagnostic_level(DiagnosticLevel::Debug)
-    }
-
-    pub(crate) fn is_debug(&self) -> Result<bool, HostError> {
-        Ok(matches!(
-            *self.try_borrow_diagnostic_level()?,
-            DiagnosticLevel::Debug
-        ))
-    }
-
     fn record_diagnostic_event(
         &self,
         contract_id: Option<Hash>,
         topics: Vec<InternalDiagnosticArg>,
         args: Vec<InternalDiagnosticArg>,
     ) -> Result<(), HostError> {
-        self.with_debug_mode(
-            || {
-                let de = Rc::metered_new(
-                    InternalDiagnosticEvent {
-                        contract_id,
-                        topics,
-                        args,
-                    },
-                    self,
-                )?;
-                self.with_events_mut(|events| events.record(InternalEvent::Diagnostic(de), self))
-            },
-            || (),
-        );
+        self.with_debug_mode(|| {
+            let de = Rc::metered_new(
+                InternalDiagnosticEvent {
+                    contract_id,
+                    topics,
+                    args,
+                },
+                self,
+            )?;
+            self.with_events_mut(|events| events.record(InternalEvent::Diagnostic(de), self))
+        });
         Ok(())
     }
 
     pub fn log_diagnostics(&self, msg: &str, args: &[Val]) {
-        self.with_debug_mode(
-            || {
-                let calling_contract = self.get_current_contract_id_opt_internal()?;
-                let log_sym = SymbolSmall::try_from_str("log")?;
-                Vec::<InternalDiagnosticArg>::charge_bulk_init_cpy(1, self)?;
-                let topics = vec![InternalDiagnosticArg::HostVal(log_sym.to_val())];
-                let msg = ScVal::String(ScString::from(StringM::try_from(
-                    self.metered_slice_to_vec(msg.as_bytes())?,
-                )?));
-                let args: Vec<_> = std::iter::once(InternalDiagnosticArg::XdrVal(msg))
-                    .chain(args.iter().map(|rv| InternalDiagnosticArg::HostVal(*rv)))
-                    .metered_collect(self)?;
-                self.record_diagnostic_event(calling_contract, topics, args)
-            },
-            || (),
-        )
+        self.with_debug_mode(|| {
+            let calling_contract = self.get_current_contract_id_opt_internal()?;
+            let log_sym = SymbolSmall::try_from_str("log")?;
+            Vec::<InternalDiagnosticArg>::charge_bulk_init_cpy(1, self)?;
+            let topics = vec![InternalDiagnosticArg::HostVal(log_sym.to_val())];
+            let msg = ScVal::String(ScString::from(StringM::try_from(
+                self.metered_slice_to_vec(msg.as_bytes())?,
+            )?));
+            let args: Vec<_> = std::iter::once(InternalDiagnosticArg::XdrVal(msg))
+                .chain(args.iter().map(|rv| InternalDiagnosticArg::HostVal(*rv)))
+                .metered_collect(self)?;
+            self.record_diagnostic_event(calling_contract, topics, args)
+        })
     }
 
     pub(crate) fn record_err_diagnostics(
@@ -89,80 +66,71 @@ impl Host {
         msg: &str,
         args: &[Val],
     ) {
-        self.with_debug_mode(
-            || {
-                let error_sym = SymbolSmall::try_from_str("error")?;
-                let contract_id = self.get_current_contract_id_opt_internal()?;
-                Vec::<InternalDiagnosticArg>::charge_bulk_init_cpy(2, self)?;
-                let topics = vec![
-                    InternalDiagnosticArg::HostVal(error_sym.to_val()),
-                    InternalDiagnosticArg::HostVal(error.to_val()),
-                ];
-                let msg = ScVal::String(ScString::from(StringM::try_from(
-                    self.metered_slice_to_vec(msg.as_bytes())?,
-                )?));
-                let args: Vec<_> = std::iter::once(InternalDiagnosticArg::XdrVal(msg))
-                    .chain(args.iter().map(|rv| InternalDiagnosticArg::HostVal(*rv)))
-                    .metered_collect(self)?;
+        self.with_debug_mode(|| {
+            let error_sym = SymbolSmall::try_from_str("error")?;
+            let contract_id = self.get_current_contract_id_opt_internal()?;
+            Vec::<InternalDiagnosticArg>::charge_bulk_init_cpy(2, self)?;
+            let topics = vec![
+                InternalDiagnosticArg::HostVal(error_sym.to_val()),
+                InternalDiagnosticArg::HostVal(error.to_val()),
+            ];
+            let msg = ScVal::String(ScString::from(StringM::try_from(
+                self.metered_slice_to_vec(msg.as_bytes())?,
+            )?));
+            let args: Vec<_> = std::iter::once(InternalDiagnosticArg::XdrVal(msg))
+                .chain(args.iter().map(|rv| InternalDiagnosticArg::HostVal(*rv)))
+                .metered_collect(self)?;
 
-                // We do the event-recording ourselves here rather than calling
-                // self.record_system_debug_contract_event because we can/should
-                // only be called with an already-borrowed events buffer (to
-                // insulate against double-faulting).
-                let ce = Rc::metered_new(
-                    InternalDiagnosticEvent {
-                        contract_id,
-                        topics,
-                        args,
-                    },
-                    self,
-                )?;
-                events.record(InternalEvent::Diagnostic(ce), self)
-            },
-            || (),
-        )
+            // We do the event-recording ourselves here rather than calling
+            // self.record_system_debug_contract_event because we can/should
+            // only be called with an already-borrowed events buffer (to
+            // insulate against double-faulting).
+            let ce = Rc::metered_new(
+                InternalDiagnosticEvent {
+                    contract_id,
+                    topics,
+                    args,
+                },
+                self,
+            )?;
+            events.record(InternalEvent::Diagnostic(ce), self)
+        })
     }
 
     // Emits an event with topic = ["fn_call", called_contract_id, function_name] and
     // data = [arg1, args2, ...]
     // Should called prior to opening a frame for the next call so the calling contract can be inferred correctly
     pub fn fn_call_diagnostics(&self, called_contract_id: &Hash, func: &Symbol, args: &[Val]) {
-        self.with_debug_mode(
-            || {
-                let calling_contract = self.get_current_contract_id_opt_internal()?;
-                Vec::<InternalDiagnosticArg>::charge_bulk_init_cpy(3, self)?;
-                let topics = vec![
-                    InternalDiagnosticArg::HostVal(SymbolSmall::try_from_str("fn_call")?.into()),
-                    InternalDiagnosticArg::XdrVal(ScVal::Bytes(ScBytes::try_from(
-                        self.metered_slice_to_vec(called_contract_id.as_slice())?,
-                    )?)),
-                    InternalDiagnosticArg::HostVal(func.into()),
-                ];
-                let args = args
-                    .iter()
-                    .map(|rv| InternalDiagnosticArg::HostVal(*rv))
-                    .metered_collect(self)?;
-                self.record_diagnostic_event(calling_contract, topics, args)
-            },
-            || (),
-        )
+        self.with_debug_mode(|| {
+            let calling_contract = self.get_current_contract_id_opt_internal()?;
+            Vec::<InternalDiagnosticArg>::charge_bulk_init_cpy(3, self)?;
+            let topics = vec![
+                InternalDiagnosticArg::HostVal(SymbolSmall::try_from_str("fn_call")?.into()),
+                InternalDiagnosticArg::XdrVal(ScVal::Bytes(ScBytes::try_from(
+                    self.metered_slice_to_vec(called_contract_id.as_slice())?,
+                )?)),
+                InternalDiagnosticArg::HostVal(func.into()),
+            ];
+            let args = args
+                .iter()
+                .map(|rv| InternalDiagnosticArg::HostVal(*rv))
+                .metered_collect(self)?;
+            self.record_diagnostic_event(calling_contract, topics, args)
+        })
     }
 
     // Emits an event with topic = ["fn_return", function_name] and
     // data = [return_val]
     pub fn fn_return_diagnostics(&self, contract_id: &Hash, func: &Symbol, res: &Val) {
-        self.with_debug_mode(
-            || {
-                Vec::<InternalDiagnosticArg>::charge_bulk_init_cpy(2, self)?;
-                let topics = vec![
-                    InternalDiagnosticArg::HostVal(SymbolSmall::try_from_str("fn_return")?.into()),
-                    InternalDiagnosticArg::HostVal(func.into()),
-                ];
-                Vec::<InternalDiagnosticArg>::charge_bulk_init_cpy(1, self)?;
-                let args = vec![InternalDiagnosticArg::HostVal(*res)];
-                self.record_diagnostic_event(Some(contract_id.metered_clone(self)?), topics, args)
-            },
-            || (),
-        )
+        self.with_debug_mode(|| {
+            Vec::<InternalDiagnosticArg>::charge_bulk_init_cpy(2, self)?;
+            let topics = vec![
+                InternalDiagnosticArg::HostVal(SymbolSmall::try_from_str("fn_return")?.into()),
+                InternalDiagnosticArg::HostVal(func.into()),
+            ];
+            Vec::<InternalDiagnosticArg>::charge_bulk_init_cpy(1, self)?;
+            let args = vec![InternalDiagnosticArg::HostVal(*res)];
+            self.record_diagnostic_event(Some(contract_id.metered_clone(self)?), topics, args)
+        })
     }
 }

--- a/soroban-env-host/src/events/internal.rs
+++ b/soroban-env-host/src/events/internal.rs
@@ -159,9 +159,7 @@ impl InternalEventsBuffer {
 
         match &e {
             InternalEvent::Contract(_) => metered_internal_event_push(e)?,
-            InternalEvent::Diagnostic(_) => {
-                host.with_debug_mode(|| metered_internal_event_push(e), || ())
-            }
+            InternalEvent::Diagnostic(_) => host.with_debug_mode(|| metered_internal_event_push(e)),
         }
 
         Ok(())
@@ -211,10 +209,7 @@ impl InternalEventsBuffer {
                     metered_external_event_push(c.to_xdr(host)?, status)?;
                 }
                 InternalEvent::Diagnostic(d) => {
-                    host.with_debug_mode(
-                        || metered_external_event_push(d.to_xdr(host)?, status),
-                        || (),
-                    );
+                    host.with_debug_mode(|| metered_external_event_push(d.to_xdr(host)?, status));
                 }
             }
         }

--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -113,6 +113,11 @@ struct HostImpl {
     budget: Budget,
     events: RefCell<InternalEventsBuffer>,
     authorization_manager: RefCell<AuthorizationManager>,
+    // Note: to reduce the risk of future maintainers accidentally adding a new
+    // way of observing the diagnostic level (which may vary between different
+    // replicas of the host, thus causing divergence) there are no borrow
+    // helpers for it and the only method to use it is inside the
+    // `with_debug_mode` callback that switches to the shadow budget.
     diagnostic_level: RefCell<DiagnosticLevel>,
     base_prng: RefCell<Option<Prng>>,
     // Auth-recording mode generates pseudorandom nonces to populate its output.
@@ -222,12 +227,12 @@ impl_checked_borrow_helpers!(
     try_borrow_authorization_manager,
     try_borrow_authorization_manager_mut
 );
-impl_checked_borrow_helpers!(
-    diagnostic_level,
-    DiagnosticLevel,
-    try_borrow_diagnostic_level,
-    try_borrow_diagnostic_level_mut
-);
+
+// Note: diagnostic_mode borrow helpers are _not_ defined here to reduce the
+// risk of future maintainers accidentally revealing any way of observing the
+// diagnostic level in user code (which may vary between different replicas of
+// the host).
+
 impl_checked_borrow_helpers!(
     base_prng,
     Option<Prng>,
@@ -471,19 +476,46 @@ impl Host {
         self.0.budget.set_shadow_limits(cpu, mem)
     }
 
-    /// Wraps the `budget.with_internal_mode` call with the check `host.is_debug`.
-    /// This wrapper should be used for any work that is part of the production
-    /// workflow but in debug mode, i.e. diagnostic related work (logging, or any
-    /// operations on diagnostic event).
-    pub(crate) fn with_debug_mode<T, F, E>(&self, f: F, e: E) -> T
+    pub fn set_diagnostic_level(&self, diagnostic_level: DiagnosticLevel) -> Result<(), HostError> {
+        use crate::host::error::TryBorrowOrErr;
+        *self.0.diagnostic_level.try_borrow_mut_or_err()? = diagnostic_level;
+        Ok(())
+    }
+
+    // As above, avoids having to import DiagnosticLevel.
+    pub fn enable_debug(&self) -> Result<(), HostError> {
+        self.set_diagnostic_level(DiagnosticLevel::Debug)
+    }
+
+    /// Wraps a `budget.with_shadow_mode` call with a check against the
+    /// diagnostic level. This wrapper should be used for any work that is part
+    /// of the production workflow but in debug mode, i.e. diagnostic related
+    /// work (logging, or any operations on diagnostic events).
+    ///
+    /// Note: to help minimize the risk of divergence based on accidental
+    /// observation of the diagnostic level in any context _other_ than this
+    /// callback, we make two things at least inconvenient enough to maybe cause
+    /// people to come to this comment and read it:
+    ///
+    ///   1. We avoid having any other direct way of observing the flag.
+    ///   2. We eat all errors and return no values from the closure.
+    ///
+    /// If you need to observe a value from the execution of debug mode, you can
+    /// of course still mutate a mutable reference pointing outside the closure,
+    /// but be _absolutely certain_ any observation you thereby make of the
+    /// debug-level _only_ flows into other functions that are themselves
+    /// debug-mode-guarded and/or only write results into debug state (eg.
+    /// diagnostic events).
+    pub(crate) fn with_debug_mode<F>(&self, f: F)
     where
-        F: FnOnce() -> Result<T, HostError>,
-        E: Fn() -> T,
+        F: FnOnce() -> Result<(), HostError>,
     {
-        if self.is_debug().ok() != Some(true) {
-            return e();
+        use crate::host::error::TryBorrowOrErr;
+        if let Ok(cell) = self.0.diagnostic_level.try_borrow_or_err() {
+            if matches!(*cell, DiagnosticLevel::Debug) {
+                return self.budget_ref().with_shadow_mode(f);
+            }
         }
-        self.as_budget().with_shadow_mode(f, e)
     }
 
     /// Returns whether the Host can be finished by calling
@@ -778,33 +810,30 @@ impl VmCallerEnv for Host {
         vals_pos: U32Val,
         vals_len: U32Val,
     ) -> Result<Void, HostError> {
-        self.with_debug_mode(
-            || {
-                let VmSlice { vm, pos, len } = self.decode_vmslice(msg_pos, msg_len)?;
-                Vec::<u8>::charge_bulk_init_cpy(len as u64, self)?;
-                let mut msg: Vec<u8> = vec![0u8; len as usize];
-                self.metered_vm_read_bytes_from_linear_memory(vmcaller, &vm, pos, &mut msg)?;
-                // `String::from_utf8_lossy` iternally allocates a `String` which is a `Vec<u8>`
-                Vec::<u8>::charge_bulk_init_cpy(len as u64, self)?;
-                let msg = String::from_utf8_lossy(&msg);
+        self.with_debug_mode(|| {
+            let VmSlice { vm, pos, len } = self.decode_vmslice(msg_pos, msg_len)?;
+            Vec::<u8>::charge_bulk_init_cpy(len as u64, self)?;
+            let mut msg: Vec<u8> = vec![0u8; len as usize];
+            self.metered_vm_read_bytes_from_linear_memory(vmcaller, &vm, pos, &mut msg)?;
+            // `String::from_utf8_lossy` iternally allocates a `String` which is a `Vec<u8>`
+            Vec::<u8>::charge_bulk_init_cpy(len as u64, self)?;
+            let msg = String::from_utf8_lossy(&msg);
 
-                let VmSlice { vm, pos, len } = self.decode_vmslice(vals_pos, vals_len)?;
-                Vec::<Val>::charge_bulk_init_cpy((len.saturating_add(1)) as u64, self)?;
-                let mut vals: Vec<Val> = vec![Val::VOID.to_val(); len as usize];
-                // charge for conversion from bytes to `Val`s
-                self.charge_budget(ContractCostType::MemCpy, Some(len.saturating_mul(8) as u64))?;
-                self.metered_vm_read_vals_from_linear_memory::<8, Val>(
-                    vmcaller,
-                    &vm,
-                    pos,
-                    vals.as_mut_slice(),
-                    |buf| self.relative_to_absolute(Val::from_payload(u64::from_le_bytes(*buf))),
-                )?;
-                self.log_diagnostics(&msg, &vals);
-                Ok(())
-            },
-            || (),
-        );
+            let VmSlice { vm, pos, len } = self.decode_vmslice(vals_pos, vals_len)?;
+            Vec::<Val>::charge_bulk_init_cpy(len.saturating_add(1) as u64, self)?;
+            let mut vals: Vec<Val> = vec![Val::VOID.to_val(); len as usize];
+            // charge for conversion from bytes to `Val`s
+            self.charge_budget(ContractCostType::MemCpy, Some(len.saturating_mul(8) as u64))?;
+            self.metered_vm_read_vals_from_linear_memory::<8, Val>(
+                vmcaller,
+                &vm,
+                pos,
+                vals.as_mut_slice(),
+                |buf| self.relative_to_absolute(Val::from_payload(u64::from_le_bytes(*buf))),
+            )?;
+            self.log_diagnostics(&msg, &vals);
+            Ok(())
+        });
 
         Ok(Val::VOID)
     }

--- a/soroban-env-host/src/test/budget_metering.rs
+++ b/soroban-env-host/src/test/budget_metering.rs
@@ -350,13 +350,10 @@ fn total_amount_charged_from_random_inputs() -> Result<(), HostError> {
     }
 
     for (ty, &(iterations, input)) in tracker.iter().enumerate() {
-        host.as_budget().with_shadow_mode(
-            || {
-                host.as_budget()
-                    .bulk_charge(ContractCostType::VARIANTS[ty], iterations, input)
-            },
-            || (),
-        )
+        host.as_budget().with_shadow_mode(|| {
+            host.as_budget()
+                .bulk_charge(ContractCostType::VARIANTS[ty], iterations, input)
+        })
     }
 
     let actual = format!("{:?}", host.as_budget());


### PR DESCRIPTION
This does a few things @jayz22 and I discussed today:

1. Eliminates the second callback and the value-passing on the shadow and debug mode callbacks in favor of mutating a value outside the closure _when observation is required_. This is not necessarily better, just a little more awkward / less likely to be done accidentally without thinking about it.
2. Removes all convenience accessors for the debug flag, again just to make it harder to accidentally observe.
3. Feature-gates DebugInfo on testutils, so it's never live in production. Note that DebugInfo is _not_ the diagnostic event buffer, it's a snapshot of the buffer along with a (native) backtrace attached to errors that get printed to console in a panic catch, it only makes sense for testing and by eliminating it here we can actually compile _out_ all support for backtraces (including the dwarf-reading crate) from production. Which is just one less pile of software to worry about shipping (this is also good because backtrace is going to be stable in the rust stdlib soon).