### PR TITLE
Replace cargo-deny skip-tree with explicit skips

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -234,15 +234,15 @@ deny = [
 
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
-    #{ name = "ansi_term", version = "=0.11.0" },
+    { name = "hashbrown", version = "=0.13.2" },
+    { name = "syn", version = "=1.0.109" },
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive
 # dependencies starting at the specified crate, up to a certain depth, which is
 # by default infinite.
 skip-tree = [
-   { name = "soroban-wasmi" }
- ]
+]
 
 # This section is considered when running `cargo deny check sources`.
 # More documentation about the 'sources' section can be found here:


### PR DESCRIPTION
### What

Replace cargo-deny `skip-tree` with explicit `skip`s for each dependency we wish to allow duplicates.

### Why

The `skip-tree` obfuscates the dependencies that we're allowing to be duplicated, and even seems to hide some dependencies being duplicated that don't seem to be part of the soroban-wasmi dependency graph that we depend. This may be due to a bug, or possibly the dep is in the dev dependencies of soroban-wasmi, or some feature that we don't use.

I became aware of this issue because I noticed that in #1456 the Cargo.lock file gained a duplicate dependency on the `syn` crate, having already a dependency on version `2.0.39` and gaining a dependency on version `1.0.109`. This is fine and not a problem in and of itself – we can't eradicate all duplicates – except that the `deny.toml` file gained no new entry, no statement to say that we were okay with this new duplicate.

In my own testing locally it appears that when the `skip-tree` entry containing `soroban-wasmi` is present, the `syn` duplicate dependency is hidden/silenced, even though it was not a dependency prior to the change that did not involve the `soroban-wasmi` crate.

The `skip-tree` config obfuscates the duplicate dependencies in a couple ways.

Firstly due to the odd behaviour detailed above we appear to not get notified of new duplicate dependencies, even if they do not appear to be an active in use dependency in our existing graph.

Secondly because the `skip-tree` communicates only partially about what is being allowed. In our case the `skip-tree` allows two versions of the `hashbrown` dep, but we actually need the two versions for reasons other than `soroban-wasmi`, so it doesn't tell the full story.

Listing out the duplicate dependencies one-by-one is explicit, and it helps us at a glance know what our dupes are, and how many we have, as a signal to "how bad it is getting".

### Known limitations

N/A