### PR TITLE
Turn off `wasm_reference_types` in Wasmi

### DIFF
--- a/soroban-env-host/observations/test__hostile__test_extern_ref_not_allowed.json
+++ b/soroban-env-host/observations/test__hostile__test_extern_ref_not_allowed.json
@@ -1,0 +1,8 @@
+{
+  "   0 begin": "cpu:14488, mem:0, prngs:-/9b4a753, objs:-/-, vm:-/-, evt:-, store:-/-, foot:-, stk:-, auth:-/-",
+  "   1 call bytes_new_from_slice(46)": "cpu:14535",
+  "   2 ret bytes_new_from_slice -> Ok(Bytes(obj#1))": "cpu:15506, mem:126, objs:-/1@20a4edbe",
+  "   3 call upload_wasm(Bytes(obj#1))": "",
+  "   4 ret upload_wasm -> Err(Error(WasmVm, InvalidAction))": "cpu:490934, mem:132120",
+  "   5 end": "cpu:490934, mem:132120, prngs:-/9b4a753, objs:-/1@20a4edbe, vm:-/-, evt:-, store:-/-, foot:-, stk:-, auth:-/-"
+}

--- a/soroban-env-host/observations/test__hostile__test_large_number_of_tables.json
+++ b/soroban-env-host/observations/test__hostile__test_large_number_of_tables.json
@@ -1,8 +1,8 @@
 {
   "   0 begin": "cpu:14488, mem:0, prngs:-/9b4a753, objs:-/-, vm:-/-, evt:-, store:-/-, foot:-, stk:-, auth:-/-",
-  "   1 call bytes_new_from_slice(78)": "cpu:14535",
-  "   2 ret bytes_new_from_slice -> Ok(Bytes(obj#1))": "cpu:15514, mem:158, objs:-/1@a971f693",
+  "   1 call bytes_new_from_slice(75)": "cpu:14535",
+  "   2 ret bytes_new_from_slice -> Ok(Bytes(obj#1))": "cpu:15514, mem:155, objs:-/1@26ae1984",
   "   3 call upload_wasm(Bytes(obj#1))": "",
-  "   4 ret upload_wasm -> Err(Error(WasmVm, InvalidAction))": "cpu:504054, mem:133450",
-  "   5 end": "cpu:504054, mem:133450, prngs:-/9b4a753, objs:-/1@a971f693, vm:-/-, evt:-, store:-/-, foot:-, stk:-, auth:-/-"
+  "   4 ret upload_wasm -> Err(Error(WasmVm, InvalidAction))": "cpu:502826, mem:133326",
+  "   5 end": "cpu:502826, mem:133326, prngs:-/9b4a753, objs:-/1@26ae1984, vm:-/-, evt:-, store:-/-, foot:-, stk:-, auth:-/-"
 }

--- a/soroban-env-host/src/budget/util.rs
+++ b/soroban-env-host/src/budget/util.rs
@@ -99,7 +99,7 @@ impl Budget {
     /// of a specific fuel category. In order to get the correct, unscaled fuel
     /// count, we have to preset all the `FuelConfig` entries to 1.
     pub fn reset_fuel_config(&self) -> Result<(), HostError> {
-        self.0.try_borrow_mut_or_err()?.fuel_config.reset();
+        self.0.try_borrow_mut_or_err()?.fuel_costs = wasmi::FuelCosts::default();
         Ok(())
     }
 

--- a/soroban-env-host/src/budget/wasmi_helper.rs
+++ b/soroban-env-host/src/budget/wasmi_helper.rs
@@ -1,55 +1,7 @@
-use super::AsBudget;
-use crate::{xdr::ContractCostType, Host};
-use wasmi::{errors, ResourceLimiter};
-
-/// This is a subset of `wasmi::FuelCosts` which are configurable, because it
-/// doesn't derive all the traits we want. These fields (coarsely) define the
-/// relative costs of different wasm instruction types and are for wasmi internal
-/// fuel metering use only. Units are in "fuels".
-#[derive(Clone)]
-pub(crate) struct FuelConfig {
-    /// The base fuel costs for all instructions.
-    pub base: u64,
-    /// The fuel cost for instruction operating on Wasm entities.
-    ///
-    /// # Note
-    ///
-    /// A Wasm entitiy is one of `func`, `global`, `memory` or `table`.
-    /// Those instructions are usually a bit more costly since they need
-    /// multiplie indirect accesses through the Wasm instance and store.
-    pub entity: u64,
-    /// The fuel cost offset for `memory.load` instructions.
-    pub load: u64,
-    /// The fuel cost offset for `memory.store` instructions.
-    pub store: u64,
-    /// The fuel cost offset for `call` and `call_indirect` instructions.
-    pub call: u64,
-}
-
-// These values are calibrated and set by us.
-impl Default for FuelConfig {
-    fn default() -> Self {
-        FuelConfig {
-            base: 1,
-            entity: 3,
-            load: 2,
-            store: 1,
-            call: 67,
-        }
-    }
-}
-
-impl FuelConfig {
-    // These values are the "factory default" and used for calibration.
-    #[cfg(any(test, feature = "testutils", feature = "bench"))]
-    pub(crate) fn reset(&mut self) {
-        self.base = 1;
-        self.entity = 1;
-        self.load = 1;
-        self.store = 1;
-        self.call = 1;
-    }
-}
+use crate::{
+    budget::AsBudget, host::error::TryBorrowOrErr, xdr::ContractCostType, Host, HostError,
+};
+use wasmi::{errors, FuelConsumptionMode, FuelCosts, ResourceLimiter};
 
 pub(crate) struct WasmiLimits {
     pub table_elements: u32,
@@ -143,4 +95,38 @@ impl ResourceLimiter for Host {
     fn memories(&self) -> usize {
         WASMI_LIMITS_CONFIG.memories
     }
+}
+
+// These values are calibrated and set by us. Calibration is done with a given
+// wasmi version, and as long as the version is pinned, these values aren't
+// expected to change much.
+pub(crate) fn load_calibrated_fuel_costs() -> FuelCosts {
+    let mut fuel_costs = FuelCosts::default();
+    fuel_costs.base = 1;
+    fuel_costs.entity = 3;
+    fuel_costs.load = 2;
+    fuel_costs.store = 1;
+    fuel_costs.call = 67;
+    fuel_costs
+}
+
+pub(crate) fn get_wasmi_config(host: &Host) -> Result<wasmi::Config, HostError> {
+    let _protocol = host.get_ledger_protocol_version();
+
+    let mut config = wasmi::Config::default();
+    let fuel_costs = host.as_budget().0.try_borrow_or_err()?.fuel_costs;
+
+    // Turn off most optional wasm features, leaving on some
+    // post-MVP features commonly enabled by Rust and Clang.
+    config
+        .wasm_multi_value(false)
+        .wasm_mutable_global(true)
+        .wasm_saturating_float_to_int(false)
+        .wasm_sign_extension(true)
+        .floats(false)
+        .consume_fuel(true)
+        .fuel_consumption_mode(FuelConsumptionMode::Eager)
+        .set_fuel_costs(fuel_costs);
+
+    Ok(config)
 }

--- a/soroban-env-host/src/budget/wasmi_helper.rs
+++ b/soroban-env-host/src/budget/wasmi_helper.rs
@@ -111,20 +111,24 @@ pub(crate) fn load_calibrated_fuel_costs() -> FuelCosts {
 }
 
 pub(crate) fn get_wasmi_config(host: &Host) -> Result<wasmi::Config, HostError> {
-    let _protocol = host.get_ledger_protocol_version();
-
     let mut config = wasmi::Config::default();
     let fuel_costs = host.as_budget().0.try_borrow_or_err()?.fuel_costs;
 
-    // Turn off most optional wasm features, leaving on some
-    // post-MVP features commonly enabled by Rust and Clang.
+    // Turn off most optional wasm features, leaving on some post-MVP features
+    // commonly enabled by Rust and Clang. Make sure all unused features are
+    // explicited turned off, so that we don't get "opted in" by a future wasmi
+    // version.
     config
-        .wasm_multi_value(false)
-        .wasm_mutable_global(true)
-        .wasm_saturating_float_to_int(false)
-        .wasm_sign_extension(true)
-        .floats(false)
         .consume_fuel(true)
+        .wasm_bulk_memory(true)
+        .wasm_mutable_global(true)
+        .wasm_sign_extension(true)
+        .wasm_saturating_float_to_int(false)
+        .wasm_multi_value(false)
+        .wasm_reference_types(false)
+        .wasm_tail_call(false)
+        .wasm_extended_const(false)
+        .floats(false)
         .fuel_consumption_mode(FuelConsumptionMode::Eager)
         .set_fuel_costs(fuel_costs);
 

--- a/soroban-env-host/src/test/hostile.rs
+++ b/soroban-env-host/src/test/hostile.rs
@@ -1151,13 +1151,29 @@ fn test_large_globals() -> Result<(), HostError> {
 }
 
 #[test]
+fn test_extern_ref_not_allowed() -> Result<(), HostError> {
+    let host = observe_host!(Host::test_host_with_recording_footprint());
+    host.enable_debug()?;
+    // `ExternRef` is not allowed by disabling `wasmi_reference_type`
+    let wasm = wasm_util::wasm_module_with_extern_ref();
+    let res = host.register_test_contract_wasm_from_source_account(
+        wasm.as_slice(),
+        generate_account_id(&host),
+        generate_bytes_array(&host),
+    );
+    assert!(HostError::result_matches_err(
+        res,
+        (ScErrorType::WasmVm, ScErrorCode::InvalidAction)
+    ));
+    Ok(())
+}
+
+#[test]
 fn test_large_number_of_tables() -> Result<(), HostError> {
     let host = observe_host!(Host::test_host_with_recording_footprint());
     host.enable_debug()?;
-    // even though we have enabled wasmi_reference_type, which makes multiple
-    // tables possible, we have explicitly set our table count limit to 1, in
-    // `WASMI_LIMITS_CONFIG`. Thus we essentially not allow multiple tables.
-    let wasm = wasm_util::wasm_module_with_many_tables(2);
+    // multiple tables are not allowed by disabling `wasmi_reference_type`
+    let wasm = wasm_util::wasm_module_with_additional_tables(1);
     let res = host.register_test_contract_wasm_from_source_account(
         wasm.as_slice(),
         generate_account_id(&host),

--- a/soroban-env-host/src/testutils.rs
+++ b/soroban-env-host/src/testutils.rs
@@ -1016,14 +1016,22 @@ pub(crate) mod wasm {
         me.finish_no_validate()
     }
 
-    pub(crate) fn wasm_module_with_many_tables(n: u32) -> Vec<u8> {
+    pub(crate) fn wasm_module_with_extern_ref() -> Vec<u8> {
+        let mut me = ModEmitter::new();
+        me.table(RefType::EXTERNREF, 2, None);
+        me.custom_section(
+            soroban_env_common::meta::ENV_META_V0_SECTION_NAME,
+            &soroban_env_common::meta::XDR,
+        );
+        me.finish_no_validate()
+    }
+
+    pub(crate) fn wasm_module_with_additional_tables(n: u32) -> Vec<u8> {
         let mut me = ModEmitter::default();
-        for i in 0..n {
-            let rt = match i % 2 == 0 {
-                true => RefType::FUNCREF,
-                false => RefType::EXTERNREF,
-            };
-            me.table(rt, 2, None);
+        // by default, module already includes a table, here we are creating
+        // additional ones
+        for _i in 0..n {
+            me.table(RefType::FUNCREF, 2, None);
         }
         // wasmparser has an limit of 100 tables. wasmi does not have such a limit
         me.finish_no_validate()


### PR DESCRIPTION
### What

Disable wasmi `reference_types`and make all wasmi feature selections explicit.
Also did a pass-by clean up on the fuel configs code. 

### Why

`bulk_memory` and `reference_types` are both post-MVP features.
We use 1 extensively for object init/copy between host and guest. 
We do not use 2 at all. We are not using `ExternRef` and we are limiting table count to 1 (via resource limiter).

### Known limitations

[TODO or N/A]
