### PR TITLE
Derive debug, eq, ord on CostTracker for SDK

### DIFF
--- a/soroban-env-host/src/budget.rs
+++ b/soroban-env-host/src/budget.rs
@@ -24,7 +24,7 @@ use dimension::{BudgetDimension, IsCpu, IsShadowMode};
 use model::ScaledU64;
 use wasmi_helper::FuelConfig;
 
-#[derive(Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct CostTracker {
     pub iterations: u64,
     pub inputs: Option<u64>,


### PR DESCRIPTION
### What
Derive debug, eq, ord on CostTracker.

### Why
So that the SDK can expose the type and use the type in tests on assertions.