### PR TITLE
Add time tracker

### DIFF
--- a/soroban-env-host/src/test/invocation.rs
+++ b/soroban-env-host/src/test/invocation.rs
@@ -33,6 +33,13 @@ fn invoke_single_contract_function() -> Result<(), HostError> {
         host.test_vec_obj(&[a, c])?,
     );
     let code = (ScErrorType::WasmVm, ScErrorCode::InvalidAction);
+
+    eprintln!(
+        "time ellapsed in nano-seconds for VmInstantiation: {}",
+        host.as_budget()
+            .get_time(ContractCostType::VmInstantiation)?
+    );
+
     assert!(HostError::result_matches_err(res, code));
     Ok(())
 }


### PR DESCRIPTION
### What

Add a time tracker to the budget. 

### Why

Such that we can track the time spent in individual cost type, notably `VmInstantiation`. 
Combined with the cpu cost per type. We can come up with metrics in the downstream such as "metered cpu per nsecs excluding VM".

### Known limitations

[TODO or N/A]
