### PR TITLE
Bump quote and proc-macro2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1041,18 +1041,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]

--- a/soroban-builtin-sdk-macros/Cargo.toml
+++ b/soroban-builtin-sdk-macros/Cargo.toml
@@ -14,7 +14,7 @@ proc-macro = true
 
 [dependencies]
 syn = {version="=2.0.39",features=["full"]}
-quote = "=1.0.33"
+quote = "=1.0.36"
 proc-macro2 = "=1.0.69"
 itertools = "=0.11.0"
 

--- a/soroban-builtin-sdk-macros/Cargo.toml
+++ b/soroban-builtin-sdk-macros/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 [dependencies]
 syn = {version="=2.0.39",features=["full"]}
 quote = "=1.0.36"
-proc-macro2 = "=1.0.69"
+proc-macro2 = "=1.0.81"
 itertools = "=0.11.0"
 
 [package.metadata.docs.rs]

--- a/soroban-env-macros/Cargo.toml
+++ b/soroban-env-macros/Cargo.toml
@@ -15,8 +15,8 @@ proc-macro = true
 [dependencies]
 stellar-xdr = { workspace = true, features = ["curr", "std"] }
 syn = {version="=2.0.39",features=["full"]}
-quote = "=1.0.33"
-proc-macro2 = "=1.0.69"
+quote = "=1.0.36"
+proc-macro2 = "=1.0.81"
 itertools = "=0.11.0"
 serde = { version = "=1.0.192", features = ["derive"] }
 serde_json = "=1.0.108"


### PR DESCRIPTION
### What

Bump `quote` and `proc-macro2`

### Why

There is a crate conflict while updating soroban_sdk crate dependency in Solang: 
`error: failed to select a version for `quote`.
    ... required by package `parse-display-derive v0.9.0`
    ... which satisfies dependency `parse-display-derive = "=0.9.0"` of package `parse-display v0.9.0`
    ... which satisfies dependency `parse-display = "^0.9"` of package `solang v0.3.3 (C:\Users\SalaheldinSoliman\Desktop\solang\solang)`
versions that meet the requirements `^1.0.35` are: 1.0.36, 1.0.35

all possible versions conflict with previously selected packages.

  previously selected package `quote v1.0.33`
    ... which satisfies dependency `quote = "=1.0.33"` of package `soroban-builtin-sdk-macros v20.3.0`
    ... which satisfies dependency `soroban-builtin-sdk-macros = "=20.3.0"` of package `soroban-env-host v20.3.0`
    ... which satisfies dependency `soroban-env-host = "=20.3.0"` of package `soroban-sdk v20.5.0`
    ... which satisfies dependency `soroban-sdk = "^20.5.0"` of package `solang v0.3.3 (C:\Users\SalaheldinSoliman\Desktop\solang\solang)`

failed to select a version for `quote` which could resolve this conflict`

### Known limitations

N/A
