### PR TITLE
Use strkeys for contract IDs and addresses in diagnostic events.

### DIFF
--- a/soroban-env-host/src/events/mod.rs
+++ b/soroban-env-host/src/events/mod.rs
@@ -28,12 +28,12 @@ fn display_address(addr: &ScAddress, f: &mut std::fmt::Formatter<'_>) -> std::fm
         ScAddress::Account(acct) => match &acct.0 {
             PublicKeyTypeEd25519(e) => {
                 let strkey = stellar_strkey::ed25519::PublicKey(e.0.clone());
-                write!(f, "Address(Account({}))", strkey)
+                write!(f, "{}", strkey)
             }
         },
         ScAddress::Contract(hash) => {
             let strkey = stellar_strkey::Contract(hash.0.clone());
-            write!(f, "Address(Contract({}))", strkey)
+            write!(f, "{}", strkey)
         }
     }
 }
@@ -160,7 +160,7 @@ fn host_event_contract_id_is_strkey() {
     };
     assert_eq!(
         format!("{}", he),
-        "[Diagnostic Event] contract:CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4, topics:[Address(Account(GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF))], data:Void"
+        "[Diagnostic Event] contract:CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4, topics:[GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF], data:Void"
     );
 }
 

--- a/soroban-env-host/src/events/mod.rs
+++ b/soroban-env-host/src/events/mod.rs
@@ -27,12 +27,12 @@ fn display_address(addr: &ScAddress, f: &mut std::fmt::Formatter<'_>) -> std::fm
     match addr {
         ScAddress::Account(acct) => match &acct.0 {
             PublicKeyTypeEd25519(e) => {
-                let strkey = stellar_strkey::ed25519::PublicKey(e.0.clone());
+                let strkey = stellar_strkey::ed25519::PublicKey(e.0);
                 write!(f, "{}", strkey)
             }
         },
         ScAddress::Contract(hash) => {
-            let strkey = stellar_strkey::Contract(hash.0.clone());
+            let strkey = stellar_strkey::Contract(hash.0);
             write!(f, "{}", strkey)
         }
     }
@@ -116,7 +116,7 @@ impl core::fmt::Display for HostEvent {
         match &self.event.contract_id {
             None => (),
             Some(hash) => {
-                let strkey = stellar_strkey::Contract(hash.0.clone());
+                let strkey = stellar_strkey::Contract(hash.0);
                 write!(f, "contract:{}, ", strkey)?
             }
         }


### PR DESCRIPTION
What it says on the label.

Fixes #1049 