### PR TITLE
Give necessary permissions to bump-version workflow.

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -11,5 +11,9 @@ jobs:
 
   bump-version:
     uses: stellar/actions/.github/workflows/rust-bump-version.yml@main
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write    
     with:
       version: ${{ inputs.version }}


### PR DESCRIPTION
### What

Give necessary permissions to bump-version workflow.

This is likely a temporary fix until we figure out whether this should be done in the top-level workflow, or fixed in the default settings and removed.

### Why

To unblock bump-version workflow

### Known limitations

N/A
