### PR TITLE
Frame code review

### DIFF
--- a/soroban-env-host/src/host/frame.rs
+++ b/soroban-env-host/src/host/frame.rs
@@ -251,7 +251,7 @@ impl Host {
     }
 
     /// Same as [`Self::with_current_frame`] but passes `None` when there is no current
-    /// frame, rather than logging an error.
+    /// frame, rather than failing with an error.
     pub(crate) fn with_current_frame_opt<F, U>(&self, f: F) -> Result<U, HostError>
     where
         F: FnOnce(Option<&Frame>) -> Result<U, HostError>,

--- a/soroban-env-host/src/host/frame.rs
+++ b/soroban-env-host/src/host/frame.rs
@@ -127,8 +127,8 @@ pub(crate) enum Frame {
 impl Host {
     /// Returns if the host currently has a frame on the stack.
     ///
-    /// A frame being on the stack indicates that a contract is currently
-    /// executing.
+    /// A frame being on the stack usually indicates that a contract is currently
+    /// executing, or is in a state just-before or just-after executing.
     pub fn has_frame(&self) -> Result<bool, HostError> {
         self.with_current_frame_opt(|opt| Ok(opt.is_some()))
     }

--- a/soroban-env-host/src/host/frame.rs
+++ b/soroban-env-host/src/host/frame.rs
@@ -826,7 +826,7 @@ impl Host {
     }
 
     // Notes on metering: covered by the called components.
-    fn invoke_function_raw(&self, hf: HostFunction) -> Result<Val, HostError> {
+    fn invoke_function_and_return_val(&self, hf: HostFunction) -> Result<Val, HostError> {
         let hf_type = hf.discriminant();
         match hf {
             HostFunction::InvokeContract(invoke_args) => {
@@ -874,7 +874,7 @@ impl Host {
 
     // Notes on metering: covered by the called components.
     pub fn invoke_function(&self, hf: HostFunction) -> Result<ScVal, HostError> {
-        let rv = self.invoke_function_raw(hf)?;
+        let rv = self.invoke_function_and_return_val(hf)?;
         self.from_host_val(rv)
     }
 

--- a/soroban-env-host/src/host/frame.rs
+++ b/soroban-env-host/src/host/frame.rs
@@ -1,28 +1,23 @@
-use soroban_env_common::{
-    xdr::{ContractIdPreimage, ScAddress, ScContractInstance, ScErrorCode, ScErrorType},
-    AddressObject,
-};
-
 use crate::{
     auth::AuthorizationManagerSnapshot,
     budget::AsBudget,
     err,
+    host::{
+        metered_clone::{MeteredClone, MeteredContainer, MeteredIterator},
+        prng::Prng,
+    },
     storage::{InstanceStorageMap, StorageMap},
-    xdr::{ContractExecutable, Hash, HostFunction, HostFunctionType, ScVal},
-    Error, Host, HostError, Object, Symbol, SymbolStr, TryFromVal, TryIntoVal, Val,
-    DEFAULT_HOST_DEPTH_LIMIT,
+    xdr::{
+        ContractExecutable, ContractIdPreimage, Hash, HostFunction, HostFunctionType, ScAddress,
+        ScContractInstance, ScErrorCode, ScErrorType, ScVal,
+    },
+    AddressObject, Error, Host, HostError, Object, Symbol, SymbolStr, TryFromVal, TryIntoVal, Val,
+    Vm, DEFAULT_HOST_DEPTH_LIMIT,
 };
 
 #[cfg(any(test, feature = "testutils"))]
 use core::cell::RefCell;
 use std::rc::Rc;
-
-use crate::Vm;
-
-use super::{
-    metered_clone::{MeteredClone, MeteredContainer, MeteredIterator},
-    prng::Prng,
-};
 
 /// Determines the re-entry mode for calling a contract.
 pub(crate) enum ContractReentryMode {

--- a/soroban-env-host/src/host/frame.rs
+++ b/soroban-env-host/src/host/frame.rs
@@ -212,7 +212,7 @@ impl Host {
             drop(context_guard);
             Err(self.err(
                 ScErrorType::Context,
-                ScErrorCode::MissingValue,
+                ScErrorCode::InternalError,
                 "no contract running",
                 &[],
             ))
@@ -243,7 +243,7 @@ impl Host {
             drop(context_guard);
             Err(self.err(
                 ScErrorType::Context,
-                ScErrorCode::MissingValue,
+                ScErrorCode::InternalError,
                 "no contract running",
                 &[],
             ))


### PR DESCRIPTION
Mostly minor stuff:
  - Change errors that are really logic errors into InternalError
  - Notice and error in a case a callback overwrites the local PRNG while it's being established (we don't do this anywhere but in the future someone might accidentally)
  - Factor out some common code
  - Rewrite stuff for legibility (especially the reentry-prevention code which was hard to follow)
  - Fix a couple comments and imports

No functional (or at least observable) change.