### PR TITLE
Add size_hint methods to Arbitrary impls

### DIFF
--- a/soroban-env-common/src/arbitrary.rs
+++ b/soroban-env-common/src/arbitrary.rs
@@ -13,11 +13,19 @@ impl<'a> Arbitrary<'a> for Error {
         let error = Error::from(scerror);
         Ok(error)
     }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        <ScError as Arbitrary>::size_hint(depth)
+    }
 }
 
 impl<'a> Arbitrary<'a> for Void {
     fn arbitrary(_u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Val::VOID)
+    }
+
+    fn size_hint(_depth: usize) -> (usize, Option<usize>) {
+        (0, Some(0))
     }
 }
 
@@ -47,5 +55,9 @@ impl<'a> Arbitrary<'a> for StorageType {
             StorageType::Temporary,
         ])
         .map(|x| *x)
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        <usize as Arbitrary>::size_hint(depth)
     }
 }


### PR DESCRIPTION
### What

Add size_hint methods to Arbitrary impls.

### Why

It should make fuzzers more effective at producing arbitrary input, particularly in cases where these types are included in structs or collections.

### Known limitations

Note that the `impl Arbitrary for Symbol` doesn't need an implementation - the default `(0, None)` is appropriate.

Closes https://github.com/stellar/rs-soroban-sdk/issues/1147