### PR TITLE
Test bad WASMs

### DIFF
--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -49,7 +49,7 @@ tabwriter = "=1.3.0"
 thousands = "=0.2.0"
 soroban-env-macros = { workspace = true }
 soroban-test-wasms = { package = "soroban-test-wasms", path = "../soroban-test-wasms" }
-soroban-synth-wasm = { package = "soroban-synth-wasm", path = "../soroban-synth-wasm" }
+soroban-synth-wasm = { package = "soroban-synth-wasm", path = "../soroban-synth-wasm", features = ["testutils"]}
 soroban-bench-utils = { package = "soroban-bench-utils", path = "../soroban-bench-utils" }
 bytes-lit = "=0.0.5"
 textplots = "=0.8.4"

--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -49,7 +49,7 @@ tabwriter = "=1.3.0"
 thousands = "=0.2.0"
 soroban-env-macros = { workspace = true }
 soroban-test-wasms = { package = "soroban-test-wasms", path = "../soroban-test-wasms" }
-soroban-synth-wasm = { package = "soroban-synth-wasm", path = "../soroban-synth-wasm", features = ["testutils"]}
+soroban-synth-wasm = { package = "soroban-synth-wasm", path = "../soroban-synth-wasm", features = ["adversarial"]}
 soroban-bench-utils = { package = "soroban-bench-utils", path = "../soroban-bench-utils" }
 bytes-lit = "=0.0.5"
 textplots = "=0.8.4"

--- a/soroban-env-host/benches/common/cost_types/wasm_insn_exec.rs
+++ b/soroban-env-host/benches/common/cost_types/wasm_insn_exec.rs
@@ -235,7 +235,7 @@ fn call_indirect(n: u64, _rng: &mut StdRng) -> WasmModule {
     let (mut me, f2) = fe.finish();
     // store in table
     me.define_elems(&[f0, f1, f2]);
-    let ty = me.get_fn_type(Arity(0));
+    let ty = me.get_fn_type(Arity(0), Arity(1));
     // the caller
     fe = me.func(Arity(0), 0);
     for i in 0..n {

--- a/soroban-env-host/src/test/hostile.rs
+++ b/soroban-env-host/src/test/hostile.rs
@@ -849,3 +849,20 @@ fn test_corrupt_custom_section() -> Result<(), HostError> {
 
     Ok(())
 }
+
+#[test]
+fn test_floating_point() -> Result<(), HostError> {
+    let wasm = wasm_util::wasm_module_with_floating_point_ops();
+    let host = Host::test_host_with_recording_footprint();
+    host.enable_debug()?;
+    let res = host.register_test_contract_wasm_from_source_account(
+        wasm.as_slice(),
+        generate_account_id(&host),
+        generate_bytes_array(&host),
+    );
+    assert!(HostError::result_matches_err(
+        res,
+        (ScErrorType::WasmVm, ScErrorCode::InvalidAction)
+    ));
+    Ok(())
+}

--- a/soroban-env-host/src/test/hostile.rs
+++ b/soroban-env-host/src/test/hostile.rs
@@ -4,9 +4,13 @@ use soroban_test_wasms::HOSTILE;
 use crate::{
     budget::{AsBudget, Budget},
     host_object::HostVec,
+    meta,
     storage::Storage,
-    testutils::wasm as wasm_util,
-    xdr::{AccountId, ContractCostType, PublicKey, ScErrorCode, ScErrorType, Uint256},
+    testutils::{generate_account_id, generate_bytes_array, wasm as wasm_util},
+    xdr::{
+        AccountId, ContractCostType, Limited, Limits, PublicKey, ScEnvMetaEntry, ScErrorCode,
+        ScErrorType, Uint256, WriteXdr,
+    },
     DiagnosticLevel, Env, EnvBase, Error, Host, HostError, Symbol, SymbolSmall, Tag, Val,
     VecObject,
 };
@@ -737,5 +741,111 @@ fn test_integer_overflow() -> Result<(), HostError> {
         res,
         (ScErrorType::WasmVm, ScErrorCode::ArithDomain)
     ));
+    Ok(())
+}
+
+#[test]
+fn test_corrupt_custom_section() -> Result<(), HostError> {
+    // let wasm = wasm_util::wasm_module_with_custom_section("custom", vec![24; 7].as_slice());
+    let host = Host::test_host_with_recording_footprint();
+    host.enable_debug()?;
+    host.as_budget().reset_unlimited()?;
+
+    // empty custom section
+    let res = host.register_test_contract_wasm_from_source_account(
+        &wasm_util::empty_wasm_module().as_slice(),
+        generate_account_id(&host),
+        generate_bytes_array(&host),
+    );
+    assert!(HostError::result_matches_err(
+        res,
+        (ScErrorType::WasmVm, ScErrorCode::InvalidInput)
+    ));
+
+    // some random custom section
+    let res = host.register_test_contract_wasm_from_source_account(
+        wasm_util::wasm_module_with_custom_section("custom", vec![24; 7].as_slice()).as_slice(),
+        generate_account_id(&host),
+        generate_bytes_array(&host),
+    );
+    assert!(HostError::result_matches_err(
+        res,
+        (ScErrorType::WasmVm, ScErrorCode::InvalidInput)
+    ));
+
+    // invalid section name
+    let res = host.register_test_contract_wasm_from_source_account(
+        wasm_util::wasm_module_with_custom_section(
+            "contractenvmetav1",
+            &soroban_env_common::meta::XDR,
+        )
+        .as_slice(),
+        generate_account_id(&host),
+        generate_bytes_array(&host),
+    );
+    assert!(HostError::result_matches_err(
+        res,
+        (ScErrorType::WasmVm, ScErrorCode::InvalidInput)
+    ));
+
+    let ledger_protocol = meta::get_ledger_protocol_version(meta::INTERFACE_VERSION);
+    let ledger_pre = meta::get_ledger_protocol_version(meta::INTERFACE_VERSION);
+
+    let interface_meta = |proto: u32, pre: u32| -> Vec<u8> {
+        let iv = (proto as u64) << 32 | pre as u64;
+        let entry = ScEnvMetaEntry::ScEnvMetaKindInterfaceVersion(iv);
+        let bytes = Vec::<u8>::new();
+        let mut w = Limited::new(bytes, Limits::none());
+        entry.write_xdr(&mut w).unwrap();
+        w.inner
+    };
+
+    // invalid: protocol is future
+    let res = host.register_test_contract_wasm_from_source_account(
+        wasm_util::wasm_module_with_custom_section(
+            "contractenvmetav0",
+            interface_meta(ledger_protocol + 1, ledger_pre).as_slice(),
+        )
+        .as_slice(),
+        generate_account_id(&host),
+        generate_bytes_array(&host),
+    );
+    assert!(HostError::result_matches_err(
+        res,
+        (ScErrorType::WasmVm, ScErrorCode::InvalidInput)
+    ));
+
+    if cfg!(not(feature = "next")) {
+        // invalid: protocol is old but pre-release version is non-zero
+        let res = host.register_test_contract_wasm_from_source_account(
+            wasm_util::wasm_module_with_custom_section(
+                "contractenvmetav0",
+                interface_meta(ledger_protocol - 1, 1).as_slice(),
+            )
+            .as_slice(),
+            generate_account_id(&host),
+            generate_bytes_array(&host),
+        );
+        assert!(HostError::result_matches_err(
+            res,
+            (ScErrorType::WasmVm, ScErrorCode::InvalidInput)
+        ));
+
+        // invalid: protocol is current but pre-release version doesn't match env's
+        let res = host.register_test_contract_wasm_from_source_account(
+            wasm_util::wasm_module_with_custom_section(
+                "contractenvmetav0",
+                interface_meta(ledger_protocol, ledger_pre + 1).as_slice(),
+            )
+            .as_slice(),
+            generate_account_id(&host),
+            generate_bytes_array(&host),
+        );
+        assert!(HostError::result_matches_err(
+            res,
+            (ScErrorType::WasmVm, ScErrorCode::InvalidInput)
+        ));
+    }
+
     Ok(())
 }

--- a/soroban-env-host/src/test/hostile.rs
+++ b/soroban-env-host/src/test/hostile.rs
@@ -1064,3 +1064,88 @@ fn test_multi_value() -> Result<(), HostError> {
     ));
     Ok(())
 }
+
+#[test]
+fn test_large_wasm_code() -> Result<(), HostError> {
+    let host = Host::test_host_with_recording_footprint();
+
+    let wasm = wasm_util::wasm_module_with_4n_insns(100000);
+    let res = host.register_test_contract_wasm_from_source_account(
+        wasm.as_slice(),
+        generate_account_id(&host),
+        generate_bytes_array(&host),
+    );
+    assert!(HostError::result_matches_err(
+        res,
+        (ScErrorType::Budget, ScErrorCode::ExceededLimit)
+    ));
+    Ok(())
+}
+
+#[test]
+fn test_large_number_of_internal_funcs() -> Result<(), HostError> {
+    let host = Host::test_host_with_recording_footprint();
+
+    let wasm = wasm_util::wasm_module_with_n_funcs_no_export(100000);
+    let res = host.register_test_contract_wasm_from_source_account(
+        wasm.as_slice(),
+        generate_account_id(&host),
+        generate_bytes_array(&host),
+    );
+    assert!(HostError::result_matches_err(
+        res,
+        (ScErrorType::Budget, ScErrorCode::ExceededLimit)
+    ));
+    Ok(())
+}
+
+#[test]
+fn test_repeated_export_same_func() -> Result<(), HostError> {
+    let host = Host::test_host_with_recording_footprint();
+
+    // the export limit in wasmparser is 100000, although that doesn't appear in
+    // the WASM spec (or I couldn't find it), and wasmi doesn't have that limit either
+    let wasm = wasm_util::wasm_module_with_repeated_exporting_the_same_func(100001);
+    let res = host.register_test_contract_wasm_from_source_account(
+        wasm.as_slice(),
+        generate_account_id(&host),
+        generate_bytes_array(&host),
+    );
+    assert!(HostError::result_matches_err(
+        res,
+        (ScErrorType::Budget, ScErrorCode::ExceededLimit)
+    ));
+    Ok(())
+}
+
+#[test]
+fn test_large_elements() -> Result<(), HostError> {
+    let host = Host::test_host_with_recording_footprint();
+    let wasm = wasm_util::wasm_module_large_elements(100001);
+    let res = host.register_test_contract_wasm_from_source_account(
+        wasm.as_slice(),
+        generate_account_id(&host),
+        generate_bytes_array(&host),
+    );
+    assert!(HostError::result_matches_err(
+        res,
+        (ScErrorType::Budget, ScErrorCode::ExceededLimit)
+    ));
+    Ok(())
+}
+
+#[test]
+fn test_large_globals() -> Result<(), HostError> {
+    let host = Host::test_host_with_recording_footprint();
+    let wasm = wasm_util::wasm_module_large_globals(100001);
+    let res = host.register_test_contract_wasm_from_source_account(
+        wasm.as_slice(),
+        generate_account_id(&host),
+        generate_bytes_array(&host),
+    );
+    assert!(HostError::result_matches_err(
+        res,
+        (ScErrorType::Budget, ScErrorCode::ExceededLimit)
+    ));
+    Ok(())
+}

--- a/soroban-env-host/src/test/hostile.rs
+++ b/soroban-env-host/src/test/hostile.rs
@@ -1045,3 +1045,22 @@ fn test_lying_about_data_count() -> Result<(), HostError> {
     ));
     Ok(())
 }
+
+#[test]
+fn test_multi_value() -> Result<(), HostError> {
+    let host = Host::test_host_with_recording_footprint();
+    host.enable_debug()?;
+
+    // lying about the count
+    let wasm_bad = wasm_util::wasm_module_with_multi_value();
+    let res = host.register_test_contract_wasm_from_source_account(
+        wasm_bad.as_slice(),
+        generate_account_id(&host),
+        generate_bytes_array(&host),
+    );
+    assert!(HostError::result_matches_err(
+        res,
+        (ScErrorType::WasmVm, ScErrorCode::InvalidAction)
+    ));
+    Ok(())
+}

--- a/soroban-env-host/src/test/hostile.rs
+++ b/soroban-env-host/src/test/hostile.rs
@@ -944,3 +944,20 @@ fn test_duplicate_function_import() -> Result<(), HostError> {
     ));
     Ok(())
 }
+
+#[test]
+fn test_export_nonexistent_function() -> Result<(), HostError> {
+    let wasm = wasm_util::wasm_module_with_nonexistent_function_export();
+    let host = Host::test_host_with_recording_footprint();
+    host.enable_debug()?;
+    let res = host.register_test_contract_wasm_from_source_account(
+        wasm.as_slice(),
+        generate_account_id(&host),
+        generate_bytes_array(&host),
+    );
+    assert!(HostError::result_matches_err(
+        res,
+        (ScErrorType::WasmVm, ScErrorCode::InvalidAction)
+    ));
+    Ok(())
+}

--- a/soroban-env-host/src/test/hostile.rs
+++ b/soroban-env-host/src/test/hostile.rs
@@ -866,3 +866,20 @@ fn test_floating_point() -> Result<(), HostError> {
     ));
     Ok(())
 }
+
+#[test]
+fn test_multiple_memory() -> Result<(), HostError> {
+    let wasm = wasm_util::wasm_module_with_multiple_memories();
+    let host = Host::test_host_with_recording_footprint();
+    host.enable_debug()?;
+    let res = host.register_test_contract_wasm_from_source_account(
+        wasm.as_slice(),
+        generate_account_id(&host),
+        generate_bytes_array(&host),
+    );
+    assert!(HostError::result_matches_err(
+        res,
+        (ScErrorType::WasmVm, ScErrorCode::InvalidAction)
+    ));
+    Ok(())
+}

--- a/soroban-env-host/src/test/hostile.rs
+++ b/soroban-env-host/src/test/hostile.rs
@@ -961,3 +961,41 @@ fn test_export_nonexistent_function() -> Result<(), HostError> {
     ));
     Ok(())
 }
+
+#[test]
+fn test_nonexistent_func_element() -> Result<(), HostError> {
+    let wasm = wasm_util::wasm_module_with_nonexistent_func_element();
+    let host = Host::test_host_with_recording_footprint();
+    host.enable_debug()?;
+    let res = host.register_test_contract_wasm_from_source_account(
+        wasm.as_slice(),
+        generate_account_id(&host),
+        generate_bytes_array(&host),
+    );
+    assert!(HostError::result_matches_err(
+        res,
+        (ScErrorType::WasmVm, ScErrorCode::InvalidAction)
+    ));
+    Ok(())
+}
+
+#[test]
+fn test_no_start() -> Result<(), HostError> {
+    let wasm = wasm_util::wasm_module_with_start_function();
+    let printed = wasmprinter::print_bytes(wasm.clone()).unwrap();
+    println!("{}", printed);
+
+    let host = Host::test_host_with_recording_footprint();
+    host.enable_debug()?;
+    let res = host.register_test_contract_wasm_from_source_account(
+        wasm.as_slice(),
+        generate_account_id(&host),
+        generate_bytes_array(&host),
+    );
+    println!("{:?}", res);
+    assert!(HostError::result_matches_err(
+        res,
+        (ScErrorType::WasmVm, ScErrorCode::InvalidAction)
+    ));
+    Ok(())
+}

--- a/soroban-env-host/src/test/post_mvp.rs
+++ b/soroban-env-host/src/test/post_mvp.rs
@@ -1,32 +1,8 @@
-use crate::{Env, EnvBase, Host, HostError, Symbol, Tag, TryFromVal};
-use soroban_synth_wasm::{Arity, ModEmitter};
-
-// Emit a wasm module that uses post-MVP WASM features. Specifically
-// mutable-globals and sign-ext.
-fn post_mvp_wasm_module() -> Vec<u8> {
-    let mut me = ModEmitter::default();
-
-    // Emit an exported mutable global
-    me.define_global_i64(-100, true, Some("global"));
-
-    let mut fe = me.func(Arity(0), 0);
-    fe.i64_const(0x0000_0000_ffff_abcd_u64 as i64);
-
-    // Emit an op from the new sign-ext repertoire
-    fe.i64_extend32s();
-
-    // Turn this into a I64Small
-    fe.i64_const(8);
-    fe.i64_shl();
-    fe.i64_const(Tag::I64Small as i64);
-    fe.i64_or();
-
-    fe.finish_and_export("test").finish()
-}
+use crate::{testutils::wasm, Env, EnvBase, Host, HostError, Symbol, TryFromVal};
 
 #[test]
 fn test_enabled_post_mvp_features() -> Result<(), HostError> {
-    let wasm = post_mvp_wasm_module();
+    let wasm = wasm::post_mvp_wasm_module();
     let host = observe_host!(Host::test_host_with_recording_footprint());
     host.enable_debug()?;
     let addr = host.register_test_contract_wasm(wasm.as_slice());

--- a/soroban-env-host/src/testutils.rs
+++ b/soroban-env-host/src/testutils.rs
@@ -623,4 +623,11 @@ pub(crate) mod wasm {
         fe.push(Symbol::try_from_small_str("pass").unwrap());
         fe.finish_and_export("test").finish()
     }
+
+    pub fn wasm_module_with_multiple_memories() -> Vec<u8> {
+        let mut me = ModEmitter::new();
+        me.memory(1, None, false, false);
+        me.memory(1, None, false, false);
+        me.finish()
+    }
 }

--- a/soroban-env-host/src/testutils.rs
+++ b/soroban-env-host/src/testutils.rs
@@ -630,4 +630,26 @@ pub(crate) mod wasm {
         me.memory(1, None, false, false);
         me.finish()
     }
+
+    pub fn wasm_module_lying_about_import_function_type() -> Vec<u8> {
+        let mut me = ModEmitter::default();
+        // function {"t", "_"} is "dummy0", taking 0 arguments
+        // this will not pass the wasmi linker
+        me.import_func("t", "_", Arity(1));
+        me.finish()
+    }
+
+    pub fn wasm_module_importing_nonexistent_function() -> Vec<u8> {
+        let mut me = ModEmitter::default();
+        me.import_func("t", "z", Arity(1));
+        me.finish()
+    }
+
+    pub fn wasm_module_with_duplicate_function_import(n: u32) -> Vec<u8> {
+        let mut me = ModEmitter::default();
+        for _ in 0..n {
+            me.import_func_no_check("t", "_", Arity(0));
+        }
+        me.finish()
+    }
 }

--- a/soroban-env-host/src/testutils.rs
+++ b/soroban-env-host/src/testutils.rs
@@ -714,4 +714,12 @@ pub(crate) mod wasm {
         me.start(fid);
         me.finish_no_validate()
     }
+
+    pub(crate) fn wasm_module_with_multi_value() -> Vec<u8> {
+        let me = ModEmitter::default();
+        let mut fe = me.func_with_arity_and_ret(Arity(0), Arity(2), 0);
+        fe.push(Symbol::try_from_small_str("pass1").unwrap());
+        fe.push(Symbol::try_from_small_str("pass2").unwrap());
+        fe.finish_and_export("test").finish()
+    }
 }

--- a/soroban-env-host/src/testutils.rs
+++ b/soroban-env-host/src/testutils.rs
@@ -612,4 +612,15 @@ pub(crate) mod wasm {
         me.custom_section(name, data);
         me.finish()
     }
+
+    pub fn wasm_module_with_floating_point_ops() -> Vec<u8> {
+        let me = ModEmitter::default();
+        let mut fe = me.func(Arity(0), 0);
+        fe.f64_const(1.1f64);
+        fe.f64_const(2.2f64);
+        fe.f64_add();
+        fe.drop();
+        fe.push(Symbol::try_from_small_str("pass").unwrap());
+        fe.finish_and_export("test").finish()
+    }
 }

--- a/soroban-env-host/src/testutils.rs
+++ b/soroban-env-host/src/testutils.rs
@@ -602,4 +602,14 @@ pub(crate) mod wasm {
 
         fe.finish_and_export("test").finish()
     }
+
+    pub fn empty_wasm_module() -> Vec<u8> {
+        ModEmitter::new().finish()
+    }
+
+    pub fn wasm_module_with_custom_section(name: &str, data: &[u8]) -> Vec<u8> {
+        let mut me = ModEmitter::new();
+        me.custom_section(name, data);
+        me.finish()
+    }
 }

--- a/soroban-synth-wasm/Cargo.toml
+++ b/soroban-synth-wasm/Cargo.toml
@@ -20,6 +20,7 @@ soroban-env-macros = { workspace = true }
 [features]
 next = ["soroban-env-common/next"]
 testutils = ["soroban-env-common/testutils"]
+adversarial = []
 
 [dev-dependencies]
 expect-test = "=1.4.1"

--- a/soroban-synth-wasm/src/func_emitter.rs
+++ b/soroban-synth-wasm/src/func_emitter.rs
@@ -250,15 +250,6 @@ impl FuncEmitter {
         self.insn(&insn)
     }
 
-    /// Emit an [`Instruction::I64Const`]
-    pub fn i64_const(&mut self, i: i64) -> &mut Self {
-        self.insn(&Instruction::I64Const(i))
-    }
-    /// Emit an [`Instruction::I32Const`]
-    pub fn i32_const(&mut self, i: i32) -> &mut Self {
-        self.insn(&Instruction::I32Const(i))
-    }
-
     /// Emit an [`Instruction::If`], call `t(self)`, then emit
     /// an [`Instruction::End`].
     pub fn if_then<THEN>(&mut self, t: THEN) -> &mut Self
@@ -389,7 +380,28 @@ variable_insn!(
     (global_set, GlobalSet, GlobalRef)
 );
 
-macro_rules! i64_mem_insn {
+macro_rules! consts {
+    ( $(($func_name: ident, $insn: ident, $ty: ty)),* )
+    =>
+    {
+        impl FuncEmitter {
+        $(
+            pub fn $func_name(&mut self, i: $ty,
+            ) -> &mut Self {
+                self.insn(&Instruction::$insn(i))
+            }
+        )*
+        }
+    }
+}
+consts!(
+    (i64_const, I64Const, i64),
+    (i32_const, I32Const, i32),
+    // forbidden instructions
+    (f64_const, F64Const, f64)
+);
+
+macro_rules! store_load {
     ( $(($func_name: ident, $insn: ident)),* )
     =>
     {
@@ -408,7 +420,7 @@ macro_rules! i64_mem_insn {
         }
     }
 }
-i64_mem_insn!(
+store_load!(
     (i64_store, I64Store),
     (i64_load, I64Load),
     (i64_load8_s, I64Load8S),
@@ -416,7 +428,10 @@ i64_mem_insn!(
     (i64_load32_s, I64Load32S),
     (i64_store8, I64Store8),
     (i64_store16, I64Store16),
-    (i64_store32, I64Store32)
+    (i64_store32, I64Store32),
+    (f64_load, F64Load),
+    // forbidden instructions
+    (f64_store, F64Store)
 );
 
 macro_rules! numeric_insn {
@@ -464,5 +479,10 @@ numeric_insn!(
     (i64_rotl, I64Rotl),
     (i64_rotr, I64Rotr),
     // post-MVP instructions
-    (i64_extend32s, I64Extend32S)
+    (i64_extend32s, I64Extend32S),
+    // forbidden instructions
+    (f64_add, F64Add),
+    (f64_sub, F64Sub),
+    (f64_mul, F64Mul),
+    (f64_div, F64Div)
 );

--- a/soroban-synth-wasm/src/func_emitter.rs
+++ b/soroban-synth-wasm/src/func_emitter.rs
@@ -108,6 +108,7 @@ impl From<ScError> for Operand {
 pub struct FuncEmitter {
     pub(crate) mod_emit: ModEmitter,
     pub(crate) arity: Arity,
+    pub(crate) ret: Arity,
     pub(crate) func: Function,
 
     /// A vector of [`LocalRef`]s that cover the arguments to the function. If
@@ -143,7 +144,7 @@ impl FuncEmitter {
     /// [`FuncEmitter::args`] and [`FuncEmitter::locals`] of [`LocalRef`]s, each
     /// indexing into the arguments and locals. Access these member vectors
     /// directly to get the corresponding [`LocalRef`]s.
-    pub fn new(mod_emit: ModEmitter, arity: Arity, n_locals: u32) -> Self {
+    pub fn new(mod_emit: ModEmitter, arity: Arity, ret: Arity, n_locals: u32) -> Self {
         let func = Function::new([(n_locals, ValType::I64)]);
         let args = (0..arity.0).map(|n| (LocalRef(n), None)).collect();
         let locals = (arity.0..arity.0 + n_locals)
@@ -152,6 +153,7 @@ impl FuncEmitter {
         Self {
             mod_emit,
             arity,
+            ret,
             func,
             args,
             locals,
@@ -326,7 +328,7 @@ impl FuncEmitter {
     /// function.
     pub fn finish(mut self) -> (ModEmitter, FuncRef) {
         self.insn(&Instruction::End);
-        let fid = self.mod_emit.define_func(self.arity, &self.func);
+        let fid = self.mod_emit.define_func(self.arity, self.ret, &self.func);
         (self.mod_emit, fid)
     }
 

--- a/soroban-synth-wasm/src/mod_emitter.rs
+++ b/soroban-synth-wasm/src/mod_emitter.rs
@@ -213,6 +213,16 @@ impl ModEmitter {
         }
     }
 
+
+    #[cfg(feature = "testutils")]
+    pub fn import_func_no_check(&mut self, module: &str, fname: &str, arity: Arity) -> FuncRef {
+        let import_id = FuncRef(self.imports.len());
+        let ty_id = self.get_fn_type(arity);
+        self.imports
+            .import(module, fname, EntityType::Function(ty_id.0));
+        import_id
+    }
+
     /// Define a function in the module with a given arity, adding its code to
     /// the `code` section of the module and declaring it in the `function`
     /// section of the module, and returning a new [`FuncRef`] denoting it.

--- a/soroban-synth-wasm/src/mod_emitter.rs
+++ b/soroban-synth-wasm/src/mod_emitter.rs
@@ -213,7 +213,6 @@ impl ModEmitter {
         }
     }
 
-
     #[cfg(feature = "testutils")]
     pub fn import_func_no_check(&mut self, module: &str, fname: &str, arity: Arity) -> FuncRef {
         let import_id = FuncRef(self.imports.len());
@@ -304,4 +303,40 @@ impl ModEmitter {
             Err(ty) => panic!("invalid WASM module: {:?}", ty.message()),
         }
     }
+
+    #[cfg(feature = "testutils")]
+    pub fn finish_no_validate(mut self) -> Vec<u8> {
+        // NB: these sections must be emitted in this order, by spec.
+        if !self.types.is_empty() {
+            self.module.section(&self.types);
+        }
+        if !self.imports.is_empty() {
+            self.module.section(&self.imports);
+        }
+        if !self.funcs.is_empty() {
+            self.module.section(&self.funcs);
+        }
+        if !self.tables.is_empty() {
+            self.module.section(&self.tables);
+        }
+        if !self.memories.is_empty() {
+            self.module.section(&self.memories);
+        }
+        if !self.globals.is_empty() {
+            self.module.section(&self.globals);
+        }
+        if !self.exports.is_empty() {
+            self.module.section(&self.exports);
+        }
+        if !self.elements.is_empty() {
+            self.module.section(&self.elements);
+        }
+        if !self.codes.is_empty() {
+            self.module.section(&self.codes);
+        }
+        if !self.data.is_empty() {
+            self.module.section(&self.data);
+        }
+        self.module.finish()
+    }    
 }

--- a/soroban-synth-wasm/src/mod_emitter.rs
+++ b/soroban-synth-wasm/src/mod_emitter.rs
@@ -1,6 +1,6 @@
 use crate::FuncEmitter;
 use std::{borrow::Cow, collections::BTreeMap};
-#[cfg(feature = "testutils")]
+#[cfg(feature = "adversarial")]
 use wasm_encoder::StartSection;
 use wasm_encoder::{
     CodeSection, ConstExpr, CustomSection, DataCountSection, DataSection, ElementSection, Elements,
@@ -52,7 +52,7 @@ pub struct ModEmitter {
     memories: MemorySection,
     globals: GlobalSection,
     exports: ExportSection,
-    #[cfg(feature = "testutils")]
+    #[cfg(feature = "adversarial")]
     start: Option<StartSection>,
     elements: ElementSection,
     codes: CodeSection,
@@ -118,7 +118,7 @@ impl ModEmitter {
             memories,
             globals,
             exports,
-            #[cfg(feature = "testutils")]
+            #[cfg(feature = "adversarial")]
             start: None,
             elements,
             codes,
@@ -178,7 +178,7 @@ impl ModEmitter {
         self
     }
 
-    #[cfg(feature = "testutils")]
+    #[cfg(feature = "adversarial")]
     pub fn start(&mut self, fid: FuncRef) -> &mut Self {
         self.start = Some(StartSection {
             function_index: fid.0,
@@ -198,7 +198,7 @@ impl ModEmitter {
         FuncEmitter::new(self, arity, Arity(1), n_locals)
     }
 
-    #[cfg(feature = "testutils")]
+    #[cfg(feature = "adversarial")]
     pub fn func_with_arity_and_ret(self, arity: Arity, ret: Arity, n_locals: u32) -> FuncEmitter {
         FuncEmitter::new(self, arity, ret, n_locals)
     }
@@ -248,7 +248,7 @@ impl ModEmitter {
         }
     }
 
-    #[cfg(feature = "testutils")]
+    #[cfg(feature = "adversarial")]
     pub fn import_func_no_check(&mut self, module: &str, fname: &str, arity: Arity) -> FuncRef {
         let import_id = FuncRef(self.imports.len());
         // import func must have return arity == 1
@@ -343,7 +343,7 @@ impl ModEmitter {
         }
     }
 
-    #[cfg(feature = "testutils")]
+    #[cfg(feature = "adversarial")]
     pub fn finish_no_validate(mut self) -> Vec<u8> {
         // NB: these sections must be emitted in this order, by spec.
         if !self.types.is_empty() {

--- a/soroban-synth-wasm/src/test.rs
+++ b/soroban-synth-wasm/src/test.rs
@@ -136,7 +136,7 @@ fn call_indirect() {
     let (mut me, f2) = fe.finish();
     // store in table
     me.define_elems(&[f0, f1, f2]);
-    let ty = me.get_fn_type(Arity(0));
+    let ty = me.get_fn_type(Arity(0), Arity(1));
     // the caller
     fe = me.func(Arity(1), 0);
     fe.push(Operand::Const32(1));


### PR DESCRIPTION
### What

Parts of #1145 

- [x]  corrupt metadata custom section
- [x]  floating point instructions
- [ ]  SIMD instructions,
- [ ]  other post-MVP extensions
    - [x]  multi-value
- [x]  very large import table that imports the same host functions over and over
- [x]  importing nonexistent host functions
- [x]  multiple memories
- [x]  exporting nonexistent functions
- [ ]  invalid table entries
    - [x]  FuncRef
    - [ ]  ExternRef
- [x]  start functions (these are banned)
- [ ]  invalid const-expressions and active table references in elements table
- [ ]  invalid const-expressions in active data segment mode
- [x]  multiple data-count sections, sections with an invalid count
- [ ]  very large versions of every section type:
    - [x]  `Custom` (not valid)
    - [ ]  `Type`
    - [x]  `Import`
    - [ ]  `Function`
    - [ ]  `Table`
    - [x]  `Memory`
    - [x]  `Global`
    - [x]  `Export`
    - [x]  `Start` (not valid)
    - [x]  `Element`
    - [x]  `Code`
    - [x]  `Data`
    - [x]  `DataCount`