### PR TITLE
Improved TTL testing UX and cleaned up storage diagnostics.

### DIFF
--- a/soroban-env-host/observations/20/test_v_new_call_nonexistent_wasm_call.json
+++ b/soroban-env-host/observations/20/test_v_new_call_nonexistent_wasm_call.json
@@ -3,6 +3,6 @@
   "   1 call vec_new()": "cpu:42436, mem:373, objs:-/1@10432200, store:-/1@6f750601, foot:1@2784223c",
   "   2 ret vec_new -> Ok(Vec(obj#3))": "cpu:42937, mem:437, objs:-/2@acf0be8f",
   "   3 call call(Address(obj#1), Symbol(test), Vec(obj#3))": "",
-  "   4 ret call -> Err(Error(Storage, ExceededLimit))": "cpu:51600, mem:941",
-  "   5 end": "cpu:51600, mem:941, prngs:-/-, objs:-/2@acf0be8f, vm:-/-, evt:-, store:-/1@6f750601, foot:1@2784223c, stk:-, auth:-/-"
+  "   4 ret call -> Err(Error(Storage, ExceededLimit))": "cpu:51600, mem:941, objs:-/3@69a02720",
+  "   5 end": "cpu:51600, mem:941, prngs:-/-, objs:-/3@69a02720, vm:-/-, evt:-, store:-/1@6f750601, foot:1@2784223c, stk:-, auth:-/-"
 }

--- a/soroban-env-host/observations/20/test_v_new_call_runtime_deleted_wasm_call.json
+++ b/soroban-env-host/observations/20/test_v_new_call_runtime_deleted_wasm_call.json
@@ -7,6 +7,6 @@
   "   5 pop VM:3fa21985:test -> Ok(Symbol(pass))": "cpu:219364, mem:169803",
   "   6 ret call -> Ok(Symbol(pass))": " vm:-/-, stk:-, auth:-/-",
   "   7 call call(Address(obj#1), Symbol(test), Vec(obj#3))": "cpu:261360, mem:170112, store:-/1@6f750601, foot:1@2784223c",
-  "   8 ret call -> Err(Error(Storage, ExceededLimit))": "cpu:269410, mem:170600",
-  "   9 end": "cpu:269410, mem:170600, prngs:-/-, objs:-/3@2988da9d, vm:-/-, evt:-, store:-/1@6f750601, foot:1@2784223c, stk:-, auth:-/-"
+  "   8 ret call -> Err(Error(Storage, ExceededLimit))": "cpu:269410, mem:170600, objs:-/4@d193fe73",
+  "   9 end": "cpu:269410, mem:170600, prngs:-/-, objs:-/4@d193fe73, vm:-/-, evt:-, store:-/1@6f750601, foot:1@2784223c, stk:-, auth:-/-"
 }

--- a/soroban-env-host/observations/20/test_v_new_rewrite_call_fail.json
+++ b/soroban-env-host/observations/20/test_v_new_rewrite_call_fail.json
@@ -1,4 +1,4 @@
 {
   "   0 begin": "cpu:2746, mem:343, prngs:-/-, objs:-/-, vm:-/-, evt:-, store:-/2@82fc3f1e, foot:2@5287c081, stk:-, auth:-/-",
-  "   1 end": "cpu:2106672, mem:534384, prngs:-/-, objs:-/2@846c64a, vm:-/-, evt:-, store:-/2@82fc3f1e, foot:2@5287c081, stk:-, auth:-/-"
+  "   1 end": "cpu:2105703, mem:534272, prngs:-/-, objs:-/2@846c64a, vm:-/-, evt:-, store:-/2@82fc3f1e, foot:2@5287c081, stk:-, auth:-/-"
 }

--- a/soroban-env-host/observations/21/test_v_new_call_nonexistent_wasm_call.json
+++ b/soroban-env-host/observations/21/test_v_new_call_nonexistent_wasm_call.json
@@ -3,6 +3,6 @@
   "   1 call vec_new()": "cpu:42436, mem:373, objs:-/1@10432200, store:-/1@6f750601, foot:1@2784223c",
   "   2 ret vec_new -> Ok(Vec(obj#3))": "cpu:42937, mem:437, objs:-/2@acf0be8f",
   "   3 call call(Address(obj#1), Symbol(test), Vec(obj#3))": "",
-  "   4 ret call -> Err(Error(Storage, ExceededLimit))": "cpu:51600, mem:941",
-  "   5 end": "cpu:51600, mem:941, prngs:-/-, objs:-/2@acf0be8f, vm:-/-, evt:-, store:-/1@6f750601, foot:1@2784223c, stk:-, auth:-/-"
+  "   4 ret call -> Err(Error(Storage, ExceededLimit))": "cpu:51600, mem:941, objs:-/3@69a02720",
+  "   5 end": "cpu:51600, mem:941, prngs:-/-, objs:-/3@69a02720, vm:-/-, evt:-, store:-/1@6f750601, foot:1@2784223c, stk:-, auth:-/-"
 }

--- a/soroban-env-host/observations/21/test_v_new_call_runtime_deleted_wasm_call.json
+++ b/soroban-env-host/observations/21/test_v_new_call_runtime_deleted_wasm_call.json
@@ -7,6 +7,6 @@
   "   5 pop VM:3fa21985:test -> Ok(Symbol(pass))": "cpu:219364, mem:169803",
   "   6 ret call -> Ok(Symbol(pass))": " vm:-/-, stk:-, auth:-/-",
   "   7 call call(Address(obj#1), Symbol(test), Vec(obj#3))": "cpu:261360, mem:170112, store:-/1@6f750601, foot:1@2784223c",
-  "   8 ret call -> Err(Error(Storage, ExceededLimit))": "cpu:269410, mem:170600",
-  "   9 end": "cpu:269410, mem:170600, prngs:-/-, objs:-/3@2988da9d, vm:-/-, evt:-, store:-/1@6f750601, foot:1@2784223c, stk:-, auth:-/-"
+  "   8 ret call -> Err(Error(Storage, ExceededLimit))": "cpu:269410, mem:170600, objs:-/4@d193fe73",
+  "   9 end": "cpu:269410, mem:170600, prngs:-/-, objs:-/4@d193fe73, vm:-/-, evt:-, store:-/1@6f750601, foot:1@2784223c, stk:-, auth:-/-"
 }

--- a/soroban-env-host/observations/21/test_v_new_rewrite_call_fail.json
+++ b/soroban-env-host/observations/21/test_v_new_rewrite_call_fail.json
@@ -1,4 +1,4 @@
 {
   "   0 begin": "cpu:2746, mem:343, prngs:-/-, objs:-/-, vm:-/-, evt:-, store:-/2@82fc3f1e, foot:2@5287c081, stk:-, auth:-/-",
-  "   1 end": "cpu:1467786, mem:454165, prngs:-/-, objs:-/2@846c64a, vm:-/-, evt:-, store:-/2@82fc3f1e, foot:2@5287c081, stk:-, auth:-/-"
+  "   1 end": "cpu:1466817, mem:454053, prngs:-/-, objs:-/2@846c64a, vm:-/-, evt:-, store:-/2@82fc3f1e, foot:2@5287c081, stk:-, auth:-/-"
 }

--- a/soroban-env-host/src/host/lifecycle.rs
+++ b/soroban-env-host/src/host/lifecycle.rs
@@ -1,5 +1,4 @@
 use crate::{
-    budget::AsBudget,
     err,
     host::{
         metered_clone::{MeteredAlloc, MeteredClone},
@@ -25,8 +24,7 @@ impl Host {
         let storage_key = self.contract_instance_ledger_key(&contract_id)?;
         if self
             .try_borrow_storage_mut()?
-            .has(&storage_key, self.as_budget())
-            .map_err(|e| self.decorate_contract_instance_storage_error(e, &contract_id))?
+            .has_with_host(&storage_key, self, None)?
         {
             return Err(self.err(
                 ScErrorType::Storage,
@@ -212,17 +210,13 @@ impl Host {
 
         // We will definitely put the contract in the ledger if it isn't there yet.
         #[allow(unused_mut)]
-        let mut should_put_contract = !storage
-            .has(&code_key, self.as_budget())
-            .map_err(|e| self.decorate_contract_code_storage_error(e, &Hash(hash_bytes)))?;
+        let mut should_put_contract = !storage.has_with_host(&code_key, self, None)?;
 
         // We may also, in the cache-supporting protocol, overwrite the contract if its ext field changed.
         if !should_put_contract
             && self.get_ledger_protocol_version()? >= super::ModuleCache::MIN_LEDGER_VERSION
         {
-            let entry = storage
-                .get(&code_key, self.as_budget())
-                .map_err(|e| self.decorate_contract_code_storage_error(e, &Hash(hash_bytes)))?;
+            let entry = storage.get_with_host(&code_key, self, None)?;
             if let crate::xdr::LedgerEntryData::ContractCode(ContractCodeEntry {
                 ext: old_ext,
                 ..
@@ -238,14 +232,13 @@ impl Host {
                 ext,
                 code: wasm_bytes_m,
             };
-            storage
-                .put(
-                    &code_key,
-                    &Host::new_contract_code(self, data)?,
-                    Some(self.get_min_live_until_ledger(ContractDataDurability::Persistent)?),
-                    self.as_budget(),
-                )
-                .map_err(|e| self.decorate_contract_code_storage_error(e, &Hash(hash_bytes)))?;
+            storage.put_with_host(
+                &code_key,
+                &Host::new_contract_code(self, data)?,
+                Some(self.get_min_live_until_ledger(ContractDataDurability::Persistent)?),
+                self,
+                None,
+            )?;
         }
         Ok(hash_obj)
     }

--- a/soroban-env-host/src/storage.rs
+++ b/soroban-env-host/src/storage.rs
@@ -9,11 +9,13 @@
 
 use std::rc::Rc;
 
+use crate::budget::AsBudget;
+use crate::host::metered_clone::MeteredClone;
 use crate::{
     budget::Budget,
     host::metered_map::MeteredOrdMap,
     ledger_info::get_key_durability,
-    xdr::{ContractDataDurability, LedgerEntry, LedgerKey, ScErrorCode, ScErrorType},
+    xdr::{ContractDataDurability, LedgerEntry, LedgerKey, ScErrorCode, ScErrorType, ScVal},
     Env, Error, Host, HostError, Val,
 };
 
@@ -221,6 +223,24 @@ impl Storage {
         }
     }
 
+    fn try_get_full_with_host(
+        &mut self,
+        key: &Rc<LedgerKey>,
+        host: &Host,
+        key_val: Option<Val>,
+    ) -> Result<Option<EntryWithLiveUntil>, HostError> {
+        let res = self
+            .try_get_full(key, host.as_budget())
+            .map_err(|e| host.decorate_storage_error(e, &*key, key_val))?;
+
+        #[cfg(any(test, feature = "testutils"))]
+        if !host.check_if_entry_is_live(&*key, &res, key_val)? {
+            return Ok(None);
+        }
+
+        Ok(res)
+    }
+
     /// Attempts to retrieve the [LedgerEntry] associated with a given
     /// [LedgerKey] in the [Storage], returning an error if the key is not
     /// found.
@@ -237,18 +257,31 @@ impl Storage {
         key: &Rc<LedgerKey>,
         budget: &Budget,
     ) -> Result<Rc<LedgerEntry>, HostError> {
-        self.try_get(key, budget)?
+        self.try_get_full(key, budget)?
             .ok_or_else(|| (ScErrorType::Storage, ScErrorCode::MissingValue).into())
+            .map(|e| e.0)
+    }
+    pub(crate) fn get_with_host(
+        &mut self,
+        key: &Rc<LedgerKey>,
+        host: &Host,
+        key_val: Option<Val>,
+    ) -> Result<Rc<LedgerEntry>, HostError> {
+        self.try_get_full_with_host(key, host, key_val)?
+            .ok_or_else(|| (ScErrorType::Storage, ScErrorCode::MissingValue).into())
+            .map(|e| e.0)
+            .map_err(|e| host.decorate_storage_error(e, &*key, key_val))
     }
 
-    // Like `get`, but distinguishes between missing values (return `Ok(None)`)
+    // Like `get_with_host`, but distinguishes between missing values (return `Ok(None)`)
     // and out-of-footprint values or errors (`Err(...)`).
     pub(crate) fn try_get(
         &mut self,
         key: &Rc<LedgerKey>,
-        budget: &Budget,
+        host: &Host,
+        key_val: Option<Val>,
     ) -> Result<Option<Rc<LedgerEntry>>, HostError> {
-        self.try_get_full(key, budget)
+        self.try_get_full_with_host(key, host, key_val)
             .map(|ok| ok.map(|pair| pair.0))
     }
 
@@ -269,10 +302,14 @@ impl Storage {
     pub(crate) fn get_with_live_until_ledger(
         &mut self,
         key: &Rc<LedgerKey>,
-        budget: &Budget,
+        host: &Host,
+        key_val: Option<Val>,
     ) -> Result<EntryWithLiveUntil, HostError> {
-        self.try_get_full(key, budget)?
-            .ok_or_else(|| (ScErrorType::Storage, ScErrorCode::MissingValue).into())
+        self.try_get_full_with_host(key, host, key_val)
+            .and_then(|maybe_entry| {
+                maybe_entry.ok_or_else(|| (ScErrorType::Storage, ScErrorCode::MissingValue).into())
+            })
+            .map_err(|e| host.decorate_storage_error(e, &*key, key_val))
     }
 
     // Helper function `put` and `del` funnel into.
@@ -299,6 +336,30 @@ impl Storage {
         Ok(())
     }
 
+    fn put_opt_with_host(
+        &mut self,
+        key: &Rc<LedgerKey>,
+        val: Option<EntryWithLiveUntil>,
+        host: &Host,
+        key_val: Option<Val>,
+    ) -> Result<(), HostError> {
+        let prev = host.as_budget().get_cpu_insns_consumed().unwrap();
+        #[cfg(any(test, feature = "testutils"))]
+        let _ = host.as_budget().with_observable_shadow_mode(|| {
+            let Ok(Some(entry_with_live_until)) =
+                self.map.get::<Rc<LedgerKey>>(key, host.as_budget())
+            else {
+                return Ok(());
+            };
+            let _ = host.check_if_entry_is_live(&*key, &entry_with_live_until, key_val)?;
+            Ok(())
+        })?;
+        let curr = host.as_budget().get_cpu_insns_consumed().unwrap();
+        assert_eq!(prev, curr);
+        self.put_opt(key, val, host.as_budget())
+            .map_err(|e| host.decorate_storage_error(e, &*key, key_val))
+    }
+
     /// Attempts to write to the [LedgerEntry] associated with a given
     /// [LedgerKey] in the [Storage].
     ///
@@ -319,6 +380,18 @@ impl Storage {
         self.put_opt(key, Some((val.clone(), live_until_ledger)), budget)
     }
 
+    pub(crate) fn put_with_host(
+        &mut self,
+        key: &Rc<LedgerKey>,
+        val: &Rc<LedgerEntry>,
+        live_until_ledger: Option<u32>,
+        host: &Host,
+        key_val: Option<Val>,
+    ) -> Result<(), HostError> {
+        let _span = tracy_span!("storage put");
+        self.put_opt_with_host(key, Some((val.clone(), live_until_ledger)), host, key_val)
+    }
+
     /// Attempts to delete the [LedgerEntry] associated with a given [LedgerKey]
     /// in the [Storage].
     ///
@@ -331,6 +404,17 @@ impl Storage {
     pub fn del(&mut self, key: &Rc<LedgerKey>, budget: &Budget) -> Result<(), HostError> {
         let _span = tracy_span!("storage del");
         self.put_opt(key, None, budget)
+    }
+
+    pub(crate) fn del_with_host(
+        &mut self,
+        key: &Rc<LedgerKey>,
+        host: &Host,
+        key_val: Option<Val>,
+    ) -> Result<(), HostError> {
+        let _span = tracy_span!("storage del");
+        self.put_opt_with_host(key, None, host, key_val)
+            .map_err(|e| host.decorate_storage_error(e, &*key, key_val))
     }
 
     /// Attempts to determine the presence of a [LedgerEntry] associated with a
@@ -355,6 +439,18 @@ impl Storage {
             .is_some())
     }
 
+    pub(crate) fn has_with_host(
+        &mut self,
+        key: &Rc<LedgerKey>,
+        host: &Host,
+        key_val: Option<Val>,
+    ) -> Result<bool, HostError> {
+        let _span = tracy_span!("storage has");
+        Ok(self.try_get_full_with_host(key, host, key_val)?.is_some())
+        // self.has(key, host.as_budget())
+        //     .map_err(|e| host.decorate_storage_error(e, &*key, key_val))
+    }
+
     /// Extends `key` to live `extend_to` ledgers from now (not counting the
     /// current ledger) if the current live_until_ledger for the entry is
     /// `threshold` ledgers or less away from the current ledger.
@@ -370,6 +466,7 @@ impl Storage {
         key: Rc<LedgerKey>,
         threshold: u32,
         extend_to: u32,
+        key_val: Option<Val>,
     ) -> Result<(), HostError> {
         let _span = tracy_span!("extend key");
         Self::check_supported_ledger_key_type(&key)?;
@@ -385,7 +482,7 @@ impl Storage {
 
         // Extending deleted/non-existing/out-of-footprint entries will result in
         // an error.
-        let (entry, old_live_until) = self.get_with_live_until_ledger(&key, host.budget_ref())?;
+        let (entry, old_live_until) = self.get_with_live_until_ledger(&key, &host, key_val)?;
         let old_live_until = old_live_until.ok_or_else(|| {
             host.err(
                 ScErrorType::Storage,
@@ -489,5 +586,159 @@ impl Storage {
             }
         };
         Ok(())
+    }
+}
+
+fn get_key_type_string_for_error(lk: &LedgerKey) -> &str {
+    match lk {
+        LedgerKey::ContractData(cd) => match cd.key {
+            ScVal::LedgerKeyContractInstance => "contract instance",
+            ScVal::LedgerKeyNonce(_) => "nonce",
+            _ => "contract data key",
+        },
+        LedgerKey::ContractCode(_) => "contract code",
+        LedgerKey::Account(_) => "account",
+        LedgerKey::Trustline(_) => "account trustline",
+        // This shouldn't normally trigger, but it's safer to just return
+        // a safe default instead of an error in case if new key types are
+        // accessed.
+        _ => "ledger key",
+    }
+}
+
+impl Host {
+    fn decorate_storage_error(
+        &self,
+        err: HostError,
+        lk: &LedgerKey,
+        key_val: Option<Val>,
+    ) -> HostError {
+        let mut err = err;
+        self.with_debug_mode(|| {
+            if !err.error.is_type(ScErrorType::Storage) {
+                return Ok(());
+            }
+            if !err.error.is_code(ScErrorCode::ExceededLimit)
+                && !err.error.is_code(ScErrorCode::MissingValue)
+            {
+                return Ok(());
+            }
+
+            let key_type_str = get_key_type_string_for_error(lk);
+            // Accessing an entry outside of the footprint is a non-recoverable error, thus
+            // there is no way to observe the object pool being changed (host will continue
+            // propagating an error until there are no frames left and control is never
+            // returned to guest). This allows us to build a nicer error message.
+            // For the missing values we unfortunately can only safely use the existing `Val`s
+            // to enhance errors.
+            let can_create_new_objects = err.error.is_code(ScErrorCode::ExceededLimit);
+            let args = self
+                .get_args_for_error(lk, key_val, can_create_new_objects)
+                .unwrap_or_else(|_| vec![]);
+            if err.error.is_code(ScErrorCode::ExceededLimit) {
+                err = self.err(
+                    ScErrorType::Storage,
+                    ScErrorCode::ExceededLimit,
+                    format!("trying to access {} outside of the footprint", key_type_str).as_str(),
+                    args.as_slice(),
+                );
+            } else if err.error.is_code(ScErrorCode::MissingValue) {
+                err = self.err(
+                    ScErrorType::Storage,
+                    ScErrorCode::MissingValue,
+                    format!("trying to get non-existing value for {}", key_type_str).as_str(),
+                    args.as_slice(),
+                );
+            }
+
+            Ok(())
+        });
+        err
+    }
+
+    fn get_args_for_error(
+        &self,
+        lk: &LedgerKey,
+        key_val: Option<Val>,
+        can_create_new_objects: bool,
+    ) -> Result<Vec<Val>, HostError> {
+        let mut res = vec![];
+        match lk {
+            LedgerKey::ContractData(cd) => {
+                if can_create_new_objects {
+                    let address_val = self
+                        .add_host_object(cd.contract.metered_clone(self.as_budget())?)?
+                        .into();
+                    res.push(address_val);
+                }
+                match &cd.key {
+                    ScVal::LedgerKeyContractInstance => (),
+                    ScVal::LedgerKeyNonce(n) => {
+                        if can_create_new_objects {
+                            res.push(self.add_host_object(n.nonce)?.into());
+                        }
+                    }
+                    _ => {
+                        if let Some(key) = key_val {
+                            res.push(key);
+                        }
+                    }
+                }
+            }
+            LedgerKey::ContractCode(c) => {
+                if can_create_new_objects {
+                    res.push(
+                        self.add_host_object(self.scbytes_from_hash(&c.hash)?)?
+                            .into(),
+                    );
+                }
+            }
+            LedgerKey::Account(_) | LedgerKey::Trustline(_) => {
+                if can_create_new_objects {
+                    res.push(self.account_address_from_key(lk)?.into())
+                }
+            }
+            // This shouldn't normally trigger, but it's safer to just return
+            // a safe default instead of an error in case if new key types are
+            // accessed.
+            _ => (),
+        };
+        Ok(res)
+    }
+
+    #[cfg(any(test, feature = "testutils"))]
+    fn check_if_entry_is_live(
+        &self,
+        key: &LedgerKey,
+        entry_with_live_until: &Option<EntryWithLiveUntil>,
+        key_val: Option<Val>,
+    ) -> Result<bool, HostError> {
+        let Some((_, Some(live_until_ledger))) = &entry_with_live_until else {
+            return Ok(true);
+        };
+        let ledger_seq = self
+            .with_ledger_info(|li| Ok(li.sequence_number))
+            .unwrap_or_default();
+        if *live_until_ledger >= ledger_seq {
+            return Ok(true);
+        }
+        match get_key_durability(key) {
+            Some(ContractDataDurability::Temporary) => Ok(false),
+            Some(ContractDataDurability::Persistent) => {
+                let key_type_str = get_key_type_string_for_error(key);
+                let args = self
+                    .as_budget()
+                    .with_observable_shadow_mode(|| self.get_args_for_error(key, key_val, true))
+                    .unwrap_or_else(|_| vec![]);
+                let msg = format!("[testing-only] Accessed {} key that has been archived. Important: this error may only appear in tests; in the real network contracts aren't called at all if any archived entry is accessed.", key_type_str);
+                Err(self.err(
+                    ScErrorType::Storage,
+                    ScErrorCode::InternalError,
+                    msg.as_str(),
+                    args.as_slice(),
+                ))
+            }
+            None => Ok(true),
+        }
     }
 }

--- a/soroban-env-host/src/test/auth.rs
+++ b/soroban-env-host/src/test/auth.rs
@@ -302,11 +302,11 @@ impl AuthTest {
             .unwrap();
         self.host
             .with_mut_storage(|storage| {
-                if !storage.has(&nonce_key, self.host.budget_ref())? {
+                if !storage.has_with_host(&nonce_key, &self.host, None)? {
                     return Ok(None);
                 }
                 let (_, live_until_ledger) =
-                    storage.get_with_live_until_ledger(&nonce_key, self.host.budget_ref())?;
+                    storage.get_with_live_until_ledger(&nonce_key, &self.host, None)?;
                 Ok(live_until_ledger)
             })
             .unwrap()
@@ -553,7 +553,7 @@ fn test_single_authorized_call() {
             let key = test.host.to_account_key(account_id)?;
             // Note, that this represents 'correct footprint, missing value' scenario.
             // Incorrect footprint scenario is not covered (it's not auth specific).
-            storage.del(&key, test.host.budget_ref())
+            storage.del_with_host(&key, &test.host, None)
         })
         .unwrap();
 

--- a/soroban-env-host/src/test/lifecycle.rs
+++ b/soroban-env-host/src/test/lifecycle.rs
@@ -24,9 +24,9 @@ use crate::testutils::{generate_account_id, generate_bytes_array};
 fn get_contract_wasm_ref(host: &Host, contract_id: Hash) -> Hash {
     let storage_key = host.contract_instance_ledger_key(&contract_id).unwrap();
     host.with_mut_storage(|s: &mut Storage| {
-        assert!(s.has(&storage_key, host.as_budget()).unwrap());
+        assert!(s.has_with_host(&storage_key, &host, None).unwrap());
 
-        match &s.get(&storage_key, host.as_budget()).unwrap().data {
+        match &s.get_with_host(&storage_key, host, None).unwrap().data {
             LedgerEntryData::ContractData(e) => match &e.val {
                 ScVal::ContractInstance(i) => match &i.executable {
                     ContractExecutable::Wasm(h) => Ok(h.clone()),
@@ -43,9 +43,9 @@ fn get_contract_wasm_ref(host: &Host, contract_id: Hash) -> Hash {
 fn get_contract_wasm(host: &Host, wasm_hash: Hash) -> Vec<u8> {
     let storage_key = host.contract_code_ledger_key(&wasm_hash).unwrap();
     host.with_mut_storage(|s: &mut Storage| {
-        assert!(s.has(&storage_key, host.as_budget()).unwrap());
+        assert!(s.has_with_host(&storage_key, &host, None).unwrap());
 
-        match &s.get(&storage_key, host.as_budget()).unwrap().data {
+        match &s.get_with_host(&storage_key, host, None).unwrap().data {
             LedgerEntryData::ContractCode(code_entry) => Ok(code_entry.code.to_vec()),
             _ => panic!("expected contract WASM code"),
         }
@@ -658,9 +658,8 @@ mod cap_54_55_56 {
         }
         fn reload(self, host: &Host) -> Result<Self, HostError> {
             host.with_mut_storage(|storage| {
-                let budget = host.budget_cloned();
-                let contract_entry = storage.get(&self.contract_key, &budget)?;
-                let wasm_entry = storage.get(&self.wasm_key, &budget)?;
+                let contract_entry = storage.get_with_host(&self.contract_key, host, None)?;
+                let wasm_entry = storage.get_with_host(&self.wasm_key, host, None)?;
                 Ok(ContractAndWasmEntries {
                     contract_key: self.contract_key,
                     contract_entry,
@@ -675,9 +674,8 @@ mod cap_54_55_56 {
             let wasm_key = host.contract_code_ledger_key(&wasm_hash)?;
 
             host.with_mut_storage(|storage| {
-                let budget = host.budget_cloned();
-                let contract_entry = storage.get(&contract_key, &budget)?;
-                let wasm_entry = storage.get(&wasm_key, &budget)?;
+                let contract_entry = storage.get_with_host(&contract_key, host, None)?;
+                let wasm_entry = storage.get_with_host(&wasm_key, host, None)?;
                 Ok(ContractAndWasmEntries {
                     contract_key,
                     contract_entry,

--- a/soroban-env-host/src/test/lifetime_extension.rs
+++ b/soroban-env-host/src/test/lifetime_extension.rs
@@ -49,8 +49,6 @@ impl InstanceCodeTest {
 }
 
 mod separate_instance_code_extension {
-    use crate::budget::AsBudget;
-
     use super::*;
 
     const PROTOCOL_SUPPORT_FOR_SEPARATE_EXTENSIONS: u32 = 21;
@@ -76,7 +74,8 @@ mod separate_instance_code_extension {
             .unwrap()
             .get_with_live_until_ledger(
                 &host.contract_instance_ledger_key(&contract).unwrap(),
-                host.as_budget(),
+                &host,
+                None,
             )
             .unwrap();
 
@@ -102,10 +101,7 @@ mod separate_instance_code_extension {
         let entry_with_live_until = host
             .try_borrow_storage_mut()
             .unwrap()
-            .get_with_live_until_ledger(
-                &host.contract_code_ledger_key(&code).unwrap(),
-                host.as_budget(),
-            )
+            .get_with_live_until_ledger(&host.contract_code_ledger_key(&code).unwrap(), &host, None)
             .unwrap();
 
         assert_eq!(entry_with_live_until.1, Some(9090));
@@ -126,10 +122,7 @@ mod separate_instance_code_extension {
         let code_entry_with_live_until = host
             .try_borrow_storage_mut()
             .unwrap()
-            .get_with_live_until_ledger(
-                &host.contract_code_ledger_key(&code).unwrap(),
-                host.as_budget(),
-            )
+            .get_with_live_until_ledger(&host.contract_code_ledger_key(&code).unwrap(), &host, None)
             .unwrap();
 
         assert_eq!(code_entry_with_live_until.1, Some(9090));
@@ -139,7 +132,8 @@ mod separate_instance_code_extension {
             .unwrap()
             .get_with_live_until_ledger(
                 &host.contract_instance_ledger_key(&contract).unwrap(),
-                host.as_budget(),
+                &host,
+                None,
             )
             .unwrap();
 


### PR DESCRIPTION
### What

Improved TTL testing UX and cleaned up storage diagnostics.

Both improvements rely on passing host into storage methods. This also allows us to use the ledger info and to encapsulate detailed diagnostic errors in the storage module.  We have to still keep the old storage methods around. There are a few users of storage getters, which probably don't have to use it, but the clean up will have some time and can only be performed in v22 due to semver.

There is a subtle change in observations because we now only allocate a new object in diagnostic mode (charged to shadow budget). However, this shouldn't cause divergence (because this version of env won't run in p20) and is highly unlikely to affect replay of p20 with the new env. If necessary, we can still emulate the p20 behavior.

The TTL testing support includes:

- Provide testutil getters for the `live_until_ledger` of all the ledger entries
- Treat expired temp entries as non-existent
- Emit special test-only errors for accessing expired persistent entries

### Why

Improving testing UX

### Known limitations

N/A
