### PR TITLE
Bug #1178 - use Timepoint on get_ledger_timestamp

### DIFF
--- a/soroban-env-common/env.json
+++ b/soroban-env-common/env.json
@@ -78,7 +78,7 @@
                     "export": "4",
                     "name": "get_ledger_timestamp",
                     "args": [],
-                    "return": "U64Val",
+                    "return": "TimepointVal",
                     "docs": "Return the timestamp number of the current ledger as a u64."
                 },
                 {

--- a/soroban-env-common/src/env.rs
+++ b/soroban-env-common/src/env.rs
@@ -5,8 +5,8 @@ use crate::Object;
 use super::Symbol;
 use super::{
     AddressObject, Bool, BytesObject, DurationObject, Error, I128Object, I256Object, I256Val,
-    I64Object, MapObject, StorageType, StringObject, SymbolObject, TimepointObject, U128Object,
-    U256Object, U256Val, U32Val, U64Object, U64Val, Val, VecObject, Void,
+    I64Object, MapObject, StorageType, StringObject, SymbolObject, TimepointObject, TimepointVal,
+    U128Object, U256Object, U256Val, U32Val, U64Object, U64Val, Val, VecObject, Void,
 };
 use crate::xdr::{ScErrorCode, ScErrorType};
 
@@ -235,6 +235,7 @@ impl_checkedenvarg_for_val_or_wrapper!(BytesObject);
 impl_checkedenvarg_for_val_or_wrapper!(DurationObject);
 
 impl_checkedenvarg_for_val_or_wrapper!(TimepointObject);
+impl_checkedenvarg_for_val_or_wrapper!(TimepointVal);
 impl_checkedenvarg_for_val_or_wrapper!(SymbolObject);
 impl_checkedenvarg_for_val_or_wrapper!(StringObject);
 

--- a/soroban-env-common/src/vmcaller_env.rs
+++ b/soroban-env-common/src/vmcaller_env.rs
@@ -3,8 +3,8 @@ use crate::xdr::{ScErrorCode, ScErrorType};
 
 use super::{
     AddressObject, Bool, BytesObject, DurationObject, Error, I128Object, I256Object, I256Val,
-    I64Object, MapObject, StorageType, StringObject, SymbolObject, TimepointObject, U128Object,
-    U256Object, U256Val, U32Val, U64Object, U64Val, Val, VecObject, Void,
+    I64Object, MapObject, StorageType, StringObject, SymbolObject, TimepointObject, TimepointVal,
+    U128Object, U256Object, U256Val, U32Val, U64Object, Val, VecObject, Void,
 };
 use crate::call_macro_with_all_host_functions;
 use crate::{CheckedEnvArg, EnvBase, Symbol};

--- a/soroban-env-guest/src/guest.rs
+++ b/soroban-env-guest/src/guest.rs
@@ -4,8 +4,8 @@ use soroban_env_common::call_macro_with_all_host_functions;
 
 use super::{
     AddressObject, Bool, BytesObject, DurationObject, Error, I128Object, I256Object, I256Val,
-    I64Object, MapObject, StorageType, StringObject, SymbolObject, TimepointObject, U128Object,
-    U256Object, U256Val, U32Val, U64Object, U64Val, Val, VecObject, Void,
+    I64Object, MapObject, StorageType, StringObject, SymbolObject, TimepointObject, TimepointVal,
+    U128Object, U256Object, U256Val, U32Val, U64Object, Val, VecObject, Void,
 };
 use super::{Env, EnvBase, Symbol};
 use static_assertions as sa;
@@ -329,7 +329,7 @@ macro_rules! generate_extern_modules {
                 #[allow(unused_imports)]
                 use crate::{Val,Object,Symbol,Error,MapObject,VecObject,BytesObject};
                 #[allow(unused_imports)]
-                use crate::{I128Object, I256Object, I256Val, I64Object, I64Val, U128Object, U256Object, U256Val, U32Val, U64Object, U64Val, StorageType, TimepointObject, DurationObject};
+                use crate::{I128Object, I256Object, I256Val, I64Object, I64Val, U128Object, U256Object, U256Val, U32Val, U64Object, U64Val, StorageType, TimepointObject, TimepointVal, DurationObject};
                 #[allow(unused_imports)]
                 use crate::{Void,AddressObject,SymbolObject,StringObject,Bool};
                 #[link(wasm_import_module = $mod_str)]

--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -18,8 +18,8 @@ use crate::{
     },
     AddressObject, Bool, BytesObject, Compare, ConversionError, EnvBase, Error, I128Object,
     I256Object, MapObject, Object, StorageType, StringObject, Symbol, SymbolObject, SymbolSmall,
-    TryFromVal, U128Object, U256Object, U32Val, U64Val, Val, VecObject, Vm, VmCaller, VmCallerEnv,
-    Void, I256, U256,
+    TimepointVal, TryFromVal, U128Object, U256Object, U32Val, Val, VecObject, Vm, VmCaller,
+    VmCallerEnv, Void, I256, U256,
 };
 
 mod comparison;
@@ -1052,8 +1052,11 @@ impl VmCallerEnv for Host {
         self.with_ledger_info(|li| Ok(li.sequence_number.into()))
     }
 
-    fn get_ledger_timestamp(&self, _vmcaller: &mut VmCaller<Host>) -> Result<U64Val, Self::Error> {
-        self.with_ledger_info(|li| Ok(U64Val::try_from_val(self, &li.timestamp)?))
+    fn get_ledger_timestamp(
+        &self,
+        _vmcaller: &mut VmCaller<Host>,
+    ) -> Result<TimepointVal, Self::Error> {
+        self.with_ledger_info(|li| Ok(TimepointVal::try_from_val(self, &li.timestamp)?))
     }
 
     fn fail_with_error(

--- a/soroban-env-host/src/vm/dispatch.rs
+++ b/soroban-env-host/src/vm/dispatch.rs
@@ -6,7 +6,7 @@ use crate::{
 use crate::{
     AddressObject, Bool, BytesObject, DurationObject, Error, I128Object, I256Object, I256Val,
     I64Object, MapObject, StorageType, StringObject, Symbol, SymbolObject, TimepointObject,
-    U128Object, U256Object, U256Val, U32Val, U64Object, U64Val, Val, VecObject, Void,
+    TimepointVal, U128Object, U256Object, U256Val, U32Val, U64Object, U64Val, Val, VecObject, Void,
 };
 use soroban_env_common::{call_macro_with_all_host_functions, WasmiMarshal};
 use wasmi::{
@@ -61,6 +61,7 @@ impl_relative_object_conversion!(BytesObject);
 impl_relative_object_conversion!(DurationObject);
 
 impl_relative_object_conversion!(TimepointObject);
+impl_relative_object_conversion!(TimepointVal);
 impl_relative_object_conversion!(SymbolObject);
 impl_relative_object_conversion!(StringObject);
 


### PR DESCRIPTION
Fixes #1178 

This would be an env-breaking change if we do later. But it's also not _super_ important? We can paper it over in the SDK or ship a different function in the future.