### PR TITLE
Bump version to 21.2.1

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -20,6 +20,7 @@
 rustflags = [
      "-Dwarnings",
      "-Aclippy::style",
+     "-Aunexpected_cfgs",
 #    "-Dclippy::pedantic",
 #    "-Aclippy::module_name_repetitions",
 #    "-Aclippy::needless_pass_by_value",

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,7 +74,7 @@ jobs:
         - os: ubuntu-latest
           target: wasm32-unknown-unknown
           test: false
-        - os: ubuntu-latest
+        - os: ubuntu-latest-16-cores
           target: x86_64-unknown-linux-gnu
           test: true
         # TODO: Re-enable these builds if we see value in doing so.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1352,7 +1352,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "soroban-bench-utils"
-version = "21.2.0"
+version = "21.2.1"
 dependencies = [
  "perf-event",
  "soroban-env-common",
@@ -1361,7 +1361,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "21.2.0"
+version = "21.2.1"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1371,7 +1371,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "21.2.0"
+version = "21.2.1"
 dependencies = [
  "arbitrary",
  "crate-git-revision",
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "21.2.0"
+version = "21.2.1"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -1398,7 +1398,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "21.2.0"
+version = "21.2.1"
 dependencies = [
  "arbitrary",
  "backtrace",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "21.2.0"
+version = "21.2.1"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-simulation"
-version = "21.2.0"
+version = "21.2.1"
 dependencies = [
  "anyhow",
  "pretty_assertions",
@@ -1479,7 +1479,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-synth-wasm"
-version = "21.2.0"
+version = "21.2.1"
 dependencies = [
  "arbitrary",
  "expect-test",
@@ -1493,7 +1493,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-test-wasms"
-version = "21.2.0"
+version = "21.2.1"
 
 [[package]]
 name = "soroban-wasmi"
@@ -1596,7 +1596,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "test_no_std"
-version = "21.2.0"
+version = "21.2.1"
 dependencies = [
  "soroban-env-common",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,15 +20,15 @@ exclude = ["soroban-test-wasms/wasm-workspace"]
 # NB: When bumping the major version make sure to clean up the
 # code guarded by `unstable-*` features to make it enabled
 # unconditionally.
-version = "21.2.0"
+version = "21.2.1"
 rust-version = "1.74.0"
 
 [workspace.dependencies]
-soroban-env-common = { version = "=21.2.0", path = "soroban-env-common", default-features = false }
-soroban-env-guest = { version = "=21.2.0", path = "soroban-env-guest" }
-soroban-env-host = { version = "=21.2.0", path = "soroban-env-host" }
-soroban-env-macros = { version = "=21.2.0", path = "soroban-env-macros" }
-soroban-builtin-sdk-macros = { version = "=21.2.0", path = "soroban-builtin-sdk-macros" }
+soroban-env-common = { version = "=21.2.1", path = "soroban-env-common", default-features = false }
+soroban-env-guest = { version = "=21.2.1", path = "soroban-env-guest" }
+soroban-env-host = { version = "=21.2.1", path = "soroban-env-host" }
+soroban-env-macros = { version = "=21.2.1", path = "soroban-env-macros" }
+soroban-builtin-sdk-macros = { version = "=21.2.1", path = "soroban-builtin-sdk-macros" }
 # NB: this must match the wasmparser version wasmi is using
 wasmparser = "=0.116.1"
 

--- a/soroban-builtin-sdk-macros/Cargo.toml
+++ b/soroban-builtin-sdk-macros/Cargo.toml
@@ -13,10 +13,10 @@ rust-version.workspace = true
 proc-macro = true
 
 [dependencies]
-syn = {version="=2.0.39",features=["full"]}
-quote = "=1.0.33"
-proc-macro2 = "=1.0.69"
-itertools = "=0.11.0"
+syn = {version="2.0.39",features=["full"]}
+quote = "1.0.33"
+proc-macro2 = "1.0.69"
+itertools = "0.11.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/soroban-env-common/Cargo.toml
+++ b/soroban-env-common/Cargo.toml
@@ -11,26 +11,26 @@ edition = "2021"
 rust-version.workspace = true
 
 [build_dependencies]
-crate-git-revision = "=0.0.6"
+crate-git-revision = "0.0.6"
 
 [dependencies]
 soroban-env-macros = { workspace = true }
 stellar-xdr = { workspace = true, default-features = false, features = [ "curr" ] }
 wasmi = { workspace = true, optional = true }
 wasmparser = { workspace = true, optional = true}
-serde = { version = "=1.0.192", features = ["derive"], optional = true }
-static_assertions = "=1.1.0"
-ethnum = "=1.5.0"
-arbitrary = { version = "=1.3.2", features = ["derive"], optional = true }
-num-traits = {version = "=0.2.17", default-features = false}
-num-derive = "=0.4.1"
+serde = { version = "1.0.192", features = ["derive"], optional = true }
+static_assertions = "1.1.0"
+ethnum = "1.5.0"
+arbitrary = { version = "1.3.2", features = ["derive"], optional = true }
+num-traits = {version = "0.2.17", default-features = false}
+num-derive = "0.4.1"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-tracy-client = { version = "=0.16.4", features = ["enable", "timer-fallback"], default-features = false, optional = true }
+tracy-client = { version = "0.16.4", features = ["enable", "timer-fallback"], default-features = false, optional = true }
 
 [dev-dependencies]
-num_enum = "=0.7.1"
-num-traits = "=0.2.17"
+num_enum = "0.7.1"
+num-traits = "0.2.17"
 
 [features]
 std = ["stellar-xdr/std", "stellar-xdr/base64"]

--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -18,32 +18,32 @@ soroban-builtin-sdk-macros = { workspace = true }
 soroban-env-common = { workspace = true, features = ["std", "wasmi", "shallow-val-hash"] }
 wasmi = { workspace = true }
 wasmparser = { workspace = true }
-stellar-strkey = "=0.0.8"
-static_assertions = "=1.1.0"
-sha2 = "=0.10.8"
-hex-literal = "=0.4.1"
-hmac = "=0.12.1"
+stellar-strkey = "0.0.8"
+static_assertions = "1.1.0"
+sha2 = "0.10.8"
+hex-literal = "0.4.1"
+hmac = "0.12.1"
 # NB: We'll need to pin this again after switching the Core to the new env version.
 ed25519-dalek = {version = ">=2.0.0", features = ["rand_core"] }
 # NB: this must match the same rand version used by ed25519-dalek above
-rand = "=0.8.5"
+rand = "0.8.5"
 # NB: this must match the same rand_chacha version used by ed25519-dalek above
-rand_chacha = "=0.3.1"
-num-traits = "=0.2.17"
-num-integer = "=0.1.45"
-num-derive = "=0.4.1"
-backtrace = { version = "=0.3.69", optional = true }
-k256 = {version = "=0.13.1", default-features = false, features = ["ecdsa", "arithmetic"]}
-p256 = {version = "=0.13.2", default-features = false, features = ["ecdsa", "arithmetic"]}
-ecdsa = {version = "=0.16.7", default-features = false}
-sec1 = {version = "=0.7.2"}
+rand_chacha = "0.3.1"
+num-traits = "0.2.17"
+num-integer = "0.1.45"
+num-derive = "0.4.1"
+backtrace = { version = "0.3.69", optional = true }
+k256 = {version = "0.13.1", default-features = false, features = ["ecdsa", "arithmetic"]}
+p256 = {version = "0.13.2", default-features = false, features = ["ecdsa", "arithmetic"]}
+ecdsa = {version = "0.16.7", default-features = false}
+sec1 = {version = "0.7.2"}
 elliptic-curve ={ version = "0.13.5", default-features = false}
 generic-array ={ version = "0.14.7"}
 # NB: getrandom is a transitive dependency of k256 which we're not using directly
 # but we have to specify it here in order to enable its 'js' feature which
 # is needed to build the host for wasm (a rare but supported config).
-getrandom = { version = "=0.2.11", features=["js"] }
-sha3 = "=0.10.8"
+getrandom = { version = "0.2.11", features=["js"] }
+sha3 = "0.10.8"
 # NB: this must match the same curve25519-dalek version used by ed25519-dalek
 # above used only for calibration
 #
@@ -69,33 +69,33 @@ sha3 = "=0.10.8"
 curve25519-dalek = { version = ">=4.1.1", default-features = false, features = ["digest"]}
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-tracy-client = { version = "=0.16.4", features = ["enable", "timer-fallback"], default-features = false, optional = true }
+tracy-client = { version = "0.16.4", features = ["enable", "timer-fallback"], default-features = false, optional = true }
 
 [dev-dependencies]
-hex = "=0.4.3"
-itertools = "=0.11.0"
-tabwriter = "=1.3.0"
-thousands = "=0.2.0"
+hex = "0.4.3"
+itertools = "0.11.0"
+tabwriter = "1.3.0"
+thousands = "0.2.0"
 soroban-env-macros = { workspace = true }
 soroban-test-wasms = { package = "soroban-test-wasms", path = "../soroban-test-wasms" }
 soroban-synth-wasm = { package = "soroban-synth-wasm", path = "../soroban-synth-wasm", features = ["adversarial"]}
 soroban-bench-utils = { package = "soroban-bench-utils", path = "../soroban-bench-utils" }
-bytes-lit = "=0.0.5"
-textplots = "=0.8.4"
-wasmprinter = "=0.2.72"
-expect-test = "=1.4.1"
-more-asserts = "=0.3.1"
-pretty_assertions = "=1.4.0"
-backtrace = "=0.3.69"
-serde_json = "=1.0.108"
-arbitrary = "=1.3.2"
-lstsq = "=0.5.0"
-nalgebra = { version = "=0.32.3", default-features = false, features = ["std"]}
-wasm-encoder = "=0.36.2"
+bytes-lit = "0.0.5"
+textplots = "0.8.4"
+wasmprinter = "0.2.72"
+expect-test = "1.4.1"
+more-asserts = "0.3.1"
+pretty_assertions = "1.4.0"
+backtrace = "0.3.69"
+serde_json = "1.0.108"
+arbitrary = "1.3.2"
+lstsq = "0.5.0"
+nalgebra = { version = "0.32.3", default-features = false, features = ["std"]}
+wasm-encoder = "0.36.2"
 rustversion = "1.0"
-wycheproof = "=0.5.1"
-k256 = {version = "=0.13.1", default-features = false, features = ["alloc"]}
-p256 = {version = "=0.13.2", default-features = false, features = ["alloc"]}
+wycheproof = "0.5.1"
+k256 = {version = "0.13.1", default-features = false, features = ["alloc"]}
+p256 = {version = "0.13.2", default-features = false, features = ["alloc"]}
 
 [dev-dependencies.stellar-xdr]
 version = "=21.2.0"

--- a/soroban-env-macros/Cargo.toml
+++ b/soroban-env-macros/Cargo.toml
@@ -14,12 +14,12 @@ proc-macro = true
 
 [dependencies]
 stellar-xdr = { workspace = true, features = ["curr", "std"] }
-syn = {version="=2.0.39",features=["full"]}
-quote = "=1.0.33"
-proc-macro2 = "=1.0.69"
-itertools = "=0.11.0"
-serde = { version = "=1.0.192", features = ["derive"] }
-serde_json = "=1.0.108"
+syn = {version="2.0.39",features=["full"]}
+quote = "1.0.33"
+proc-macro2 = "1.0.69"
+itertools = "0.11.0"
+serde = { version = "1.0.192", features = ["derive"] }
+serde_json = "1.0.108"
 
 [features]
 next = ["stellar-xdr/next"]

--- a/soroban-synth-wasm/Cargo.toml
+++ b/soroban-synth-wasm/Cargo.toml
@@ -15,7 +15,7 @@ wasm-encoder = "=0.36.2"
 wasmparser = { workspace = true }
 soroban-env-common = { workspace = true }
 stellar-xdr = { workspace = true, features = ["std"] }
-arbitrary = { version = "=1.3.2", features = ["derive"] }
+arbitrary = { version = "1.3.2", features = ["derive"] }
 soroban-env-macros = { workspace = true }
 
 [features]
@@ -23,5 +23,5 @@ testutils = ["soroban-env-common/testutils"]
 adversarial = []
 
 [dev-dependencies]
-expect-test = "=1.4.1"
-wasmprinter = "=0.2.72"
+expect-test = "1.4.1"
+wasmprinter = "0.2.72"


### PR DESCRIPTION
### What
Bump version to 21.2.1, creating release branch.

### Why

Created by @leighmcculloch manually because the Bump Version workflow is currently erroring with permission errors. Related links about those failures:
- https://github.com/stellar/rs-soroban-env/actions/runs/10446396038/job/28930412319
- https://stellarfoundation.slack.com/archives/C02U19A2A/p1723857725537729

### What is next

See the release instructions for a full rundown on the release process:
https://github.com/stellar/actions/blob/main/README-rust-release.md

Commit any changes to the `release/v21.2.1` branch that are needed in this release.

~~If this is a regular release releasing from `main`, merge this PR when ready, and after merging, create a release for this version by going to this link: https://github.com/stellar/rs-soroban-env/releases/new?tag=v21.2.1&title=21.2.1~~

If this is a backport or patch release of a past version, see the release instructions. When ready to release this branch create a release by going to this link: 
https://github.com/stellar/rs-soroban-env/releases/new?tag=v21.2.1&title=21.2.1&target=release/v21.2.1