### PR TITLE
Add @dmkozh as code owner of soroban-env-host

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 
 # Members of contract committers who are on the core team own the host
 # implementation.
-/soroban-env-host/            @graydon @sisuresh
+/soroban-env-host/            @graydon @sisuresh @dmkozh


### PR DESCRIPTION
### What

Add @dmkozh as code owner of `soroban-env-host`.

### Why

So that @dmkozh is mentioned on any PRs that modify the host, in the same way that @graydon and @sisuresh are.