### PR TITLE
Pass ref to host to contract invocation hook

### DIFF
--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -96,7 +96,7 @@ pub enum ContractInvocationEvent {
 }
 
 #[cfg(any(test, feature = "testutils"))]
-pub type ContractInvocationHook = Rc<dyn Fn(ContractInvocationEvent) -> ()>;
+pub type ContractInvocationHook = Rc<dyn for<'a> Fn(&'a Host, ContractInvocationEvent) -> ()>;
 
 #[derive(Clone, Default)]
 struct HostImpl {

--- a/soroban-env-host/src/host/frame.rs
+++ b/soroban-env-host/src/host/frame.rs
@@ -363,6 +363,7 @@ impl Host {
                                 self.try_borrow_top_contract_invocation_hook()?.as_ref()
                             {
                                 contract_invocation_hook(
+                                    self,
                                     crate::host::ContractInvocationEvent::Start,
                                 );
                             }
@@ -470,7 +471,10 @@ impl Host {
                 if let Some(top_contract_invocation_hook) =
                     self.try_borrow_top_contract_invocation_hook()?.as_ref()
                 {
-                    top_contract_invocation_hook(crate::host::ContractInvocationEvent::Finish);
+                    top_contract_invocation_hook(
+                        self,
+                        crate::host::ContractInvocationEvent::Finish,
+                    );
                 }
             }
             // Empty call stack in tests means that some contract function call


### PR DESCRIPTION
### What
Pass ref to host to contract invocation hook.

### Why
So that hook implementations have access to the host without needing to hold a reference to the host via some other means.

This is the pattern used on other hooks in the Host.