### PR TITLE
Add fuzz target that runs wasmi on wasm-smith output

### DIFF
--- a/soroban-env-host/fuzz/Cargo.lock
+++ b/soroban-env-host/fuzz/Cargo.lock
@@ -287,6 +287,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "escape-bytes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
+
+[[package]]
 name = "ethnum"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,6 +313,12 @@ name = "fiat-crypto"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a481586acf778f1b1455424c343f71124b048ffa5f4fc3f8f6ae9dc432dcb3c7"
+
+[[package]]
+name = "flagset"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a7e408202050813e6f1d9addadcaafef3dca7530c7ddfb005d4081cce6779"
 
 [[package]]
 name = "generic-array"
@@ -758,7 +770,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "soroban-env-macros",
- "soroban-wasmi",
+ "soroban-wasmi 0.31.1-soroban.20.0.0 (git+https://github.com/stellar/wasmi?rev=ab29800224d85ee64d4ac127bac84cdbb0276721)",
  "static_assertions",
  "stellar-xdr",
 ]
@@ -783,7 +795,7 @@ dependencies = [
  "sha3",
  "soroban-builtin-sdk-macros",
  "soroban-env-common",
- "soroban-wasmi",
+ "soroban-wasmi 0.31.1-soroban.20.0.0 (git+https://github.com/stellar/wasmi?rev=ab29800224d85ee64d4ac127bac84cdbb0276721)",
  "static_assertions",
  "stellar-strkey",
 ]
@@ -796,6 +808,8 @@ dependencies = [
  "libfuzzer-sys",
  "soroban-env-host",
  "soroban-synth-wasm",
+ "soroban-wasmi 0.31.1-soroban.20.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-smith",
 ]
 
 [[package]]
@@ -818,19 +832,32 @@ dependencies = [
  "arbitrary",
  "soroban-env-common",
  "soroban-env-macros",
- "wasm-encoder",
+ "wasm-encoder 0.36.2",
  "wasmparser",
 ]
 
 [[package]]
 name = "soroban-wasmi"
-version = "0.31.0-soroban1"
-source = "git+https://github.com/stellar/wasmi?rev=7e63b4c9e08c4163f417d118d81f7ea34789d0be#7e63b4c9e08c4163f417d118d81f7ea34789d0be"
+version = "0.31.1-soroban.20.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1aaa682a67cbd2173f1d60cb1e7b951d490d7c4e0b7b6f5387cbb952e963c46"
 dependencies = [
  "smallvec",
  "spin",
- "wasmi_arena",
- "wasmi_core",
+ "wasmi_arena 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmi_core 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser-nostd",
+]
+
+[[package]]
+name = "soroban-wasmi"
+version = "0.31.1-soroban.20.0.0"
+source = "git+https://github.com/stellar/wasmi?rev=ab29800224d85ee64d4ac127bac84cdbb0276721#ab29800224d85ee64d4ac127bac84cdbb0276721"
+dependencies = [
+ "smallvec",
+ "spin",
+ "wasmi_arena 0.4.0 (git+https://github.com/stellar/wasmi?rev=ab29800224d85ee64d4ac127bac84cdbb0276721)",
+ "wasmi_core 0.13.0 (git+https://github.com/stellar/wasmi?rev=ab29800224d85ee64d4ac127bac84cdbb0276721)",
  "wasmparser-nostd",
 ]
 
@@ -869,12 +896,13 @@ dependencies = [
 
 [[package]]
 name = "stellar-xdr"
-version = "20.0.0-rc1"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=d6f8ece2c89809d5e2800b9df64ae60787ee492b#d6f8ece2c89809d5e2800b9df64ae60787ee492b"
+version = "20.0.0"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=24dd3c1b9fada6e2b28e8456a915adc212d6c47e#24dd3c1b9fada6e2b28e8456a915adc212d6c47e"
 dependencies = [
  "arbitrary",
  "base64",
  "crate-git-revision",
+ "escape-bytes",
  "hex",
  "stellar-strkey",
 ]
@@ -1004,14 +1032,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.38.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad2b51884de9c7f4fe2fd1043fccb8dcad4b1e29558146ee57a144d15779f3f"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wasm-smith"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58273756970c82a1769b11e13a05bd21f95a767e4a2fab03afd0cff0085ae89d"
+dependencies = [
+ "arbitrary",
+ "flagset",
+ "indexmap",
+ "leb128",
+ "wasm-encoder 0.38.1",
+]
+
+[[package]]
 name = "wasmi_arena"
 version = "0.4.0"
-source = "git+https://github.com/stellar/wasmi?rev=7e63b4c9e08c4163f417d118d81f7ea34789d0be#7e63b4c9e08c4163f417d118d81f7ea34789d0be"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "401c1f35e413fac1846d4843745589d9ec678977ab35a384db8ae7830525d468"
+
+[[package]]
+name = "wasmi_arena"
+version = "0.4.0"
+source = "git+https://github.com/stellar/wasmi?rev=ab29800224d85ee64d4ac127bac84cdbb0276721#ab29800224d85ee64d4ac127bac84cdbb0276721"
 
 [[package]]
 name = "wasmi_core"
 version = "0.13.0"
-source = "git+https://github.com/stellar/wasmi?rev=7e63b4c9e08c4163f417d118d81f7ea34789d0be#7e63b4c9e08c4163f417d118d81f7ea34789d0be"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf1a7db34bff95b85c261002720c00c3a6168256dcb93041d3fa2054d19856a"
+dependencies = [
+ "downcast-rs",
+ "libm",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "wasmi_core"
+version = "0.13.0"
+source = "git+https://github.com/stellar/wasmi?rev=ab29800224d85ee64d4ac127bac84cdbb0276721#ab29800224d85ee64d4ac127bac84cdbb0276721"
 dependencies = [
  "downcast-rs",
  "libm",

--- a/soroban-env-host/fuzz/Cargo.toml
+++ b/soroban-env-host/fuzz/Cargo.toml
@@ -12,6 +12,8 @@ libfuzzer-sys = "=0.4.7"
 arbitrary = { version = "=1.3.2", features = ["derive"] }
 soroban-env-host = { path = "..", features = ["testutils"]}
 soroban-synth-wasm = { path = "../../soroban-synth-wasm", features = ["testutils"]}
+wasmi = { package = "soroban-wasmi", version = "=0.31.1-soroban.20.0.0" }
+wasm-smith = "=0.13.1"
 
 # Prevent this from interfering with workspaces
 [workspace]
@@ -23,5 +25,11 @@ debug = 1
 [[bin]]
 name = "expr"
 path = "fuzz_targets/expr.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "wasmi"
+path = "fuzz_targets/wasmi.rs"
 test = false
 doc = false

--- a/soroban-env-host/fuzz/fuzz_targets/expr.rs
+++ b/soroban-env-host/fuzz/fuzz_targets/expr.rs
@@ -3,8 +3,8 @@
 use arbitrary::Arbitrary;
 use libfuzzer_sys::fuzz_target;
 use soroban_env_host::{
-    xdr::{HostFunction, InvokeContractArgs, ScErrorCode, ScErrorType, ScSymbol, ScVal, Validate},
-    Host, StorageType, Val,
+    xdr::{HostFunction, InvokeContractArgs, ScErrorCode, ScErrorType, ScSymbol, ScVal},
+    Host, StorageType,
 };
 use soroban_synth_wasm::{Emit, Expr};
 

--- a/soroban-env-host/fuzz/fuzz_targets/wasmi.rs
+++ b/soroban-env-host/fuzz/fuzz_targets/wasmi.rs
@@ -1,0 +1,107 @@
+#![no_main]
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use wasmi::{core::ValueType, Engine, Extern, Linker, Module, Store, StoreLimitsBuilder, Value};
+
+#[derive(Debug, Arbitrary)]
+struct WasmiConfig;
+impl wasm_smith::Config for WasmiConfig {
+    fn max_imports(&self) -> usize {
+        0
+    }
+    fn export_everything(&self) -> bool {
+        true
+    }
+    fn min_funcs(&self) -> usize {
+        1
+    }
+    fn reference_types_enabled(&self) -> bool {
+        false
+    }
+    fn max_memory_pages(&self, _is_64: bool) -> u64 {
+        1000
+    }
+    fn allow_start_export(&self) -> bool {
+        false
+    }
+    fn max_data_segments(&self) -> usize {
+        1000
+    }
+    fn max_element_segments(&self) -> usize {
+        1000
+    }
+    fn max_exports(&self) -> usize {
+        1000
+    }
+    fn max_elements(&self) -> usize {
+        1000
+    }
+    fn max_funcs(&self) -> usize {
+        1000
+    }
+    fn max_globals(&self) -> usize {
+        1000
+    }
+    fn max_table_elements(&self) -> u32 {
+        1000
+    }
+    fn max_values(&self) -> usize {
+        1000
+    }
+    fn max_instructions(&self) -> usize {
+        10000
+    }
+}
+
+fn ty_to_arg(ty: &ValueType) -> Value {
+    match ty {
+        ValueType::I32 => Value::I32(1),
+        ValueType::I64 => Value::I64(1),
+        ValueType::F32 => Value::F32(1.0.into()),
+        ValueType::F64 => Value::F64(1.0.into()),
+        _ => panic!("reference type"),
+    }
+}
+
+fuzz_target!(|cfg_module: wasm_smith::ConfiguredModule<WasmiConfig>| {
+    let mut smith_module = cfg_module.module;
+    smith_module.ensure_termination(1000);
+    let wasm = smith_module.to_bytes();
+    let engine = Engine::default();
+    let linker = Linker::new(&engine);
+    let limiter = StoreLimitsBuilder::new()
+        .memory_size(1000 * 0x10000)
+        .build();
+    let mut store = Store::new(&engine, limiter);
+    store.limiter(|lim| lim);
+    let module = Module::new(store.engine(), wasm.as_slice()).unwrap();
+    let Ok(preinstance) = linker.instantiate(&mut store, &module) else {
+        return;
+    };
+    let Ok(instance) = preinstance.ensure_no_start(&mut store) else {
+        return;
+    };
+
+    let mut args = Vec::new();
+    let mut out = Vec::new();
+    let mut name = None;
+
+    let exports = instance.exports(&store);
+    for e in exports {
+        match e.ty(&store) {
+            wasmi::ExternType::Func(fty) => {
+                args = fty.params().iter().map(ty_to_arg).collect::<Vec<_>>();
+                out = fty.results().iter().map(ty_to_arg).collect::<Vec<_>>();
+                name = Some(e.name().to_string());
+            }
+            _ => continue,
+        }
+    }
+    if let Some(name) = name {
+        let wasm_fn = instance
+            .get_export(&store, &name)
+            .and_then(Extern::into_func)
+            .unwrap();
+        let _ = wasm_fn.call(&mut store, &args, &mut out);
+    }
+});


### PR DESCRIPTION
This adds a new fuzz target that fuzzes wasmi -- including execution -- with wasms generated by wasm-smith.