### PR TITLE
Allow using higher versions of dalek in env.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,10 +68,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: rustup update
-    - uses: stellar/binaries@v18
+    - uses: stellar/binaries@v24
       with:
         name: cargo-semver-checks
-        version: 0.27.0
+        version: 0.32.0
     - run: cargo semver-checks --exclude soroban-simulation
 
   build-and-test:

--- a/deny.toml
+++ b/deny.toml
@@ -51,7 +51,9 @@ exclude = [
    # Somehow the tracking machinery of two different dev-dep tracing
    # subsystems also winds up pulling in conflicts, but again, just
    # dev-deps or non-produciton configs.
-   "tracking-allocator"
+   "tracking-allocator",
+   # Temporary
+   "ed25519-dalek"
 ]
 
 # If true, metadata will be collected with `--all-features`. Note that this can't

--- a/deny.toml
+++ b/deny.toml
@@ -53,7 +53,7 @@ exclude = [
    # dev-deps or non-produciton configs.
    "tracking-allocator",
    # Temporary
-   "ed25519-dalek"
+   "curve25519-dalek"
 ]
 
 # If true, metadata will be collected with `--all-features`. Note that this can't

--- a/soroban-env-common/src/tuple.rs
+++ b/soroban-env-common/src/tuple.rs
@@ -98,6 +98,6 @@ impl<E: Env> TryFromVal<E, ()> for [Val; 0] {
     type Error = crate::Error;
 
     fn try_from_val(_env: &E, _v: &()) -> Result<Self, Self::Error> {
-        Ok([Val::VOID.into(); 0])
+        Ok([])
     }
 }

--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -23,7 +23,8 @@ static_assertions = "=1.1.0"
 sha2 = "=0.10.8"
 hex-literal = "=0.4.1"
 hmac = "=0.12.1"
-ed25519-dalek = {version = "=2.0.0", features = ["rand_core"] }
+# NB: We'll need to pin this again after switching the Core to the new env version.
+ed25519-dalek = {version = ">=2.0.0", features = ["rand_core"] }
 # NB: this must match the same rand version used by ed25519-dalek above
 rand = "=0.8.5"
 # NB: this must match the same rand_chacha version used by ed25519-dalek above


### PR DESCRIPTION
### What

Allow using higher versions of dalek in env.

### Why

Unblock the deps from picking up new versions of dalek, specifically the ones with vulnerability fixes. We don't strictly bump the version in order to make sure we don't break the Core build.

### Known limitations

N/A
