### PR TITLE
Improve cost model fitting for better lower-range accuracy

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -18,7 +18,7 @@
 # target = "triple"             # build for the target triple (ignored by `cargo install`)
 # target-dir = "target"         # path of where to place all generated artifacts
 rustflags = [
-     "-Dwarnings",
+     # "-Dwarnings",
      "-Aclippy::style",
 #    "-Dclippy::pedantic",
 #    "-Aclippy::module_name_repetitions",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -18,7 +18,7 @@
 # target = "triple"             # build for the target triple (ignored by `cargo install`)
 # target-dir = "target"         # path of where to place all generated artifacts
 rustflags = [
-     # "-Dwarnings",
+     "-Dwarnings",
      "-Aclippy::style",
 #    "-Dclippy::pedantic",
 #    "-Aclippy::module_name_repetitions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,6 +775,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lstsq"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2591c55069b74283fbdd97167b402b69c534ba6b2c037847cbcae7e14471d8"
+dependencies = [
+ "nalgebra",
+]
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1405,7 +1414,9 @@ dependencies = [
  "itertools",
  "k256",
  "linregress",
+ "lstsq",
  "more-asserts",
+ "nalgebra",
  "num-derive",
  "num-integer",
  "num-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,7 +152,7 @@ dependencies = [
  "num-bigint",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn",
 ]
 
 [[package]]
@@ -273,7 +273,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn",
 ]
 
 [[package]]
@@ -297,7 +297,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.39",
+ "syn",
 ]
 
 [[package]]
@@ -308,7 +308,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.39",
+ "syn",
 ]
 
 [[package]]
@@ -339,7 +339,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn",
 ]
 
 [[package]]
@@ -741,15 +741,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
-name = "linregress"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4de04dcecc58d366391f9920245b85ffa684558a5ef6e7736e754347c3aea9c2"
-dependencies = [
- "nalgebra",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -831,23 +822,11 @@ checksum = "307ed9b18cc2423f29e83f84fd23a8e73628727990181f18641a8b5dc2ab1caa"
 dependencies = [
  "approx",
  "matrixmultiply",
- "nalgebra-macros",
  "num-complex",
  "num-rational",
  "num-traits",
  "simba",
  "typenum",
-]
-
-[[package]]
-name = "nalgebra-macros"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91761aed67d03ad966ef783ae962ef9bbaca728d2dd7ceb7939ec110fffad998"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -888,7 +867,7 @@ checksum = "cfb77679af88f8b125209d354a202862602672222e7f2313fdd6dc349bad4712"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn",
 ]
 
 [[package]]
@@ -939,7 +918,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn",
 ]
 
 [[package]]
@@ -1250,7 +1229,7 @@ checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn",
 ]
 
 [[package]]
@@ -1290,7 +1269,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn",
 ]
 
 [[package]]
@@ -1368,7 +1347,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn",
 ]
 
 [[package]]
@@ -1413,7 +1392,6 @@ dependencies = [
  "hmac",
  "itertools",
  "k256",
- "linregress",
  "lstsq",
  "more-asserts",
  "nalgebra",
@@ -1453,7 +1431,7 @@ dependencies = [
  "serde",
  "serde_json",
  "stellar-xdr",
- "syn 2.0.39",
+ "syn",
 ]
 
 [[package]]
@@ -1548,17 +1526,6 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
@@ -1611,7 +1578,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn",
 ]
 
 [[package]]
@@ -1695,7 +1662,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn",
 ]
 
 [[package]]
@@ -1824,7 +1791,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -1846,7 +1813,7 @@ checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -61,6 +61,8 @@ pretty_assertions = "=1.4.0"
 backtrace = "=0.3.69"
 serde_json = "=1.0.108"
 arbitrary = "=1.3.2"
+lstsq = "=0.5.0"
+nalgebra = "=0.32.3"
 
 [dev-dependencies.stellar-xdr]
 version = "=20.0.0"

--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -56,13 +56,12 @@ textplots = "=0.8.4"
 wasmprinter = "=0.2.72"
 expect-test = "=1.4.1"
 more-asserts = "=0.3.1"
-linregress = "=0.5.3"
 pretty_assertions = "=1.4.0"
 backtrace = "=0.3.69"
 serde_json = "=1.0.108"
 arbitrary = "=1.3.2"
 lstsq = "=0.5.0"
-nalgebra = "=0.32.3"
+nalgebra = { version = "=0.32.3", default-features = false, features = ["std"]}
 
 [dev-dependencies.stellar-xdr]
 version = "=20.0.0"

--- a/soroban-env-host/benches/common/cost_types/compute_ecdsa_secp256k1_sig.rs
+++ b/soroban-env-host/benches/common/cost_types/compute_ecdsa_secp256k1_sig.rs
@@ -16,7 +16,7 @@ impl HostCostMeasurement for ComputeEcdsaSecp256k1SigMeasure {
     type Runner = ComputeEcdsaSecp256k1SigRun;
 
     fn new_random_case(_host: &Host, _rng: &mut StdRng, input: u64) -> Vec<u8> {
-        let size = 1 + input * Self::STEP_SIZE;
+        let size = Self::INPUT_BASE_SIZE + input * Self::STEP_SIZE;
 
         // Very awkward: the 'rand' crate has two copies linked in due to
         // divergence between the requirements of k256 and ed25519. The StdRng

--- a/soroban-env-host/benches/common/cost_types/compute_keccak256_hash.rs
+++ b/soroban-env-host/benches/common/cost_types/compute_keccak256_hash.rs
@@ -11,7 +11,7 @@ impl HostCostMeasurement for ComputeKeccak256HashMeasure {
     type Runner = ComputeKeccak256HashRun;
 
     fn new_random_case(_host: &Host, _rng: &mut StdRng, input: u64) -> Vec<u8> {
-        let size = 1 + input * Self::STEP_SIZE;
+        let size = Self::INPUT_BASE_SIZE + input * Self::STEP_SIZE;
         (0..size).map(|n| n as u8).collect()
     }
 }

--- a/soroban-env-host/benches/common/cost_types/compute_sha256_hash.rs
+++ b/soroban-env-host/benches/common/cost_types/compute_sha256_hash.rs
@@ -11,7 +11,7 @@ impl HostCostMeasurement for ComputeSha256HashMeasure {
     type Runner = ComputeSha256HashRun;
 
     fn new_random_case(_host: &Host, _rng: &mut StdRng, input: u64) -> Vec<u8> {
-        let size = 1 + input * Self::STEP_SIZE;
+        let size = Self::INPUT_BASE_SIZE + input * Self::STEP_SIZE;
         (0..size).map(|n| n as u8).collect()
     }
 }

--- a/soroban-env-host/benches/common/cost_types/host_mem_alloc.rs
+++ b/soroban-env-host/benches/common/cost_types/host_mem_alloc.rs
@@ -12,6 +12,6 @@ impl HostCostMeasurement for MemAllocMeasure {
     fn new_random_case(_host: &Host, _rng: &mut StdRng, input: u64) -> u64 {
         // we just pass along the size and let the runner allocate the memory
         // of the given size
-        1 + input * Self::STEP_SIZE
+        Self::INPUT_BASE_SIZE + input * Self::STEP_SIZE
     }
 }

--- a/soroban-env-host/benches/common/cost_types/host_mem_cmp.rs
+++ b/soroban-env-host/benches/common/cost_types/host_mem_cmp.rs
@@ -13,7 +13,7 @@ impl HostCostMeasurement for MemCmpMeasure {
         rng: &mut StdRng,
         input: u64,
     ) -> <Self::Runner as CostRunner>::SampleType {
-        let len = 1 + input * Self::STEP_SIZE;
+        let len = Self::INPUT_BASE_SIZE + input * Self::STEP_SIZE;
         let a = randvec(rng, len);
         let b = randvec(rng, len);
         (a, b)
@@ -24,7 +24,7 @@ impl HostCostMeasurement for MemCmpMeasure {
         rng: &mut StdRng,
         input: u64,
     ) -> <Self::Runner as CostRunner>::SampleType {
-        let len = 1 + input * Self::STEP_SIZE;
+        let len = Self::INPUT_BASE_SIZE + input * Self::STEP_SIZE;
         let a = randvec(rng, len);
         (a.clone(), a)
     }

--- a/soroban-env-host/benches/common/cost_types/host_mem_cpy.rs
+++ b/soroban-env-host/benches/common/cost_types/host_mem_cpy.rs
@@ -1,6 +1,6 @@
 use crate::common::HostCostMeasurement;
 use rand::{rngs::StdRng, RngCore};
-use soroban_env_host::{budget::COST_MODEL_LIN_TERM_SCALE_BITS, cost_runner::MemCpyRun, Host};
+use soroban_env_host::{cost_runner::MemCpyRun, Host};
 
 // Measures the cost of copying a chunk of memory in the host (no allocation).
 // The input value is the number of bytes copied.
@@ -14,9 +14,8 @@ impl HostCostMeasurement for MemCpyMeasure {
     // small memcpy, which almost all our memcpys are (they're not even likely
     // to be calls to memcpy, they're just "byte moving in the abstract sense",
     // usually only a few dozen or hundred at a time). So we use the smallest
-    // number here we're allowed to use: the linear scale factor, which
-    // STEP_SIZE literally isn't allowed to be smaller than.
-    const STEP_SIZE: u64 = 1 << COST_MODEL_LIN_TERM_SCALE_BITS;
+    // number here we're allowed to use.
+    const STEP_SIZE: u64 = 1;
 
     fn new_random_case(_host: &Host, rng: &mut StdRng, input: u64) -> (Vec<u8>, Vec<u8>) {
         let len = Self::INPUT_BASE_SIZE + input * Self::STEP_SIZE;

--- a/soroban-env-host/benches/common/cost_types/host_mem_cpy.rs
+++ b/soroban-env-host/benches/common/cost_types/host_mem_cpy.rs
@@ -19,7 +19,7 @@ impl HostCostMeasurement for MemCpyMeasure {
     const STEP_SIZE: u64 = 1 << COST_MODEL_LIN_TERM_SCALE_BITS;
 
     fn new_random_case(_host: &Host, rng: &mut StdRng, input: u64) -> (Vec<u8>, Vec<u8>) {
-        let len = 1 + input * Self::STEP_SIZE;
+        let len = Self::INPUT_BASE_SIZE + input * Self::STEP_SIZE;
         let mut a = vec![0; len as usize];
         let mut b = vec![0; len as usize];
         rng.fill_bytes(a.as_mut_slice());

--- a/soroban-env-host/benches/common/cost_types/prng.rs
+++ b/soroban-env-host/benches/common/cost_types/prng.rs
@@ -9,7 +9,7 @@ impl HostCostMeasurement for ChaCha20DrawBytesMeasure {
     type Runner = ChaCha20DrawBytesRun;
 
     fn new_random_case(_host: &Host, _rng: &mut StdRng, input: u64) -> (ChaCha20Rng, Vec<u8>) {
-        let size = 1 + input * Self::STEP_SIZE;
+        let size = Self::INPUT_BASE_SIZE + input * Self::STEP_SIZE;
         let seed = [0u8; 32];
         let rng = ChaCha20Rng::from_seed(seed);
         let dest = vec![0u8; size as usize];

--- a/soroban-env-host/benches/common/cost_types/recover_ecdsa_secp256k1_key.rs
+++ b/soroban-env-host/benches/common/cost_types/recover_ecdsa_secp256k1_key.rs
@@ -27,7 +27,7 @@ impl HostCostMeasurement for RecoverEcdsaSecp256k1KeyMeasure {
         // here, from the package k256 wants (and re-exports).
         let mut rng = k256::elliptic_curve::rand_core::OsRng;
 
-        let size = 1 + input * Self::STEP_SIZE;
+        let size = Self::INPUT_BASE_SIZE + input * Self::STEP_SIZE;
         let sec: SecretKey = SecretKey::random(&mut rng);
         let msg: Vec<u8> = (0..size).map(|x| x as u8).collect();
         let hash: Hash = Hash(Keccak256::digest(msg).into());

--- a/soroban-env-host/benches/common/cost_types/val_deser.rs
+++ b/soroban-env-host/benches/common/cost_types/val_deser.rs
@@ -9,7 +9,7 @@ pub(crate) struct ValDeserMeasure;
 
 impl HostCostMeasurement for ValDeserMeasure {
     type Runner = ValDeserRun;
-    const STEP_SIZE: u64 = 1;
+    const STEP_SIZE: u64 = 256;
 
     fn new_random_case(
         host: &soroban_env_host::Host,

--- a/soroban-env-host/benches/common/cost_types/val_deser.rs
+++ b/soroban-env-host/benches/common/cost_types/val_deser.rs
@@ -9,7 +9,7 @@ pub(crate) struct ValDeserMeasure;
 
 impl HostCostMeasurement for ValDeserMeasure {
     type Runner = ValDeserRun;
-    const STEP_SIZE: u64 = 128;
+    const STEP_SIZE: u64 = 1;
 
     fn new_random_case(
         host: &soroban_env_host::Host,
@@ -49,7 +49,7 @@ impl HostCostMeasurement for ValDeserMeasure {
         input: u64,
     ) -> Vec<u8> {
         let input = 1 + input * Self::STEP_SIZE;
-        let elem_per_level = 1 + input / MAX_DEPTH;
+        let elem_per_level = (input + MAX_DEPTH) / MAX_DEPTH;
         let mut v = ScVal::U64(0);
         let mut rem = input;
         for _i in 0..MAX_DEPTH {

--- a/soroban-env-host/benches/common/cost_types/val_deser.rs
+++ b/soroban-env-host/benches/common/cost_types/val_deser.rs
@@ -10,6 +10,7 @@ pub(crate) struct ValDeserMeasure;
 impl HostCostMeasurement for ValDeserMeasure {
     type Runner = ValDeserRun;
     const STEP_SIZE: u64 = 128;
+    const INPUT_BASE_SIZE: u64 = 1;
 
     fn new_random_case(
         host: &soroban_env_host::Host,
@@ -48,7 +49,7 @@ impl HostCostMeasurement for ValDeserMeasure {
         _rng: &mut rand::prelude::StdRng,
         input: u64,
     ) -> Vec<u8> {
-        let input = 1 + input * Self::STEP_SIZE;
+        let input = Self::INPUT_BASE_SIZE + input * Self::STEP_SIZE;
         let elem_per_level = (input + MAX_DEPTH) / MAX_DEPTH;
         let mut v = ScVal::U64(0);
         let mut rem = input;

--- a/soroban-env-host/benches/common/cost_types/val_deser.rs
+++ b/soroban-env-host/benches/common/cost_types/val_deser.rs
@@ -9,7 +9,7 @@ pub(crate) struct ValDeserMeasure;
 
 impl HostCostMeasurement for ValDeserMeasure {
     type Runner = ValDeserRun;
-    const STEP_SIZE: u64 = 256;
+    const STEP_SIZE: u64 = 128;
 
     fn new_random_case(
         host: &soroban_env_host::Host,

--- a/soroban-env-host/benches/common/cost_types/val_deser.rs
+++ b/soroban-env-host/benches/common/cost_types/val_deser.rs
@@ -10,7 +10,6 @@ pub(crate) struct ValDeserMeasure;
 impl HostCostMeasurement for ValDeserMeasure {
     type Runner = ValDeserRun;
     const STEP_SIZE: u64 = 128;
-    const INPUT_BASE_SIZE: u64 = 1;
 
     fn new_random_case(
         host: &soroban_env_host::Host,

--- a/soroban-env-host/benches/common/cost_types/val_ser.rs
+++ b/soroban-env-host/benches/common/cost_types/val_ser.rs
@@ -10,7 +10,7 @@ pub(crate) struct ValSerMeasure;
 // This measures the costs of converting an ScVal into bytes.
 impl HostCostMeasurement for ValSerMeasure {
     type Runner = ValSerRun;
-    const STEP_SIZE: u64 = 256;
+    const STEP_SIZE: u64 = 1;
 
     fn new_random_case(_host: &Host, rng: &mut StdRng, input: u64) -> (ScVal, Vec<u8>) {
         let len = 1 + input * Self::STEP_SIZE;

--- a/soroban-env-host/benches/common/cost_types/val_ser.rs
+++ b/soroban-env-host/benches/common/cost_types/val_ser.rs
@@ -11,9 +11,10 @@ pub(crate) struct ValSerMeasure;
 impl HostCostMeasurement for ValSerMeasure {
     type Runner = ValSerRun;
     const STEP_SIZE: u64 = 256;
+    const INPUT_BASE_SIZE: u64 = 100;
 
     fn new_random_case(_host: &Host, rng: &mut StdRng, input: u64) -> (ScVal, Vec<u8>) {
-        let len = 1 + input * Self::STEP_SIZE;
+        let len = Self::INPUT_BASE_SIZE + input * Self::STEP_SIZE;
         let mut buf = vec![0; len as usize];
         rng.fill_bytes(buf.as_mut_slice());
         let v = ScVal::Bytes(buf.try_into().unwrap());
@@ -43,7 +44,7 @@ impl HostCostMeasurement for ValSerMeasure {
     // interference of u32.
 
     fn new_worst_case(_host: &Host, rng: &mut StdRng, input: u64) -> (ScVal, Vec<u8>) {
-        let len = 1 + input * Self::STEP_SIZE;
+        let len = Self::INPUT_BASE_SIZE + input * Self::STEP_SIZE;
         let mut buf = vec![0; len as usize];
         rng.fill_bytes(buf.as_mut_slice());
         let scv_bytes = ScVal::Bytes(buf.try_into().unwrap());

--- a/soroban-env-host/benches/common/cost_types/val_ser.rs
+++ b/soroban-env-host/benches/common/cost_types/val_ser.rs
@@ -10,7 +10,7 @@ pub(crate) struct ValSerMeasure;
 // This measures the costs of converting an ScVal into bytes.
 impl HostCostMeasurement for ValSerMeasure {
     type Runner = ValSerRun;
-    const STEP_SIZE: u64 = 1;
+    const STEP_SIZE: u64 = 256;
 
     fn new_random_case(_host: &Host, rng: &mut StdRng, input: u64) -> (ScVal, Vec<u8>) {
         let len = 1 + input * Self::STEP_SIZE;

--- a/soroban-env-host/benches/common/cost_types/val_ser.rs
+++ b/soroban-env-host/benches/common/cost_types/val_ser.rs
@@ -11,7 +11,6 @@ pub(crate) struct ValSerMeasure;
 impl HostCostMeasurement for ValSerMeasure {
     type Runner = ValSerRun;
     const STEP_SIZE: u64 = 256;
-    const INPUT_BASE_SIZE: u64 = 100;
 
     fn new_random_case(_host: &Host, rng: &mut StdRng, input: u64) -> (ScVal, Vec<u8>) {
         let len = Self::INPUT_BASE_SIZE + input * Self::STEP_SIZE;

--- a/soroban-env-host/benches/common/cost_types/verify_ed25519_sig.rs
+++ b/soroban-env-host/benches/common/cost_types/verify_ed25519_sig.rs
@@ -15,7 +15,7 @@ impl HostCostMeasurement for VerifyEd25519SigMeasure {
     type Runner = VerifyEd25519SigRun;
 
     fn new_random_case(_host: &Host, rng: &mut StdRng, input: u64) -> VerifyEd25519SigSample {
-        let size = 1 + input * Self::STEP_SIZE;
+        let size = Self::INPUT_BASE_SIZE + input * Self::STEP_SIZE;
         let signingkey: SigningKey = SigningKey::generate(rng);
         let key: VerifyingKey = signingkey.verifying_key();
         let msg: Vec<u8> = (0..size).map(|x| x as u8).collect();

--- a/soroban-env-host/benches/common/cost_types/visit_object.rs
+++ b/soroban-env-host/benches/common/cost_types/visit_object.rs
@@ -9,7 +9,7 @@ impl HostCostMeasurement for VisitObjectMeasure {
     fn new_random_case(host: &Host, _rng: &mut rand::prelude::StdRng, input: u64) -> Vec<Object> {
         // During setup we inject a bunch of copies of the object to make
         // the host object array large.
-        let size = 1 + input * Self::STEP_SIZE;
+        let size = Self::INPUT_BASE_SIZE + input * Self::STEP_SIZE;
         let mut vec: Vec<Object> = Vec::with_capacity(size as usize);
         let val = ScVal::I64(i64::MAX);
         for _ in 0..size {

--- a/soroban-env-host/benches/common/cost_types/vm_ops.rs
+++ b/soroban-env-host/benches/common/cost_types/vm_ops.rs
@@ -26,7 +26,7 @@ impl HostCostMeasurement for VmInstantiationMeasure {
         let id: xdr::Hash = [0; 32].into();
         // generate a test wasm contract with many trivial internal functions,
         // which represents the worst case in terms of work needed for WASM parsing.
-        let n = (input * 30) as usize;
+        let n = (Self::INPUT_BASE_SIZE + input * 30) as usize;
         let wasm = wasm_module_with_n_internal_funcs(n);
         // replace the above two lines with these below to test with wasm contracts
         // with a single function of many instructions. In both tests the cpu grows

--- a/soroban-env-host/benches/common/measure.rs
+++ b/soroban-env-host/benches/common/measure.rs
@@ -1,7 +1,7 @@
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use soroban_bench_utils::{tracking_allocator::AllocationGroupToken, HostTracker};
 use soroban_env_host::{
-    budget::{AsBudget, CostTracker, COST_MODEL_LIN_TERM_SCALE_BITS},
+    budget::{AsBudget, CostTracker},
     cost_runner::{CostRunner, CostType},
     Host,
 };
@@ -238,20 +238,16 @@ pub trait HostCostMeasurement: Sized {
     /// The type of host runner we're using. Uniquely identifies a `CostType`.
     type Runner: CostRunner;
 
-    /// The `input: u64` will be multiplied by the `STEP_SIZE` for two reasons:
-    /// 1. for fast-running linear components, setting the step size larger can
-    /// ensure each sample runs for longer (compared to measurement fluctuation),
-    /// thus helps extrapolating the linear coefficient.
-    /// 2. when fitting the linear model, the linear coefficient will be scaled
-    /// up by `factor = 2^COST_MODEL_LIN_TERM_SCALE_BITS`, by scaling down the
-    /// actual input size. Thus `STEP_SIZE` must be `>= factor` to account for
-    /// the input downscaling.
+    /// The `input: u64` will be multiplied by the `STEP_SIZE`. It exist mainly
+    /// numerical reasons, for fast-running linear components, setting the step
+    /// size larger can ensure each sample runs for longer (compared to
+    /// measurement fluctuation), thus helps deriving a more accurate linear
+    /// coefficient (slope). This is not relevant for const models.
     const STEP_SIZE: u64 = 1024;
 
     /// Base size of the HCM input, which does not necessary have the same unit
-    /// as the input to the budget. By default, this has the minimal bits
-    /// required in the `ScaledU64`. Only relevant if the cost model is linear.
-    const INPUT_BASE_SIZE: u64 = 1 << COST_MODEL_LIN_TERM_SCALE_BITS;
+    /// as the input to the budget.
+    const INPUT_BASE_SIZE: u64 = 1;
 
     /// Initialize a new instance of a HostMeasurement at a given input _hint_, for
     /// the run; the HostMeasurement can choose a precise input for a given hint

--- a/soroban-env-host/benches/common/measure.rs
+++ b/soroban-env-host/benches/common/measure.rs
@@ -1,14 +1,14 @@
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use soroban_bench_utils::{tracking_allocator::AllocationGroupToken, HostTracker};
 use soroban_env_host::{
-    budget::{AsBudget, CostTracker},
+    budget::{AsBudget, CostTracker, MeteredCostComponent},
     cost_runner::{CostRunner, CostType},
     Host,
 };
 use std::{io, ops::Range};
 use tabwriter::{Alignment, TabWriter};
 
-use super::{fit_model, FPCostModel};
+use super::modelfit::fit_model;
 
 #[derive(Clone, Debug, Default)]
 pub struct Measurement {
@@ -171,7 +171,7 @@ impl Measurements {
         eprintln!("{}", String::from_utf8(tw.into_inner().unwrap()).unwrap());
     }
 
-    pub fn fit_model_to_cpu(&self) -> FPCostModel {
+    pub fn fit_model_to_cpu(&self) -> MeteredCostComponent {
         // data must be preprocessed
         assert_eq!(
             self.measurements.len(),
@@ -184,10 +184,10 @@ impl Measurements {
             .map(|m| (m.inputs.unwrap_or(0), m.cpu_insns))
             .unzip();
 
-        fit_model(x, y)
+        fit_model(x, y).into()
     }
 
-    pub fn fit_model_to_mem(&self) -> FPCostModel {
+    pub fn fit_model_to_mem(&self) -> MeteredCostComponent {
         // data must be preprocessed
         assert_eq!(
             self.measurements.len(),
@@ -200,7 +200,7 @@ impl Measurements {
             .map(|m| (m.inputs.unwrap_or(0), m.mem_bytes))
             .unzip();
 
-        fit_model(x, y)
+        fit_model(x, y).into()
     }
 }
 

--- a/soroban-env-host/benches/common/measure.rs
+++ b/soroban-env-host/benches/common/measure.rs
@@ -171,7 +171,7 @@ impl Measurements {
         eprintln!("{}", String::from_utf8(tw.into_inner().unwrap()).unwrap());
     }
 
-    pub fn fit_model_to_cpu(&self) -> MeteredCostComponent {
+    pub fn fit_model_to_cpu(&self) -> (MeteredCostComponent, f64) {
         // data must be preprocessed
         assert_eq!(
             self.measurements.len(),
@@ -184,10 +184,12 @@ impl Measurements {
             .map(|m| (m.inputs.unwrap_or(0), m.cpu_insns))
             .unzip();
 
-        fit_model(x, y).into()
+        let model = fit_model(x, y);
+        let r2 = model.r_squared;
+        (model.into(), r2)
     }
 
-    pub fn fit_model_to_mem(&self) -> MeteredCostComponent {
+    pub fn fit_model_to_mem(&self) -> (MeteredCostComponent, f64) {
         // data must be preprocessed
         assert_eq!(
             self.measurements.len(),
@@ -200,7 +202,9 @@ impl Measurements {
             .map(|m| (m.inputs.unwrap_or(0), m.mem_bytes))
             .unzip();
 
-        fit_model(x, y).into()
+        let model = fit_model(x, y);
+        let r2 = model.r_squared;
+        (model.into(), r2)
     }
 }
 

--- a/soroban-env-host/benches/common/mod.rs
+++ b/soroban-env-host/benches/common/mod.rs
@@ -69,8 +69,8 @@ pub(crate) fn for_each_host_cost_measurement<B: Benchmark>(
     call_bench::<B, VerifyEd25519SigMeasure>(&mut params)?;
     call_bench::<B, VmInstantiationMeasure>(&mut params)?;
     call_bench::<B, VisitObjectMeasure>(&mut params)?;
-    call_bench::<B, ValSerMeasure>(&mut params)?;
     call_bench::<B, ValDeserMeasure>(&mut params)?;
+    call_bench::<B, ValSerMeasure>(&mut params)?;
     call_bench::<B, InvokeVmFunctionMeasure>(&mut params)?;
     call_bench::<B, InvokeHostFunctionMeasure>(&mut params)?;
     call_bench::<B, Int256AddSubMeasure>(&mut params)?;

--- a/soroban-env-host/benches/common/mod.rs
+++ b/soroban-env-host/benches/common/mod.rs
@@ -71,17 +71,20 @@ pub(crate) fn for_each_host_cost_measurement<B: Benchmark>(
     call_bench::<B, VisitObjectMeasure>(&mut params)?;
     call_bench::<B, ValSerMeasure>(&mut params)?;
     call_bench::<B, ValDeserMeasure>(&mut params)?;
-    call_bench::<B, MemCmpMeasure>(&mut params)?;
     call_bench::<B, InvokeVmFunctionMeasure>(&mut params)?;
     call_bench::<B, InvokeHostFunctionMeasure>(&mut params)?;
-    call_bench::<B, MemAllocMeasure>(&mut params)?;
-    call_bench::<B, MemCpyMeasure>(&mut params)?;
     call_bench::<B, Int256AddSubMeasure>(&mut params)?;
     call_bench::<B, Int256MulMeasure>(&mut params)?;
     call_bench::<B, Int256DivMeasure>(&mut params)?;
     call_bench::<B, Int256PowMeasure>(&mut params)?;
     call_bench::<B, Int256ShiftMeasure>(&mut params)?;
     call_bench::<B, ChaCha20DrawBytesMeasure>(&mut params)?;
+    // These three mem ones are derived analytically, we do not calibrate them typically
+    if std::env::var("INCLUDE_ANALYTICAL_COSTTYPES").is_ok() {
+        call_bench::<B, MemAllocMeasure>(&mut params)?;
+        call_bench::<B, MemCpyMeasure>(&mut params)?;
+        call_bench::<B, MemCmpMeasure>(&mut params)?;
+    }
 
     if get_explicit_bench_names().is_none() {
         for cost in ContractCostType::variants() {

--- a/soroban-env-host/benches/common/modelfit.rs
+++ b/soroban-env-host/benches/common/modelfit.rs
@@ -1,11 +1,7 @@
+use nalgebra::{self as na, OMatrix, OVector, U1};
+use num_traits::Pow;
 use std::collections::HashSet;
 use std::str::FromStr;
-
-use linregress::{FormulaRegressionBuilder, RegressionDataBuilder};
-use na::U1;
-use num_traits::Pow;
-
-use nalgebra::{self as na, OMatrix, OVector};
 
 #[derive(Debug, Default, Clone, PartialEq, PartialOrd)]
 pub struct FPCostModel {
@@ -48,24 +44,15 @@ impl FPCostModel {
     }
 }
 
-fn fit_linear_regression(x: Vec<f64>, y: Vec<f64>) -> FPCostModel {
-    assert_eq!(x.len(), y.len());
-    let data = vec![("Y", y), ("X", x)];
-    let data = RegressionDataBuilder::new().build_from(data).unwrap();
-    let model = FormulaRegressionBuilder::new()
-        .data(&data)
-        .formula("Y ~ X")
-        .fit()
-        .unwrap();
-    let r2 = model.rsquared();
-    FPCostModel::new(model.parameters(), r2)
-}
-
 fn compute_rsquared(x: Vec<f64>, y: Vec<f64>, const_param: f64, lin_param: f64) -> f64 {
     assert_eq!(x.len(), y.len());
     let pred_y: Vec<f64> = x.iter().map(|x| const_param + lin_param * x).collect();
     let y_mean = y.iter().sum::<f64>() / y.len() as f64;
-    let ss_res = y.iter().zip(pred_y.iter()).map(|(y, y_pred)| (y - y_pred).pow(2i32)).sum::<f64>();
+    let ss_res = y
+        .iter()
+        .zip(pred_y.iter())
+        .map(|(y, y_pred)| (y - y_pred).pow(2i32))
+        .sum::<f64>();
     let ss_tot = y.iter().map(|y| (y - y_mean).pow(2)).sum::<f64>();
     1f64 - ss_res / ss_tot
 }
@@ -82,54 +69,60 @@ pub fn fit_model(x: Vec<u64>, y: Vec<u64>) -> FPCostModel {
         };
     }
 
-    let nrows = x.len();
-    let x = x.iter().map(|i| *i as f64).collect::<Vec<_>>();
-    let y = y.iter().map(|i| *i as f64).collect::<Vec<_>>();
+    let x: Vec<f64> = x.iter().map(|i| *i as f64).collect();
+    let y: Vec<f64> = y.iter().map(|i| *i as f64).collect();
 
-    // This is the solution that does not pin the x axis. Equivalent to previous solution (with wild intercepts)
-    // let mut a = x.clone();
-    // a.append(&mut vec![1.0; nrows]);
-    // // println!("{}, {}", a.len(), y.len());
-    // let a = OMatrix::<f64, na::Dyn, U2>::from_column_slice(&a);
-    // let b = OVector::<f64, na::Dyn>::from_row_slice(&y);
-    // // println!("{}, {}", a.len(), b.len());
-    // let res = lstsq::lstsq(&a, &b, 1e-14).unwrap();
-    // assert_eq!(res.solution.len(), 2);
-    // let const_param = res.solution[1];
-    // let lin_param = res.solution[0];
-    // let r_squared = compute_rsquared(x.clone(), y.clone(), const_param, lin_param);
-    // FPCostModel{ const_param, lin_param, r_squared }
-
-    // This is the solution that pins x axis to (x0, y0)
-    // x0 is not necessary at x=0, it is the first input point
-    // here we are just making sure the line produced will always pass through (x0, y0)
-    // assume X is mono-increasing
-    let x0 = x[0];
-    let y0 = y[0];
-    println!("{}, {}", x0, y0);
+    // First pass: try to pin the solution to (x0, y(x=x0)), where x0 is the
+    // smallest input in the input range X, assuming X is monotonic increasing.
+    // x0 is not necessary equal to 0. Often times it is unrealistic to build a
+    // sample with input at exactly zero (e.g you can't deserialize a zero byte
+    // blob to XDR). Here we try to pin it to the lowest point to ensure the
+    // y-intercept of the produced curve is sane.
+    assert!(y.len() > 1 && x.len() > 1);
+    let x0 = x.get(0).unwrap();
+    let y0 = y.get(0).unwrap();
+    // we build the matrix a and b, the independent and dependent variables in
+    // the equation to be optimized
     let a: Vec<f64> = x.iter().map(|x| x - x0).collect();
     let a = OMatrix::<f64, na::Dyn, U1>::from_column_slice(&a);
     let b: Vec<f64> = y.iter().map(|y| y - y0).collect();
     let b = OVector::<f64, na::Dyn>::from_row_slice(&b);
-    // println!("{}, {}", a.len(), b.len());
+    // computes the least-square solution with a small tolerance
     let lsq_res = lstsq::lstsq(&a, &b, 1e-14).unwrap();
     assert_eq!(lsq_res.solution.len(), 1);
-    let lin_param = lsq_res.solution[0];    
-    let const_param = y0 - lin_param * x0;
-    let r_squared = compute_rsquared(x.clone(), y.clone(), const_param, lin_param);
-    let mut res = FPCostModel{ const_param, lin_param, r_squared };
 
-    // second pass: we make sure that the intercept y (x=0) >= 0
-    assert!(res.lin_param > 0.0, "negative slope detected, examine your data, or choose a constant model");
-    if res.const_param < 0.0 {
-        println!("negative intercept detected, will constrain it to 0 and rerun");
-        let a = OMatrix::<f64, na::Dyn, U1>::from_column_slice(&x);
-        let b = OVector::<f64, na::Dyn>::from_row_slice(&y);
-        let lsq_res = lstsq::lstsq(&a, &b, 1e-14).unwrap();
-        assert_eq!(lsq_res.solution.len(), 1);
-        let lin_param = lsq_res.solution[0];    
-        let r_squared = compute_rsquared(x.clone(), y.clone(), 0.0, lin_param);
-        res = FPCostModel{ const_param: 0.0, lin_param, r_squared };
+    let lin_param = *lsq_res.solution.get(0).unwrap();
+    assert!(
+        lin_param > 0.0,
+        "negative slope detected, examine your data, or choose a constant model"
+    );
+    let const_param = y0 - lin_param * x0;
+    if const_param >= 0.0 {
+        // we have found our solution: the line is least-square minimal, **and**
+        // the intercept is non-negative
+        let r_squared = compute_rsquared(x.clone(), y.clone(), const_param, lin_param);
+        return FPCostModel {
+            const_param,
+            lin_param,
+            r_squared,
+        };
     }
-    res
+
+    // negative intercept means that extrapolating our solution to the range of
+    // [0, x0), will produce a negative y for some values. This is unaceptable
+    // because someone can pass in an input that produces negative cost.
+    println!(
+        "negative intercept detected, will constrain the solution to pass through (0,0) and rerun"
+    );
+    let a = OMatrix::<f64, na::Dyn, U1>::from_column_slice(&x);
+    let b = OVector::<f64, na::Dyn>::from_row_slice(&y);
+    let lsq_res = lstsq::lstsq(&a, &b, 1e-14).unwrap();
+    assert_eq!(lsq_res.solution.len(), 1);
+    let lin_param = *lsq_res.solution.get(0).unwrap();
+    let r_squared = compute_rsquared(x.clone(), y.clone(), 0.0, lin_param);
+    FPCostModel {
+        const_param: 0.0,
+        lin_param,
+        r_squared,
+    }
 }

--- a/soroban-env-host/benches/common/modelfit.rs
+++ b/soroban-env-host/benches/common/modelfit.rs
@@ -93,8 +93,12 @@ pub fn fit_model(x: Vec<u64>, y: Vec<u64>) -> FPCostModel {
 
     let lin_param = *lsq_res.solution.get(0).unwrap();
     assert!(
-        lin_param > 0.0,
-        "negative slope detected, examine your data, or choose a constant model"
+        lin_param >= 0.0,
+        "{}",
+        format!(
+            "negative slope {} detected, examine your data, or choose a constant model",
+            lin_param
+        )
     );
     let const_param = y0 - lin_param * x0;
     if const_param >= 0.0 {

--- a/soroban-env-host/benches/common/modelfit.rs
+++ b/soroban-env-host/benches/common/modelfit.rs
@@ -2,7 +2,6 @@ use nalgebra::{self as na, OMatrix, OVector, U1};
 use num_traits::Pow;
 use soroban_env_host::budget::MeteredCostComponent;
 use std::collections::HashSet;
-use std::str::FromStr;
 
 #[derive(Debug, Default, Clone, PartialEq, PartialOrd)]
 pub(crate) struct FPCostModel {
@@ -47,8 +46,12 @@ impl FPCostModel {
     // retain enough precision to apply the scale factor to. This prevents
     // numerical noises from being rounded up as a non-zero linear term.
     fn truncate_noise_digits(&mut self) {
-        self.const_param = f64::from_str(format!("{:.6}", self.const_param).as_str()).unwrap();
-        self.lin_param = f64::from_str(format!("{:.6}", self.lin_param).as_str()).unwrap();
+        let round_to_decimal_places = |num: f64, decimal_places: u32| -> f64 {
+            let factor = 10f64.powi(decimal_places as i32);
+            (num * factor).ceil() / factor
+        };
+        self.const_param = round_to_decimal_places(self.const_param, 6);
+        self.lin_param = round_to_decimal_places(self.lin_param, 6);
     }
 }
 

--- a/soroban-env-host/benches/common/modelfit.rs
+++ b/soroban-env-host/benches/common/modelfit.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 pub(crate) struct FPCostModel {
     const_param: f64,
     lin_param: f64,
-    r_squared: f64,
+    pub(crate) r_squared: f64,
 }
 
 impl From<FPCostModel> for MeteredCostComponent {

--- a/soroban-env-host/benches/common/modelfit.rs
+++ b/soroban-env-host/benches/common/modelfit.rs
@@ -58,27 +58,6 @@ fn compute_rsquared(x: Vec<f64>, y: Vec<f64>, const_param: f64, lin_param: f64) 
     1f64 - ss_res / ss_tot
 }
 
-fn check_inputs_for_fitting(x: &Vec<u64>) {
-    assert!(
-        *x.get(0).unwrap() >= 1 << COST_MODEL_LIN_TERM_SCALE_BITS,
-        "{}",
-        format!("The first point in the input data is too small: {:?}", x)
-    );
-    for w in x.as_slice().windows(2) {
-        let [lo, hi] = w else {
-            panic!("inputs do not contain enough elements");
-        };
-        assert!(
-            hi.saturating_sub(*lo) >= 1 << COST_MODEL_LIN_TERM_SCALE_BITS,
-            "{}",
-            format!(
-                "inputs do not have large enough gap to fit the model. lo: {}, hi: {}",
-                lo, hi
-            )
-        );
-    }
-}
-
 pub fn fit_model(raw_inputs: Vec<u64>, outputs: Vec<u64>) -> FPCostModel {
     assert_eq!(raw_inputs.len(), outputs.len());
     let const_model = raw_inputs.iter().collect::<HashSet<_>>().len() == 1;
@@ -90,8 +69,6 @@ pub fn fit_model(raw_inputs: Vec<u64>, outputs: Vec<u64>) -> FPCostModel {
             r_squared: 0.0, // we are always predicting the mean
         };
     }
-
-    check_inputs_for_fitting(&raw_inputs);
 
     // We shrink the raw_inputs by the predefined scale, before passing them
     // into model fitting. This will produce the linear coefficients at a

--- a/soroban-env-host/benches/common/modelfit.rs
+++ b/soroban-env-host/benches/common/modelfit.rs
@@ -92,12 +92,16 @@ pub fn fit_model(raw_inputs: Vec<u64>, outputs: Vec<u64>) -> FPCostModel {
     }
 
     check_inputs_for_fitting(&raw_inputs);
-    // we've already made sure all the inputs contain enough bits, so we can
-    // safely scale them back. This will produce the linear coefficinet with
-    // higher precision.
+
+    // We shrink the raw_inputs by the predefined scale, before passing them
+    // into model fitting. This will produce the linear coefficients at a
+    // larger-than-normal scale, thus when converted back to u64, will retain
+    // more precision. In the actual budget charge, when the model is applied,
+    // the evaluated output will be scaled back to produce the corrrect cost
+    // output.
     let x: Vec<f64> = raw_inputs
         .iter()
-        .map(|i| (*i >> COST_MODEL_LIN_TERM_SCALE_BITS) as f64)
+        .map(|i| (*i as f64) / ((1u64 << COST_MODEL_LIN_TERM_SCALE_BITS) as f64))
         .collect();
     let y: Vec<f64> = outputs.iter().map(|i| *i as f64).collect();
 

--- a/soroban-env-host/benches/variation_histograms.rs
+++ b/soroban-env-host/benches/variation_histograms.rs
@@ -2,11 +2,12 @@
 // $ cargo bench --features testutils --bench variation_histograms -- --nocapture
 mod common;
 use common::*;
-use soroban_env_host::cost_runner::CostRunner;
+use soroban_env_host::{budget::MeteredCostComponent, cost_runner::CostRunner};
 
 struct LinearModelTables;
 impl Benchmark for LinearModelTables {
-    fn bench<HCM: HostCostMeasurement>() -> std::io::Result<(FPCostModel, FPCostModel)> {
+    fn bench<HCM: HostCostMeasurement>(
+    ) -> std::io::Result<(MeteredCostComponent, MeteredCostComponent)> {
         let mut measurements = measure_cost_variation::<HCM>(100, 1000, false, false)?;
         measurements.check_range_against_baseline(&HCM::Runner::COST_TYPE)?;
         measurements.preprocess();

--- a/soroban-env-host/benches/worst_case_linear_models.rs
+++ b/soroban-env-host/benches/worst_case_linear_models.rs
@@ -15,7 +15,9 @@ use tabwriter::{Alignment, TabWriter};
 struct WorstCaseLinearModels;
 impl Benchmark for WorstCaseLinearModels {
     fn bench<HCM: HostCostMeasurement>() -> std::io::Result<(FPCostModel, FPCostModel)> {
-        let mut measurements = measure_worst_case_costs::<HCM>(1..20)?;
+        let floor = std::env::var("FLOOR").ok().map(|v| v.parse::<u64>().ok()).flatten().unwrap_or(1);
+        let range = std::env::var("RANGE").ok().map(|v| v.parse::<u64>().ok()).flatten().unwrap_or(20);
+        let mut measurements = measure_worst_case_costs::<HCM>(floor..range)?;
         measurements.check_range_against_baseline(&HCM::Runner::COST_TYPE)?;
         measurements.preprocess();
         measurements.report_table();

--- a/soroban-env-host/benches/worst_case_linear_models.rs
+++ b/soroban-env-host/benches/worst_case_linear_models.rs
@@ -31,10 +31,20 @@ impl Benchmark for WorstCaseLinearModels {
         measurements.check_range_against_baseline(&HCM::Runner::COST_TYPE)?;
         measurements.preprocess();
         measurements.report_table();
-        let cpu_model = measurements.fit_model_to_cpu();
-        let mem_model = measurements.fit_model_to_mem();
-        println!("cpu model params: {:?}", cpu_model);
-        println!("mem model params: {:?}", mem_model);
+        let (cpu_model, cpu_r2) = measurements.fit_model_to_cpu();
+        let (mem_model, mem_r2) = measurements.fit_model_to_mem();
+        println!(
+            "{:?} cpu: {:?}, R2 score: {}",
+            HCM::Runner::COST_TYPE,
+            cpu_model,
+            cpu_r2
+        );
+        println!(
+            "{:?} mem: {:?}, R2 score: {}",
+            HCM::Runner::COST_TYPE,
+            mem_model,
+            mem_r2
+        );
         Ok((cpu_model, mem_model))
     }
 }

--- a/soroban-env-host/benches/worst_case_linear_models.rs
+++ b/soroban-env-host/benches/worst_case_linear_models.rs
@@ -15,8 +15,16 @@ use tabwriter::{Alignment, TabWriter};
 struct WorstCaseLinearModels;
 impl Benchmark for WorstCaseLinearModels {
     fn bench<HCM: HostCostMeasurement>() -> std::io::Result<(FPCostModel, FPCostModel)> {
-        let floor = std::env::var("FLOOR").ok().map(|v| v.parse::<u64>().ok()).flatten().unwrap_or(1);
-        let range = std::env::var("RANGE").ok().map(|v| v.parse::<u64>().ok()).flatten().unwrap_or(20);
+        let floor = std::env::var("FLOOR")
+            .ok()
+            .map(|v| v.parse::<u64>().ok())
+            .flatten()
+            .unwrap_or(1);
+        let range = std::env::var("RANGE")
+            .ok()
+            .map(|v| v.parse::<u64>().ok())
+            .flatten()
+            .unwrap_or(20);
         let mut measurements = measure_worst_case_costs::<HCM>(floor..range)?;
         measurements.check_range_against_baseline(&HCM::Runner::COST_TYPE)?;
         measurements.preprocess();

--- a/soroban-env-host/benches/worst_case_linear_models.rs
+++ b/soroban-env-host/benches/worst_case_linear_models.rs
@@ -19,7 +19,7 @@ impl Benchmark for WorstCaseLinearModels {
             .ok()
             .map(|v| v.parse::<u64>().ok())
             .flatten()
-            .unwrap_or(1);
+            .unwrap_or(0);
         let range = std::env::var("RANGE")
             .ok()
             .map(|v| v.parse::<u64>().ok())

--- a/soroban-env-host/src/budget.rs
+++ b/soroban-env-host/src/budget.rs
@@ -6,7 +6,7 @@ mod wasmi_helper;
 
 pub(crate) use limits::DepthLimiter;
 pub use limits::{DEFAULT_HOST_DEPTH_LIMIT, DEFAULT_XDR_RW_LIMITS};
-pub use model::COST_MODEL_LIN_TERM_SCALE_BITS;
+pub use model::{MeteredCostComponent, ScaledU64};
 
 use std::{
     cell::{RefCell, RefMut},
@@ -21,7 +21,6 @@ use crate::{
 };
 
 use dimension::{BudgetDimension, IsCpu, IsShadowMode};
-use model::ScaledU64;
 use wasmi_helper::FuelConfig;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord)]

--- a/soroban-env-host/src/budget.rs
+++ b/soroban-env-host/src/budget.rs
@@ -587,14 +587,6 @@ impl Display for BudgetImpl {
 #[allow(unused)]
 #[cfg(test)]
 impl BudgetImpl {
-    fn retrieve_unscaled_param(param: ScaledU64, is_protocol20: bool) -> u64 {
-        const PROTOCOL_20_LIN_TERM_SCALE_BITS: u32 = 7;
-        match is_protocol20 {
-            true => param.unscale() << PROTOCOL_20_LIN_TERM_SCALE_BITS,
-            false => param.0,
-        }
-    }
-
     // Utility function for printing default budget cost parameters in cpp format
     // so that it can be ported into stellar-core.
     // When needing it, copy and run the following test
@@ -602,11 +594,11 @@ impl BudgetImpl {
     // #[test]
     // fn test() {
     //     let bi = BudgetImpl::default();
-    //     bi.print_default_params_in_cpp(true);
+    //     bi.print_default_params_in_cpp();
     // }
     // ```
     // and copy the screen output.
-    fn print_default_params_in_cpp(&self, is_protocol20: bool) {
+    fn print_default_params_in_cpp(&self) {
         // cpu
         println!();
         println!();
@@ -618,8 +610,7 @@ impl BudgetImpl {
             println!("case {}:", ct.name());
             println!(
                 "params[val] = ContractCostParamEntry{{ExtensionPoint{{0}}, {}, {}}};",
-                cpu.const_term,
-                Self::retrieve_unscaled_param(cpu.lin_term.clone(), is_protocol20)
+                cpu.const_term, cpu.lin_term.0
             );
             println!("break;");
         }
@@ -634,8 +625,7 @@ impl BudgetImpl {
             println!("case {}:", ct.name());
             println!(
                 "params[val] = ContractCostParamEntry{{ExtensionPoint{{0}}, {}, {}}};",
-                mem.const_term,
-                Self::retrieve_unscaled_param(mem.lin_term.clone(), is_protocol20)
+                mem.const_term, mem.lin_term.0
             );
             println!("break;");
         }

--- a/soroban-env-host/src/budget/model.rs
+++ b/soroban-env-host/src/budget/model.rs
@@ -35,7 +35,7 @@ pub trait HostCostModel {
 /// been scaled by this factor during parameter fitting to retain more significant
 /// digits. Thus to get the cost from the raw input, we need to scale the result
 /// back by the same factor.
-pub const COST_MODEL_LIN_TERM_SCALE_BITS: u32 = 7;
+pub const COST_MODEL_LIN_TERM_SCALE_BITS: u32 = 0;
 
 /// A helper type that wraps an u64 to signify the wrapped value have been scaled.
 #[derive(Clone, Default)]

--- a/soroban-env-host/src/budget/model.rs
+++ b/soroban-env-host/src/budget/model.rs
@@ -35,19 +35,19 @@ pub trait HostCostModel {
 /// been scaled by this factor during parameter fitting to retain more significant
 /// digits. Thus to get the cost from the raw input, we need to scale the result
 /// back by the same factor.
-pub const COST_MODEL_LIN_TERM_SCALE_BITS: u32 = 7;
+const COST_MODEL_LIN_TERM_SCALE_BITS: u32 = 7;
 
 /// A helper type that wraps an u64 to signify the wrapped value have been scaled.
-#[derive(Clone, Default)]
-pub(crate) struct ScaledU64(pub(crate) u64);
+#[derive(Clone, Default, Debug)]
+pub struct ScaledU64(pub(crate) u64);
 
 impl ScaledU64 {
-    pub const fn unscale(self) -> u64 {
-        self.0 >> COST_MODEL_LIN_TERM_SCALE_BITS
-    }
-
     pub const fn from_unscaled_u64(u: u64) -> Self {
         ScaledU64(u << COST_MODEL_LIN_TERM_SCALE_BITS)
+    }
+
+    pub const fn unscale(self) -> u64 {
+        self.0 >> COST_MODEL_LIN_TERM_SCALE_BITS
     }
 
     pub const fn is_zero(&self) -> bool {
@@ -72,16 +72,10 @@ impl Display for ScaledU64 {
     }
 }
 
-impl Debug for ScaledU64 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Scaled({})", self.0)
-    }
-}
-
 #[derive(Clone, Debug, Default)]
-pub(crate) struct MeteredCostComponent {
-    pub(crate) const_term: u64,
-    pub(crate) lin_term: ScaledU64,
+pub struct MeteredCostComponent {
+    pub const_term: u64,
+    pub lin_term: ScaledU64,
 }
 
 impl TryFrom<&ContractCostParamEntry> for MeteredCostComponent {

--- a/soroban-env-host/src/budget/model.rs
+++ b/soroban-env-host/src/budget/model.rs
@@ -35,7 +35,7 @@ pub trait HostCostModel {
 /// been scaled by this factor during parameter fitting to retain more significant
 /// digits. Thus to get the cost from the raw input, we need to scale the result
 /// back by the same factor.
-pub const COST_MODEL_LIN_TERM_SCALE_BITS: u32 = 0;
+pub const COST_MODEL_LIN_TERM_SCALE_BITS: u32 = 7;
 
 /// A helper type that wraps an u64 to signify the wrapped value have been scaled.
 #[derive(Clone, Default)]

--- a/soroban-env-host/src/budget/model.rs
+++ b/soroban-env-host/src/budget/model.rs
@@ -35,7 +35,7 @@ pub trait HostCostModel {
 /// been scaled by this factor during parameter fitting to retain more significant
 /// digits. Thus to get the cost from the raw input, we need to scale the result
 /// back by the same factor.
-pub const COST_MODEL_LIN_TERM_SCALE_BITS: u32 = 5;
+pub const COST_MODEL_LIN_TERM_SCALE_BITS: u32 = 7;
 
 /// A helper type that wraps an u64 to signify the wrapped value have been scaled.
 #[derive(Clone, Default)]

--- a/soroban-env-host/src/budget/model.rs
+++ b/soroban-env-host/src/budget/model.rs
@@ -72,6 +72,7 @@ impl Display for ScaledU64 {
     }
 }
 
+#[cfg(feature = "bench")]
 impl From<f64> for ScaledU64 {
     fn from(unscaled: f64) -> Self {
         let scaled = unscaled * ((1 << COST_MODEL_LIN_TERM_SCALE_BITS) as f64);

--- a/soroban-env-host/src/budget/model.rs
+++ b/soroban-env-host/src/budget/model.rs
@@ -35,7 +35,7 @@ pub trait HostCostModel {
 /// been scaled by this factor during parameter fitting to retain more significant
 /// digits. Thus to get the cost from the raw input, we need to scale the result
 /// back by the same factor.
-pub const COST_MODEL_LIN_TERM_SCALE_BITS: u32 = 7;
+pub const COST_MODEL_LIN_TERM_SCALE_BITS: u32 = 5;
 
 /// A helper type that wraps an u64 to signify the wrapped value have been scaled.
 #[derive(Clone, Default)]

--- a/soroban-env-host/src/budget/model.rs
+++ b/soroban-env-host/src/budget/model.rs
@@ -72,6 +72,14 @@ impl Display for ScaledU64 {
     }
 }
 
+impl From<f64> for ScaledU64 {
+    fn from(unscaled: f64) -> Self {
+        let scaled = unscaled * ((1 << COST_MODEL_LIN_TERM_SCALE_BITS) as f64);
+        // We err on the side of overestimation by applying `ceil` to the input.
+        ScaledU64(scaled.ceil() as u64)
+    }
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct MeteredCostComponent {
     pub const_term: u64,


### PR DESCRIPTION
### What

This PR was originated from the fact that previously the `VarDeser` cost's constant term was unrealistically high.  

It improves the numerical approach towards model generation by constraining it to the smallest input in the range. 
Thus it avoids fitting a model that tries to produce a marginally better fitness at the expense of lower-range accuracy. 

It also removes the dependency of the `HostCostMeasurement`'s input size on the linear parameter's scale factor (`COST_MODEL_LIN_TERM_SCALE_BITS`), which previously put a numerical constrain on the smallest input size and minimal gaps.

[raw calibration outputs](https://github.com/stellar/rs-soroban-env/files/13621533/output_x86_dec_8.txt)

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
