### PR TITLE
Clarify (and add redundant defensive code) in check_val_integrity

### DIFF
--- a/soroban-env-host/src/host_object.rs
+++ b/soroban-env-host/src/host_object.rs
@@ -386,7 +386,13 @@ impl Host {
     }
 
     pub(crate) fn check_val_integrity(&self, val: Val) -> Result<(), HostError> {
-        if val.get_tag() == Tag::Bad {
+        // Technically Tag::Bad is the only one that can occur here -- the other
+        // 3 are mapped to it -- but we check for them just in case.
+        if let Tag::Bad
+        | Tag::SmallCodeUpperBound
+        | Tag::ObjectCodeLowerBound
+        | Tag::ObjectCodeUpperBound = val.get_tag()
+        {
             Err(self.err(
                 ScErrorType::Value,
                 ScErrorCode::InvalidInput,


### PR DESCRIPTION
Fix #1135 (the new code here is not actually dynamically reachable but it's harmless to be extra-paranoid)