### PR TITLE
Enable publish of soroban-simulation crate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,7 +72,7 @@ jobs:
       with:
         name: cargo-semver-checks
         version: 0.27.0
-    - run: cargo semver-checks
+    - run: cargo semver-checks --exclude soroban-simulation
 
   build-and-test:
     strategy:

--- a/soroban-simulation/Cargo.toml
+++ b/soroban-simulation/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 rust-version.workspace = true
 
 # Temporary until we publish, to satisfy cargo-semver-checks
-publish = false
+publish = true
 
 [dependencies]
 # To be removed


### PR DESCRIPTION
### What
Enable publish of soroban-simulation crate

### Why
It is depended on by the soroban-rpc and should have been included in the v20.2.0 release, but appears we forgot to set it as publishable.