### PR TITLE
Fix InstantiateWasmImports which was broken by protocol-version gating

### DIFF
--- a/soroban-env-host/benches/common/cost_types/wasm_insn_exec.rs
+++ b/soroban-env-host/benches/common/cost_types/wasm_insn_exec.rs
@@ -86,10 +86,20 @@ pub fn wasm_module_with_n_globals(n: usize) -> Vec<u8> {
 
 pub fn wasm_module_with_n_imports(n: usize) -> Vec<u8> {
     let mut me = ModEmitter::default().add_bench_import();
-    let names = Vm::get_all_host_functions();
-    for (module, name, arity) in names.iter().take(n) {
+    let names = Vm::get_all_host_functions_with_supported_protocol_range();
+    for (module, name, arity, min_proto, max_proto) in names.iter().take(n) {
         if *module == "t" {
             continue;
+        }
+        if let Some(proto) = min_proto {
+            if *proto > 20 {
+                continue;
+            }
+        }
+        if let Some(proto) = max_proto {
+            if *proto < 20 {
+                continue;
+            }
         }
         me.import_func(module, name, Arity(*arity));
     }

--- a/soroban-env-host/benches/common/util.rs
+++ b/soroban-env-host/benches/common/util.rs
@@ -1,5 +1,5 @@
 use rand::{rngs::StdRng, RngCore};
-use soroban_env_host::{budget::AsBudget, meta, Host, LedgerInfo, Val, I256};
+use soroban_env_host::{budget::AsBudget, Host, LedgerInfo, Val, I256};
 
 pub(crate) fn test_host() -> Host {
     let host = Host::default();

--- a/soroban-env-host/src/vm.rs
+++ b/soroban-env-host/src/vm.rs
@@ -134,6 +134,15 @@ impl Vm {
             .collect()
     }
 
+    #[cfg(feature = "testutils")]
+    pub fn get_all_host_functions_with_supported_protocol_range(
+    ) -> Vec<(&'static str, &'static str, u32, Option<u32>, Option<u32>)> {
+        HOST_FUNCTIONS
+            .iter()
+            .map(|hf| (hf.mod_str, hf.fn_str, hf.arity, hf.min_proto, hf.max_proto))
+            .collect()
+    }
+
     /// Instantiates a VM given the arguments provided in [`Self::new`],
     /// or [`Self::new_from_module_cache`]
     fn instantiate(


### PR DESCRIPTION
The support for (and p21 use of) protocol gating on host functions breaks the benchmark code that imports all functions into a p20 contract. This fixes the bug.