### PR TITLE
Tighten up `saturating_` math checks

### DIFF
--- a/soroban-env-host/src/budget/limits.rs
+++ b/soroban-env-host/src/budget/limits.rs
@@ -96,7 +96,9 @@ impl DepthLimiter for BudgetImpl {
     // `leave` should be called in tandem with `enter` such that the depth
     // doesn't exceed the initial depth limit.
     fn leave(&mut self) -> Result<(), HostError> {
-        self.depth_limit = self.depth_limit.saturating_add(1);
+        self.depth_limit = self.depth_limit.checked_add(1).ok_or_else(|| {
+            Error::from_type_and_code(ScErrorType::Value, ScErrorCode::ArithDomain)
+        })?;
         Ok(())
     }
 }

--- a/soroban-env-host/src/budget/limits.rs
+++ b/soroban-env-host/src/budget/limits.rs
@@ -97,7 +97,7 @@ impl DepthLimiter for BudgetImpl {
     // doesn't exceed the initial depth limit.
     fn leave(&mut self) -> Result<(), HostError> {
         self.depth_limit = self.depth_limit.checked_add(1).ok_or_else(|| {
-            Error::from_type_and_code(ScErrorType::Value, ScErrorCode::ArithDomain)
+            Error::from_type_and_code(ScErrorType::Context, ScErrorCode::InternalError)
         })?;
         Ok(())
     }

--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -2426,9 +2426,9 @@ impl VmCallerEnv for Host {
             self.validate_index_lt_bound(i, hv.len())?;
             let mut vnew: Vec<u8> = hv.metered_clone(self)?.into();
             // len > i has been verified above but use checked_sub just in case
-            let n_elts = (hv.len() as u64)
-                .checked_sub(i as u64)
-                .ok_or_else(|| self.err_arith_overflow())?;
+            let n_elts = (hv.len() as u64).checked_sub(i as u64).ok_or_else(|| {
+                Error::from_type_and_code(ScErrorType::Context, ScErrorCode::InternalError)
+            })?;
             // remove elements incurs the cost of moving bytes, it does not incur
             // allocation/deallocation
             metered_clone::charge_shallow_copy::<u8>(n_elts, self)?;

--- a/soroban-env-host/src/host/ledger_info_helper.rs
+++ b/soroban-env-host/src/host/ledger_info_helper.rs
@@ -16,16 +16,18 @@ impl Host {
                 self.with_ledger_info(|li: &LedgerInfo| Ok(li.min_persistent_entry_ttl))?
             }
         };
-        Ok(ledger_seq.saturating_add(min_live_until.saturating_sub(1)))
+        ledger_seq
+            .checked_add(min_live_until.saturating_sub(1))
+            .ok_or_else(|| self.err_arith_overflow())
     }
 
     pub(crate) fn max_live_until_ledger(&self) -> Result<u32, HostError> {
         self.with_ledger_info(|li| {
-            Ok(li
-                .sequence_number
+            li.sequence_number
                 // Entry can live for at most max_entry_live_until ledgers from
                 // now, counting the current one.
-                .saturating_add(li.max_entry_ttl.saturating_sub(1)))
+                .checked_add(li.max_entry_ttl.saturating_sub(1))
+                .ok_or_else(|| self.err_arith_overflow())
         })
     }
 }

--- a/soroban-env-host/src/storage.rs
+++ b/soroban-env-host/src/storage.rs
@@ -9,14 +9,12 @@
 
 use std::rc::Rc;
 
-use soroban_env_common::xdr::{ContractDataDurability, ScErrorCode, ScErrorType};
-use soroban_env_common::{Env, Val};
-
-use crate::budget::Budget;
-use crate::host::ledger_info_helper::get_key_durability;
-use crate::xdr::{LedgerEntry, LedgerKey};
-use crate::Host;
-use crate::{host::metered_map::MeteredOrdMap, HostError};
+use crate::{
+    budget::Budget,
+    host::{ledger_info_helper::get_key_durability, metered_map::MeteredOrdMap},
+    xdr::{ContractDataDurability, LedgerEntry, LedgerKey, ScErrorCode, ScErrorType},
+    Env, Error, Host, HostError, Val,
+};
 
 pub type FootprintMap = MeteredOrdMap<Rc<LedgerKey>, AccessType, Budget>;
 pub type EntryWithLiveUntil = (Rc<LedgerEntry>, Option<u32>);
@@ -423,9 +421,16 @@ impl Storage {
         }
 
         let mut new_live_until = host.with_ledger_info(|li| {
-            li.sequence_number
-                .checked_add(extend_to)
-                .ok_or_else(|| host.err_arith_overflow())
+            li.sequence_number.checked_add(extend_to).ok_or_else(|| {
+                // overflowing here means a misconfiguration of the network (the
+                // ttl is too large), in which case we immediately flag it as an
+                // unrecoverable `InternalError`, even though the source is
+                // external to the host.
+                HostError::from(Error::from_type_and_code(
+                    ScErrorType::Context,
+                    ScErrorCode::InternalError,
+                ))
+            })
         })?;
 
         if new_live_until > host.max_live_until_ledger()? {

--- a/soroban-env-host/src/storage.rs
+++ b/soroban-env-host/src/storage.rs
@@ -422,8 +422,11 @@ impl Storage {
             ));
         }
 
-        let mut new_live_until =
-            host.with_ledger_info(|li| Ok(li.sequence_number.saturating_add(extend_to)))?;
+        let mut new_live_until = host.with_ledger_info(|li| {
+            li.sequence_number
+                .checked_add(extend_to)
+                .ok_or_else(|| host.err_arith_overflow())
+        })?;
 
         if new_live_until > host.max_live_until_ledger()? {
             if let Some(durability) = get_key_durability(&key) {


### PR DESCRIPTION
### What

Resolves #1141 

Several places benefit from changing `saturating_` to `checked_` math:
- `saturating_add(_mul)` on u32, saturation would be within possibility
- Some `saturating_sub` saturation would mean actual error, e.g index out of bound

In both cases, changing to `checked_` version means overflow errors are caught sooner. 

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
