### PR TITLE
XDR limits updates

### DIFF
--- a/soroban-env-host/src/host/metered_xdr.rs
+++ b/soroban-env-host/src/host/metered_xdr.rs
@@ -40,7 +40,9 @@ impl Host {
     pub fn metered_from_xdr<T: ReadXdr>(&self, bytes: &[u8]) -> Result<T, HostError> {
         let _span = tracy_span!("read xdr");
         self.charge_budget(ContractCostType::ValDeser, Some(bytes.len() as u64))?;
-        self.map_err(T::from_xdr(bytes, DEFAULT_XDR_RW_LIMITS))
+        let mut limits = DEFAULT_XDR_RW_LIMITS;
+        limits.len = bytes.len();
+        self.map_err(T::from_xdr(bytes, limits))
     }
 
     pub(crate) fn metered_from_xdr_obj<T: ReadXdr>(
@@ -74,5 +76,7 @@ pub fn metered_from_xdr_with_budget<T: ReadXdr>(
 ) -> Result<T, HostError> {
     let _span = tracy_span!("read xdr with budget");
     budget.charge(ContractCostType::ValDeser, Some(bytes.len() as u64))?;
-    T::from_xdr(bytes, DEFAULT_XDR_RW_LIMITS).map_err(|e| e.into())
+    let mut limits = DEFAULT_XDR_RW_LIMITS;
+    limits.len = bytes.len();
+    T::from_xdr(bytes, limits).map_err(|e| e.into())
 }

--- a/soroban-env-host/src/test/depth_limit.rs
+++ b/soroban-env-host/src/test/depth_limit.rs
@@ -114,10 +114,10 @@ fn depth_limited_scval_xdr_serialization() -> Result<(), HostError> {
 
 #[test]
 fn length_limited_scval_xdr_conversion() -> Result<(), HostError> {
-    let buf = vec![0; 200000];
+    let buf = vec![0; 400000];
     let scv_bytes = ScVal::Bytes(buf.try_into().unwrap());
     let mut scv_vec = ScVal::Vec(Some(ScVec(vec![scv_bytes.clone(); 1].try_into().unwrap())));
-    // roughly consumes 20MiB (> 16 MiB the limit)
+    // roughly consumes 40MiB (> 32 MiB the limit)
     for _i in 1..100 {
         let mut v = vec![scv_vec; 1];
         v.push(scv_bytes.clone());

--- a/soroban-env-host/src/vm.rs
+++ b/soroban-env-host/src/vm.rs
@@ -154,7 +154,9 @@ impl Vm {
         // us as well as a protocol that's less than or equal to our protocol.
 
         if let Some(env_meta) = Self::module_custom_section(m, meta::ENV_META_V0_SECTION_NAME) {
-            let mut cursor = Limited::new(Cursor::new(env_meta), DEFAULT_XDR_RW_LIMITS);
+            let mut limits = DEFAULT_XDR_RW_LIMITS;
+            limits.len = env_meta.len();
+            let mut cursor = Limited::new(Cursor::new(env_meta), limits);
             if let Some(env_meta_entry) = ScEnvMetaEntry::read_xdr_iter(&mut cursor).next() {
                 let ScEnvMetaEntry::ScEnvMetaKindInterfaceVersion(v) =
                     host.map_err(env_meta_entry)?;


### PR DESCRIPTION
### What

- Use the input-based limit for the de-serialization (we always know the buffer size before decoding it)
- Increase the default 'width' limit to 32MiB - is is only used for serialization now. Serialization is protected by the budget metering, so there is no need to be too restrictive with the hard limit.

### Why

Improve XDR safety/usability

### Known limitations

N/A
