### PR TITLE
Package version 21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1352,7 +1352,7 @@ checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
 name = "soroban-bench-utils"
-version = "20.3.0"
+version = "21.0.0"
 dependencies = [
  "perf-event",
  "soroban-env-common",
@@ -1361,7 +1361,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "20.3.0"
+version = "21.0.0"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1371,7 +1371,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "20.3.0"
+version = "21.0.0"
 dependencies = [
  "arbitrary",
  "crate-git-revision",
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "20.3.0"
+version = "21.0.0"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -1398,7 +1398,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "20.3.0"
+version = "21.0.0"
 dependencies = [
  "arbitrary",
  "backtrace",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "20.3.0"
+version = "21.0.0"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-simulation"
-version = "20.3.0"
+version = "21.0.0"
 dependencies = [
  "anyhow",
  "pretty_assertions",
@@ -1479,7 +1479,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-synth-wasm"
-version = "20.3.0"
+version = "21.0.0"
 dependencies = [
  "arbitrary",
  "expect-test",
@@ -1493,7 +1493,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-test-wasms"
-version = "20.3.0"
+version = "21.0.0"
 
 [[package]]
 name = "soroban-wasmi"
@@ -1607,7 +1607,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "test_no_std"
-version = "20.3.0"
+version = "21.0.0"
 dependencies = [
  "soroban-env-common",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,15 +20,15 @@ exclude = ["soroban-test-wasms/wasm-workspace"]
 # NB: When bumping the major version make sure to clean up the
 # code guarded by `unstable-*` features to make it enabled
 # unconditionally.
-version = "20.3.0"
+version = "21.0.0"
 rust-version = "1.74.0"
 
 [workspace.dependencies]
-soroban-env-common = { version = "=20.3.0", path = "soroban-env-common", default-features = false }
-soroban-env-guest = { version = "=20.3.0", path = "soroban-env-guest" }
-soroban-env-host = { version = "=20.3.0", path = "soroban-env-host" }
-soroban-env-macros = { version = "=20.3.0", path = "soroban-env-macros" }
-soroban-builtin-sdk-macros = { version = "=20.3.0", path = "soroban-builtin-sdk-macros" }
+soroban-env-common = { version = "=21.0.0", path = "soroban-env-common", default-features = false }
+soroban-env-guest = { version = "=21.0.0", path = "soroban-env-guest" }
+soroban-env-host = { version = "=21.0.0", path = "soroban-env-host" }
+soroban-env-macros = { version = "=21.0.0", path = "soroban-env-macros" }
+soroban-builtin-sdk-macros = { version = "=21.0.0", path = "soroban-builtin-sdk-macros" }
 # NB: this must match the wasmparser version wasmi is using
 wasmparser = "=0.116.1"
 

--- a/soroban-env-host/src/storage.rs
+++ b/soroban-env-host/src/storage.rs
@@ -55,18 +55,10 @@ pub enum AccessType {
 /// A helper type used by [FootprintMode::Recording] to provide access
 /// to a stable read-snapshot of a ledger.
 /// The snapshot is expected to only return live ledger entries.
-#[cfg(any(test, feature = "unstable-next-api"))]
 pub trait SnapshotSource {
     /// Returns the ledger entry for the key and its live_until ledger if entry
     /// exists, or `None` otherwise.
     fn get(&self, key: &Rc<LedgerKey>) -> Result<Option<EntryWithLiveUntil>, HostError>;
-}
-
-#[cfg(not(any(test, feature = "unstable-next-api")))]
-pub trait SnapshotSource {
-    // Returns the ledger entry for the key and its live_until ledger.
-    fn get(&self, key: &Rc<LedgerKey>) -> Result<EntryWithLiveUntil, HostError>;
-    fn has(&self, key: &Rc<LedgerKey>) -> Result<bool, HostError>;
 }
 
 /// Describes the total set of [LedgerKey]s that a given transaction
@@ -471,16 +463,7 @@ impl Storage {
                 // In recording mode we treat the map as a cache
                 // that misses read-through to the underlying src.
                 if !self.map.contains_key::<Rc<LedgerKey>>(key, budget)? {
-                    #[cfg(any(test, feature = "unstable-next-api"))]
                     let value = src.get(&key)?;
-
-                    #[cfg(not(any(test, feature = "unstable-next-api")))]
-                    let value = if src.has(&key)? {
-                        Some(src.get(key)?)
-                    } else {
-                        None
-                    };
-
                     self.map = self.map.insert(key.clone(), value, budget)?;
                 }
             }

--- a/soroban-env-host/src/testutils.rs
+++ b/soroban-env-host/src/testutils.rs
@@ -1,5 +1,4 @@
 use crate::e2e_invoke::ledger_entry_to_ledger_key;
-#[cfg(any(test, feature = "unstable-next-api"))]
 use crate::storage::EntryWithLiveUntil;
 use crate::{
     budget::Budget,
@@ -134,7 +133,6 @@ impl MockSnapshotSource {
     }
 }
 
-#[cfg(any(test, feature = "unstable-next-api"))]
 impl SnapshotSource for MockSnapshotSource {
     fn get(&self, key: &Rc<LedgerKey>) -> Result<Option<EntryWithLiveUntil>, HostError> {
         if let Some((entry, live_until)) = self.0.get(key) {
@@ -142,25 +140,6 @@ impl SnapshotSource for MockSnapshotSource {
         } else {
             Ok(None)
         }
-    }
-}
-
-#[cfg(not(any(test, feature = "unstable-next-api")))]
-impl SnapshotSource for MockSnapshotSource {
-    fn get(&self, key: &Rc<LedgerKey>) -> Result<(Rc<LedgerEntry>, Option<u32>), HostError> {
-        if let Some(val) = self.0.get(key) {
-            Ok((Rc::clone(&val.0), val.1))
-        } else {
-            Err((
-                crate::xdr::ScErrorType::Storage,
-                crate::xdr::ScErrorCode::MissingValue,
-            )
-                .into())
-        }
-    }
-
-    fn has(&self, key: &Rc<LedgerKey>) -> Result<bool, HostError> {
-        Ok(self.0.contains_key(key))
     }
 }
 


### PR DESCRIPTION
This is a followup to https://github.com/stellar/rs-soroban-env/pull/1384 that ungates the `unstable-next-api` feature code (and deletes the previous variants) and sets the package version to 21.0.0