### PR TITLE
Bump tracy-client to 0.16.4 and tracy-client-sys to 0.22.2 (for tracy v0.10)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1766,9 +1766,9 @@ dependencies = [
 
 [[package]]
 name = "tracy-client"
-version = "0.15.2"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434ecabbda9f67eeea1eab44d52f4a20538afa3e2c2770f2efc161142b25b608"
+checksum = "82da0d50d9df1106619b1e5b118f39de779f7d8b9c3504485b291cb16fabd20f"
 dependencies = [
  "loom",
  "once_cell",
@@ -1777,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "tracy-client-sys"
-version = "0.21.2"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb915ea3af048554640d76dd6f1492589a6401a41a30d789b983c1ec280455a"
+checksum = "9d104d610dfa9dd154535102cc9c6164ae1fa37842bc2d9e83f9ac82b0ae0882"
 dependencies = [
  "cc",
 ]

--- a/soroban-env-common/Cargo.toml
+++ b/soroban-env-common/Cargo.toml
@@ -26,7 +26,7 @@ num-traits = {version = "=0.2.17", default-features = false}
 num-derive = "=0.4.1"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-tracy-client = { version = "=0.15.2", features = ["enable", "timer-fallback"], default-features = false, optional = true }
+tracy-client = { version = "=0.16.4", features = ["enable", "timer-fallback"], default-features = false, optional = true }
 
 [dev-dependencies]
 num_enum = "=0.7.1"

--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -64,7 +64,7 @@ sha3 = "=0.10.8"
 curve25519-dalek = { version = ">=4.1.1, <=4.1.2", default-features = false, features = ["digest"]}
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-tracy-client = { version = "=0.15.2", features = ["enable", "timer-fallback"], default-features = false, optional = true }
+tracy-client = { version = "=0.16.4", features = ["enable", "timer-fallback"], default-features = false, optional = true }
 
 [dev-dependencies]
 hex = "=0.4.3"


### PR DESCRIPTION
This update is required for https://github.com/stellar/stellar-core/pull/4328 to go through