### PR TITLE
Noop auth fix

### DIFF
--- a/soroban-env-host/src/builtin_contracts/stellar_asset_contract/balance.rs
+++ b/soroban-env-host/src/builtin_contracts/stellar_asset_contract/balance.rs
@@ -774,19 +774,14 @@ fn set_trustline_authorization(
         }?;
 
         let is_authorized = tl.flags & (TrustLineFlags::AuthorizedFlag as u32) != 0;
+        if is_authorized == authorize {
+            return Ok(());
+        }
 
         if authorize {
-            if is_authorized {
-                return Ok(());
-            }
-
             tl.flags &= !(TrustLineFlags::AuthorizedToMaintainLiabilitiesFlag as u32);
             tl.flags |= TrustLineFlags::AuthorizedFlag as u32;
         } else {
-            if !is_authorized {
-                return Ok(());
-            }
-
             // Set AuthorizedToMaintainLiabilitiesFlag to indicate deauthorization so
             // offers don't need to get pulled and pool shares don't get redeemed.
             tl.flags &= !(TrustLineFlags::AuthorizedFlag as u32);

--- a/soroban-env-host/src/builtin_contracts/stellar_asset_contract/balance.rs
+++ b/soroban-env-host/src/builtin_contracts/stellar_asset_contract/balance.rs
@@ -808,6 +808,10 @@ fn set_trustline_authorization(
             tl.flags &= !(TrustLineFlags::AuthorizedToMaintainLiabilitiesFlag as u32);
             tl.flags |= TrustLineFlags::AuthorizedFlag as u32;
         } else {
+            if tl.flags & (TrustLineFlags::AuthorizedFlag as u32) == 0 {
+                return Ok(());
+            }
+
             // Set AuthorizedToMaintainLiabilitiesFlag to indicate deauthorization so
             // offers don't need to get pulled and pool shares don't get redeemed.
             tl.flags &= !(TrustLineFlags::AuthorizedFlag as u32);

--- a/soroban-env-host/src/builtin_contracts/stellar_asset_contract/balance.rs
+++ b/soroban-env-host/src/builtin_contracts/stellar_asset_contract/balance.rs
@@ -804,11 +804,17 @@ fn set_trustline_authorization(
             )),
         }?;
 
+        let is_authorized = tl.flags & (TrustLineFlags::AuthorizedFlag as u32) != 0;
+
         if authorize {
+            if is_authorized {
+                return Ok(());
+            }
+
             tl.flags &= !(TrustLineFlags::AuthorizedToMaintainLiabilitiesFlag as u32);
             tl.flags |= TrustLineFlags::AuthorizedFlag as u32;
         } else {
-            if tl.flags & (TrustLineFlags::AuthorizedFlag as u32) == 0 {
+            if !is_authorized {
                 return Ok(());
             }
 


### PR DESCRIPTION
### What

The SAC uses the `AuthorizedToMaintainLiabilitiesFlag` to deauthorize a trustline. If a trustline is completely deauthorized (`AuthorizedFlag` and `AuthorizedToMaintainLiabilitiesFlag` are both not set) and you call the deauthorize function from the SAC on it, the SAC will set `AuthorizedToMaintainLiabilitiesFlag`. This PR makes that scenario (as well as authorizing an authorized trustline) a noop for the auth flag state.
