### PR TITLE
Improve budget tracker

### DIFF
--- a/soroban-env-host/benches/common/measure.rs
+++ b/soroban-env-host/benches/common/measure.rs
@@ -1,7 +1,7 @@
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use soroban_bench_utils::{tracking_allocator::AllocationGroupToken, HostTracker};
 use soroban_env_host::{
-    budget::{AsBudget, COST_MODEL_LIN_TERM_SCALE_BITS},
+    budget::{AsBudget, CostTracker, COST_MODEL_LIN_TERM_SCALE_BITS},
     cost_runner::{CostRunner, CostType},
     Host,
 };
@@ -315,7 +315,7 @@ pub trait HostCostMeasurement: Sized {
         <Self::Runner as CostRunner>::run(host, samples, recycled_samples)
     }
 
-    fn get_tracker(host: &Host) -> (u64, Option<u64>) {
+    fn get_tracker(host: &Host) -> CostTracker {
         <Self::Runner as CostRunner>::get_tracker(host)
     }
 
@@ -361,10 +361,10 @@ where
 
     // Note: the `iterations` here is not same as `RUN_ITERATIONS`. This is the `N` part of the
     // cost model, which is `RUN_ITERATIONS` * "model iterations from the sample"
-    let (iterations, inputs) = HCM::get_tracker(&host);
+    let ct = HCM::get_tracker(&host);
     Measurement {
-        iterations,
-        inputs,
+        iterations: ct.iterations,
+        inputs: ct.inputs,
         cpu_insns,
         mem_bytes,
         time_nsecs,

--- a/soroban-env-host/src/budget/model.rs
+++ b/soroban-env-host/src/budget/model.rs
@@ -38,7 +38,7 @@ pub trait HostCostModel {
 pub const COST_MODEL_LIN_TERM_SCALE_BITS: u32 = 7;
 
 /// A helper type that wraps an u64 to signify the wrapped value have been scaled.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub(crate) struct ScaledU64(pub(crate) u64);
 
 impl ScaledU64 {
@@ -78,7 +78,7 @@ impl Debug for ScaledU64 {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub(crate) struct MeteredCostComponent {
     pub(crate) const_term: u64,
     pub(crate) lin_term: ScaledU64,

--- a/soroban-env-host/src/cost_runner/experimental/ed25519_scalar_mut.rs
+++ b/soroban-env-host/src/cost_runner/experimental/ed25519_scalar_mut.rs
@@ -1,6 +1,9 @@
 use std::hint::black_box;
 
-use crate::cost_runner::{CostRunner, CostType};
+use crate::{
+    budget::CostTracker,
+    cost_runner::{CostRunner, CostType},
+};
 use curve25519_dalek::{edwards, scalar};
 
 use super::ExperimentalCostType;
@@ -32,8 +35,13 @@ impl CostRunner for Ed25519ScalarMulRun {
         black_box(sample)
     }
 
-    fn get_tracker(_host: &crate::Host) -> (u64, Option<u64>) {
-        (Self::RUN_ITERATIONS, None)
+    fn get_tracker(_host: &crate::Host) -> CostTracker {
+        CostTracker {
+            iterations: Self::RUN_ITERATIONS,
+            inputs: None,
+            cpu: 0,
+            mem: 0,
+        }
     }
 
     fn run_baseline_iter(

--- a/soroban-env-host/src/cost_runner/experimental/read_xdr.rs
+++ b/soroban-env-host/src/cost_runner/experimental/read_xdr.rs
@@ -1,7 +1,7 @@
 use std::hint::black_box;
 
 use crate::{
-    budget::AsBudget,
+    budget::{AsBudget, CostTracker},
     cost_runner::{experimental::ExperimentalCostType::ReadXdrByteArray, CostRunner, CostType},
     xdr::{ContractCostType::ValDeser, ScVal},
 };
@@ -32,7 +32,7 @@ impl CostRunner for ReadXdrByteArrayRun {
         black_box((None, sample))
     }
 
-    fn get_tracker(host: &crate::Host) -> (u64, Option<u64>) {
+    fn get_tracker(host: &crate::Host) -> CostTracker {
         // internally this is still charged under `ValDeser`
         host.as_budget().get_tracker(ValDeser).unwrap()
     }

--- a/soroban-env-host/src/cost_runner/runner.rs
+++ b/soroban-env-host/src/cost_runner/runner.rs
@@ -1,5 +1,9 @@
 use super::CostType;
-use crate::{budget::AsBudget, xdr::ContractCostType, Host};
+use crate::{
+    budget::{AsBudget, CostTracker},
+    xdr::ContractCostType,
+    Host,
+};
 use std::hint::black_box;
 
 /// `CostRunner` is an interface to running a host cost entity of a `CostType` (usually a block of
@@ -66,7 +70,7 @@ pub trait CostRunner: Sized {
     /// if overridden, there is a risk of the computed input being diverged from the
     /// actual input from the host's perspective. So use it carefully. This should be
     /// after the `run`, outside of the CPU-and-memory tracking machineary.
-    fn get_tracker(host: &Host) -> (u64, Option<u64>) {
+    fn get_tracker(host: &Host) -> CostTracker {
         match Self::COST_TYPE {
             CostType::Contract(ct) => host.as_budget().get_tracker(ct).unwrap(),
             CostType::Experimental(_) => {

--- a/soroban-env-host/src/test/bytes.rs
+++ b/soroban-env-host/src/test/bytes.rs
@@ -459,7 +459,7 @@ fn instantiate_oversized_bytes_from_slice() -> Result<(), HostError> {
     assert_eq!(
         host.budget_ref()
             .get_tracker(ContractCostType::MemAlloc)?
-            .1
+            .inputs
             .unwrap(),
         42_000_000
     );
@@ -506,14 +506,14 @@ fn instantiate_oversized_bytes_from_linear_memory() -> Result<(), HostError> {
     assert_ge!(
         host.budget_ref()
             .get_tracker(ContractCostType::MemAlloc)?
-            .1
+            .inputs
             .unwrap(),
         480000
     );
     assert_ge!(
         host.budget_ref()
             .get_tracker(ContractCostType::MemCpy)?
-            .1
+            .inputs
             .unwrap(),
         480000
     );

--- a/soroban-env-host/src/test/map.rs
+++ b/soroban-env-host/src/test/map.rs
@@ -455,14 +455,14 @@ fn instantiate_oversized_map_from_linear_memory() -> Result<(), HostError> {
     assert_ge!(
         host.budget_ref()
             .get_tracker(ContractCostType::MemAlloc)?
-            .1
+            .inputs
             .unwrap(),
         480000
     );
     assert_ge!(
         host.budget_ref()
             .get_tracker(ContractCostType::MemCpy)?
-            .1
+            .inputs
             .unwrap(),
         480000
     );

--- a/soroban-env-host/src/test/vec.rs
+++ b/soroban-env-host/src/test/vec.rs
@@ -471,14 +471,14 @@ fn instantiate_oversized_vec_from_linear_memory() -> Result<(), HostError> {
     assert_ge!(
         host.budget_ref()
             .get_tracker(ContractCostType::MemAlloc)?
-            .1
+            .inputs
             .unwrap(),
         480000
     );
     assert_ge!(
         host.budget_ref()
             .get_tracker(ContractCostType::MemCpy)?
-            .1
+            .inputs
             .unwrap(),
         480000
     );


### PR DESCRIPTION
### What

Improve the budget tracker. With a bit code reorg and tightening.
The `BudgetTracker` used to contain the `(iterations, inputs)` pair for each cost type. This PR adds to it the `cpu`, `mem` costs. 

### Why

`get_tracker` can return granular costs which can be filtered/aggregated downstream for better metrics. 

### Known limitations

[TODO or N/A]
