### PR TITLE
Bump cackle-action to 0.7.0 to support debuginfo changes in rust 1.75

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cackle-rs/cackle-action@387fe459d8c037a0e7fbcd3d868f1aaba389d057
+      - uses: cackle-rs/cackle-action@997327f77e59d9cda7b0b6217f0fbdbd3f3ca904
       - run: cargo acl -n run
 
   cargo-deny:


### PR DESCRIPTION
Rust 1.75 emits some new dwarf debuginfo that cackle 0.6.0 didn't understand. This was [fixed in cackle](https://github.com/cackle-rs/cackle/commit/0d1a38e4005ccc54a2c7e39efb7f8d7061545f74) a while ago we just have a pinned dependency. This PR updates that pin.