### PR TITLE
Use the released 21.0.0 XDR.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1542,8 +1542,9 @@ dependencies = [
 
 [[package]]
 name = "stellar-xdr"
-version = "20.1.0"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=d0138770652a615e3cd99447f2f2727658c17450#d0138770652a615e3cd99447f2f2727658c17450"
+version = "21.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "193cef4375f498306b3b39d2182b8e1192904fc90dd2eec8b3f3007b87c427c7"
 dependencies = [
  "arbitrary",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,9 @@ wasmparser = "=0.116.1"
 
 # NB: When updating, also update the version in rs-soroban-env dev-dependencies
 [workspace.dependencies.stellar-xdr]
-version = "=20.1.0"
-git = "https://github.com/stellar/rs-stellar-xdr"
-rev = "d0138770652a615e3cd99447f2f2727658c17450"
+version = "=21.0.0"
+# git = "https://github.com/stellar/rs-stellar-xdr"
+# rev = "d0138770652a615e3cd99447f2f2727658c17450"
 default-features = false
 
 [workspace.dependencies.wasmi]

--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -93,9 +93,9 @@ k256 = {version = "=0.13.1", default-features = false, features = ["alloc"]}
 p256 = {version = "=0.13.2", default-features = false, features = ["alloc"]}
 
 [dev-dependencies.stellar-xdr]
-version = "=20.1.0"
-git = "https://github.com/stellar/rs-stellar-xdr"
-rev = "d0138770652a615e3cd99447f2f2727658c17450"
+version = "=21.0.0"
+# git = "https://github.com/stellar/rs-stellar-xdr"
+# rev = "d0138770652a615e3cd99447f2f2727658c17450"
 default-features = false
 features = ["arbitrary"]
 


### PR DESCRIPTION
### What

Use the released 21.0.0 XDR.

### Why

Preparing for 21.0.0 release

### Known limitations

N/A
