### PR TITLE
Cargo version pinning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,21 +19,21 @@ exclude = ["soroban-test-wasms/wasm-workspace"]
 version = "20.0.0-rc2"
 
 [workspace.dependencies]
-soroban-env-common = { version = "20.0.0-rc2", path = "soroban-env-common", default-features = false }
-soroban-env-guest = { version = "20.0.0-rc2", path = "soroban-env-guest" }
-soroban-env-host = { version = "20.0.0-rc2", path = "soroban-env-host" }
-soroban-env-macros = { version = "20.0.0-rc2", path = "soroban-env-macros" }
-soroban-builtin-sdk-macros = { version = "20.0.0-rc2", path = "soroban-builtin-sdk-macros" }
+soroban-env-common = { version = "=20.0.0-rc2", path = "soroban-env-common", default-features = false }
+soroban-env-guest = { version = "=20.0.0-rc2", path = "soroban-env-guest" }
+soroban-env-host = { version = "=20.0.0-rc2", path = "soroban-env-host" }
+soroban-env-macros = { version = "=20.0.0-rc2", path = "soroban-env-macros" }
+soroban-builtin-sdk-macros = { version = "=20.0.0-rc2", path = "soroban-builtin-sdk-macros" }
 
 [workspace.dependencies.stellar-xdr]
-version = "20.0.0-rc1"
+version = "=20.0.0-rc1"
 git = "https://github.com/stellar/rs-stellar-xdr"
 rev = "d6f8ece2c89809d5e2800b9df64ae60787ee492b"
 default-features = false
 
 [workspace.dependencies.wasmi]
 package = "soroban-wasmi"
-version = "0.31.0-soroban1"
+version = "=0.31.0-soroban1"
 git = "https://github.com/stellar/wasmi"
 rev = "7e63b4c9e08c4163f417d118d81f7ea34789d0be"
 

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 all: build test test-opt
 
 test:
-	cargo hack --each-feature test
+	cargo hack --locked --each-feature test
 
 test-opt:
-	cargo hack --each-feature test --profile test-opt
+	cargo hack --locked --each-feature test --profile test-opt
 
 build:
-	cargo hack --each-feature clippy
-	cargo hack clippy --target wasm32-unknown-unknown
+	cargo hack --locked --each-feature clippy
+	cargo hack --locked clippy --target wasm32-unknown-unknown
 
 # We use "run" to run the soroban-env-host/src/bin/main.rs
 # entrypoint, which both excludes dev-deps (noisy) and
@@ -31,7 +31,7 @@ regenerate-test-wasms:
 	make -C soroban-test-wasms regenerate-test-wasms
 
 reobserve-tests:
-	UPDATE_OBSERVATIONS=1 cargo test -p soroban-env-host --features testutils --profile test-opt
+	UPDATE_OBSERVATIONS=1 cargo test --locked -p soroban-env-host --features testutils --profile test-opt
 
 publish:
 	cargo workspaces publish --all --force '*' --from-git --yes

--- a/soroban-bench-utils/Cargo.toml
+++ b/soroban-bench-utils/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 
 [dependencies]
 soroban-env-common = { workspace = true }
-tracking-allocator = "0.4.0"
+tracking-allocator = "=0.4.0"
 
 [features]
 next = ["soroban-env-common/next"]

--- a/soroban-builtin-sdk-macros/Cargo.toml
+++ b/soroban-builtin-sdk-macros/Cargo.toml
@@ -13,10 +13,10 @@ rust-version = "1.74"
 proc-macro = true
 
 [dependencies]
-syn = {version="2.0",features=["full"]}
-quote = "1.0"
-proc-macro2 = "1.0"
-itertools = "0.11.0"
+syn = {version="=2.0.39",features=["full"]}
+quote = "=1.0.33"
+proc-macro2 = "=1.0.69"
+itertools = "=0.11.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/soroban-env-common/Cargo.toml
+++ b/soroban-env-common/Cargo.toml
@@ -11,25 +11,25 @@ edition = "2021"
 rust-version = "1.74"
 
 [build_dependencies]
-crate-git-revision = "0.0.6"
+crate-git-revision = "=0.0.6"
 
 [dependencies]
 soroban-env-macros = { workspace = true }
 stellar-xdr = { workspace = true, default-features = false, features = [ "curr" ] }
 wasmi = { workspace = true, optional = true }
-serde = { version = "1.0.0", features = ["derive"], optional = true }
-static_assertions = "1.1.0"
-ethnum = "1.5.0"
-arbitrary = { version = "1.3.2", features = ["derive"], optional = true }
-num-traits = {version = "0.2.17", default-features = false}
-num-derive = "0.4.1"
+serde = { version = "=1.0.192", features = ["derive"], optional = true }
+static_assertions = "=1.1.0"
+ethnum = "=1.5.0"
+arbitrary = { version = "=1.3.2", features = ["derive"], optional = true }
+num-traits = {version = "=0.2.17", default-features = false}
+num-derive = "=0.4.1"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 tracy-client = { version = "=0.15.2", features = ["enable", "timer-fallback"], default-features = false, optional = true }
 
 [dev-dependencies]
-num_enum = "0.7.1"
-num-traits = "0.2.17"
+num_enum = "=0.7.1"
+num-traits = "=0.2.17"
 
 [features]
 std = ["stellar-xdr/std", "stellar-xdr/base64"]

--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -15,51 +15,51 @@ build = "build.rs"
 soroban-builtin-sdk-macros = { workspace = true }
 soroban-env-common = { workspace = true, features = ["std", "wasmi"] }
 wasmi = { workspace = true }
-stellar-strkey = "0.0.8"
-static_assertions = "1.1.0"
-sha2 = "0.10.0"
-hex-literal = "0.4.1"
-hmac = "0.12.1"
-ed25519-dalek = {version = "2.0.0", features = ["rand_core"] }
+stellar-strkey = "=0.0.8"
+static_assertions = "=1.1.0"
+sha2 = "=0.10.8"
+hex-literal = "=0.4.1"
+hmac = "=0.12.1"
+ed25519-dalek = {version = "=2.0.0", features = ["rand_core"] }
 # NB: this must match the same rand version used by ed25519-dalek above
-rand = "0.8.5"
+rand = "=0.8.5"
 # NB: this must match the same rand_chacha version used by ed25519-dalek above
-rand_chacha = "0.3.1"
-num-traits = "0.2.17"
-num-integer = "0.1.45"
-num-derive = "0.4.1"
-backtrace = { version = "0.3", optional = true }
-k256 = {version = "0.13.1", features=["ecdsa", "arithmetic"]}
+rand_chacha = "=0.3.1"
+num-traits = "=0.2.17"
+num-integer = "=0.1.45"
+num-derive = "=0.4.1"
+backtrace = { version = "=0.3.69", optional = true }
+k256 = {version = "=0.13.1", features=["ecdsa", "arithmetic"]}
 # NB: getrandom is a transitive dependency of k256 which we're not using directly
 # but we have to specify it here in order to enable its 'js' feature which
 # is needed to build the host for wasm (a rare but supported config).
-getrandom = { version = "0.2", features=["js"] }
-sha3 = "0.10.8"
+getrandom = { version = "=0.2.11", features=["js"] }
+sha3 = "=0.10.8"
 # NB: this must match the same curve25519-dalek version used by ed25519-dalek above
 # used only for calibration
-curve25519-dalek = { version = "4", default-features = false, features = ["digest"]}
+curve25519-dalek = { version = "=4.1.1", default-features = false, features = ["digest"]}
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 tracy-client = { version = "=0.15.2", features = ["enable", "timer-fallback"], default-features = false, optional = true }
 
 [dev-dependencies]
-hex = "0.4.3"
-itertools = "0.11.0"
-tabwriter = "1.3.0"
-thousands = "0.2.0"
+hex = "=0.4.3"
+itertools = "=0.11.0"
+tabwriter = "=1.3.0"
+thousands = "=0.2.0"
 soroban-env-macros = { workspace = true }
 soroban-test-wasms = { package = "soroban-test-wasms", path = "../soroban-test-wasms" }
 soroban-synth-wasm = { package = "soroban-synth-wasm", path = "../soroban-synth-wasm" }
 soroban-bench-utils = { package = "soroban-bench-utils", path = "../soroban-bench-utils" }
-bytes-lit = "0.0.5"
-textplots = "0.8.4"
-wasmprinter = "0.2.72"
-expect-test = "1.4.1"
-more-asserts = "0.3.1"
-linregress = "0.5.3"
-pretty_assertions = "1.4.0"
-backtrace = "0.3"
-serde_json = "1.0.0"
+bytes-lit = "=0.0.5"
+textplots = "=0.8.4"
+wasmprinter = "=0.2.72"
+expect-test = "=1.4.1"
+more-asserts = "=0.3.1"
+linregress = "=0.5.3"
+pretty_assertions = "=1.4.0"
+backtrace = "=0.3.69"
+serde_json = "=1.0.108"
 
 [features]
 testutils = ["soroban-env-common/testutils", "soroban-synth-wasm/testutils", "recording_auth", "dep:backtrace"]

--- a/soroban-env-host/fuzz/Cargo.lock
+++ b/soroban-env-host/fuzz/Cargo.lock
@@ -321,9 +321,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -672,18 +672,18 @@ checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
-version = "1.0.190"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7"
+checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.190"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
+checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -887,9 +887,9 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/soroban-env-host/fuzz/Cargo.toml
+++ b/soroban-env-host/fuzz/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
-libfuzzer-sys = "0.4"
-arbitrary = { version = "1.3.0", features = ["derive"] }
+libfuzzer-sys = "=0.4.7"
+arbitrary = { version = "=1.3.2", features = ["derive"] }
 soroban-env-host = { path = "..", features = ["testutils"]}
 soroban-synth-wasm = { path = "../../soroban-synth-wasm", features = ["testutils"]}
 

--- a/soroban-env-macros/Cargo.toml
+++ b/soroban-env-macros/Cargo.toml
@@ -14,12 +14,12 @@ proc-macro = true
 
 [dependencies]
 stellar-xdr = { workspace = true, features = ["curr", "std"] }
-syn = {version="2.0",features=["full"]}
-quote = "1.0"
-proc-macro2 = "1.0"
-itertools = "0.11.0"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+syn = {version="=2.0.39",features=["full"]}
+quote = "=1.0.33"
+proc-macro2 = "=1.0.69"
+itertools = "=0.11.0"
+serde = { version = "=1.0.192", features = ["derive"] }
+serde_json = "=1.0.108"
 
 [features]
 next = ["stellar-xdr/next"]

--- a/soroban-synth-wasm/Cargo.toml
+++ b/soroban-synth-wasm/Cargo.toml
@@ -11,10 +11,10 @@ rust-version = "1.74"
 publish = false
 
 [dependencies]
-wasm-encoder = "0.36.2"
-wasmparser = "0.116.1"
+wasm-encoder = "=0.36.2"
+wasmparser = "=0.116.1"
 soroban-env-common = { workspace = true }
-arbitrary = { version = "1.3.0", features = ["derive"] }
+arbitrary = { version = "=1.3.2", features = ["derive"] }
 soroban-env-macros = { workspace = true }
 
 [features]
@@ -22,5 +22,5 @@ next = ["soroban-env-common/next"]
 testutils = ["soroban-env-common/testutils"]
 
 [dev-dependencies]
-expect-test = "1.4.1"
-wasmprinter = "0.2.72"
+expect-test = "=1.4.1"
+wasmprinter = "=0.2.72"

--- a/soroban-test-wasms/wasm-workspace/Cargo.toml
+++ b/soroban-test-wasms/wasm-workspace/Cargo.toml
@@ -52,11 +52,11 @@ codegen-units = 1
 lto = true
 
 [workspace.dependencies.soroban-sdk]
-version = "20.0.0-rc2"
+version = "=20.0.0-rc2"
 git = "https://github.com/stellar/rs-soroban-sdk"
 
 [workspace.dependencies.soroban-env-common]
-version = "20.0.0-rc2"
+version = "=20.0.0-rc2"
 git = "https://github.com/stellar/rs-soroban-env"
 
 # Always build from the local instance of env as we need to rebuild test WASMs


### PR DESCRIPTION
This does the env side of #1222 -- there are still core-side things to do but this is a step.

No packages are changed in the main lockfile here, just the one in the fuzzer sub-workspace which was out of sync.