### PR TITLE
Add CI concurrency group

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
   merge_group:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_protected == 'true' && github.sha || github.ref }}-{{ github.event_name }}
+  cancel-in-progress: true
+
 jobs:
 
   complete:


### PR DESCRIPTION
### What

Add CI concurrency group limiting to one build per branch, excluding main, canceling any older runs.

### Why

Limit CI resource usage. We never need out-of-date commit CI runs to complete on PRs. We do need to make sure that release vs pr builds vs merge group build runs run to completion independently so that is included in the identifier for the concurrency group.