### PR TITLE
Try giving `bump-version` workflow a permission to read other workflows.

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -11,5 +11,7 @@ jobs:
 
   bump-version:
     uses: stellar/actions/.github/workflows/rust-bump-version.yml@main
+    permissions:
+      workflows: read
     with:
       version: ${{ inputs.version }}


### PR DESCRIPTION
### What

Try giving `bump-version` workflow a permission to read other workflows.

### Why

Trying to fix the workflow.

### Known limitations

Not sure this actually works.
