### PR TITLE
Fix top contract invocation hook and auth interaction

### DIFF
--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -96,7 +96,7 @@ pub enum ContractInvocationEvent {
 }
 
 #[cfg(any(test, feature = "testutils"))]
-pub type ContractInvocationHook = Rc<dyn Fn(ContractInvocationEvent) -> ()>;
+pub type ContractInvocationHook = Rc<dyn for<'a> Fn(&'a Host, ContractInvocationEvent) -> ()>;
 
 #[derive(Clone, Default)]
 struct HostImpl {

--- a/soroban-env-host/src/host/frame.rs
+++ b/soroban-env-host/src/host/frame.rs
@@ -480,7 +480,10 @@ impl Host {
                 if let Some(top_contract_invocation_hook) =
                     self.try_borrow_top_contract_invocation_hook()?.as_ref()
                 {
-                    top_contract_invocation_hook(self, crate::host::ContractInvocationEvent::Finish);
+                    top_contract_invocation_hook(
+                        self,
+                        crate::host::ContractInvocationEvent::Finish,
+                    );
                 }
             }
         }

--- a/soroban-env-host/src/host/frame.rs
+++ b/soroban-env-host/src/host/frame.rs
@@ -466,17 +466,6 @@ impl Host {
         }
         #[cfg(any(test, feature = "testutils"))]
         if end_depth == 0 {
-            // Call the contract invocation hook for contract invocations only.
-            if is_top_contract_invocation {
-                if let Some(top_contract_invocation_hook) =
-                    self.try_borrow_top_contract_invocation_hook()?.as_ref()
-                {
-                    top_contract_invocation_hook(
-                        self,
-                        crate::host::ContractInvocationEvent::Finish,
-                    );
-                }
-            }
             // Empty call stack in tests means that some contract function call
             // has been finished and hence the authorization manager can be reset.
             // In non-test scenarios, there should be no need to ever reset
@@ -485,6 +474,15 @@ impl Host {
             *self.try_borrow_previous_authorization_manager_mut()? =
                 Some(self.try_borrow_authorization_manager()?.clone());
             self.try_borrow_authorization_manager_mut()?.reset();
+
+            // Call the contract invocation hook for contract invocations only.
+            if is_top_contract_invocation {
+                if let Some(top_contract_invocation_hook) =
+                    self.try_borrow_top_contract_invocation_hook()?.as_ref()
+                {
+                    top_contract_invocation_hook(self, crate::host::ContractInvocationEvent::Finish);
+                }
+            }
         }
         res
     }

--- a/soroban-env-host/src/host/frame.rs
+++ b/soroban-env-host/src/host/frame.rs
@@ -363,6 +363,7 @@ impl Host {
                                 self.try_borrow_top_contract_invocation_hook()?.as_ref()
                             {
                                 contract_invocation_hook(
+                                    self,
                                     crate::host::ContractInvocationEvent::Start,
                                 );
                             }
@@ -470,7 +471,10 @@ impl Host {
                 if let Some(top_contract_invocation_hook) =
                     self.try_borrow_top_contract_invocation_hook()?.as_ref()
                 {
-                    top_contract_invocation_hook(crate::host::ContractInvocationEvent::Finish);
+                    top_contract_invocation_hook(
+                        self,
+                        crate::host::ContractInvocationEvent::Finish,
+                    );
                 }
             }
             // Empty call stack in tests means that some contract function call


### PR DESCRIPTION
### What
Trigger top contract invocation finish hook after storing the auth manager.

### Why
So that hook implementations can access the auth state that occurred during the run.

### Merging
Intended to be merged to `main` after:
- #1230 