### PR TITLE
Ported the implementation of binary search from Rust <=1.81 to Soroban

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,10 +59,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: rustup update
-    - uses: stellar/binaries@v24
+    - uses: stellar/binaries@v31
       with:
         name: cargo-semver-checks
-        version: 0.32.0
+        version: 0.35.0
     - run: cargo semver-checks --exclude soroban-simulation
 
   build-and-test:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1352,7 +1352,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "soroban-bench-utils"
-version = "21.2.1"
+version = "21.2.2"
 dependencies = [
  "perf-event",
  "soroban-env-common",
@@ -1361,7 +1361,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "21.2.1"
+version = "21.2.2"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1371,7 +1371,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "21.2.1"
+version = "21.2.2"
 dependencies = [
  "arbitrary",
  "crate-git-revision",
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "21.2.1"
+version = "21.2.2"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -1398,7 +1398,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "21.2.1"
+version = "21.2.2"
 dependencies = [
  "arbitrary",
  "backtrace",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "21.2.1"
+version = "21.2.2"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-simulation"
-version = "21.2.1"
+version = "21.2.2"
 dependencies = [
  "anyhow",
  "pretty_assertions",
@@ -1479,7 +1479,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-synth-wasm"
-version = "21.2.1"
+version = "21.2.2"
 dependencies = [
  "arbitrary",
  "expect-test",
@@ -1493,7 +1493,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-test-wasms"
-version = "21.2.1"
+version = "21.2.2"
 
 [[package]]
 name = "soroban-wasmi"
@@ -1596,7 +1596,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "test_no_std"
-version = "21.2.1"
+version = "21.2.2"
 dependencies = [
  "soroban-env-common",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,15 +20,15 @@ exclude = ["soroban-test-wasms/wasm-workspace"]
 # NB: When bumping the major version make sure to clean up the
 # code guarded by `unstable-*` features to make it enabled
 # unconditionally.
-version = "21.2.1"
+version = "21.2.2"
 rust-version = "1.74.0"
 
 [workspace.dependencies]
-soroban-env-common = { version = "=21.2.1", path = "soroban-env-common", default-features = false }
-soroban-env-guest = { version = "=21.2.1", path = "soroban-env-guest" }
-soroban-env-host = { version = "=21.2.1", path = "soroban-env-host" }
-soroban-env-macros = { version = "=21.2.1", path = "soroban-env-macros" }
-soroban-builtin-sdk-macros = { version = "=21.2.1", path = "soroban-builtin-sdk-macros" }
+soroban-env-common = { version = "=21.2.2", path = "soroban-env-common", default-features = false }
+soroban-env-guest = { version = "=21.2.2", path = "soroban-env-guest" }
+soroban-env-host = { version = "=21.2.2", path = "soroban-env-host" }
+soroban-env-macros = { version = "=21.2.2", path = "soroban-env-macros" }
+soroban-builtin-sdk-macros = { version = "=21.2.2", path = "soroban-builtin-sdk-macros" }
 # NB: this must match the wasmparser version wasmi is using
 wasmparser = "=0.116.1"
 

--- a/soroban-env-host/src/host/metered_map.rs
+++ b/soroban-env-host/src/host/metered_map.rs
@@ -7,6 +7,8 @@ use crate::{
 
 use std::{borrow::Borrow, cmp::Ordering, marker::PhantomData};
 
+use super::metered_vector::binary_search_by_pre_rust_182;
+
 const MAP_OOB: Error = Error::from_type_and_code(ScErrorType::Object, ScErrorCode::IndexBounds);
 
 pub struct MeteredOrdMap<K, V, Ctx> {
@@ -161,7 +163,7 @@ where
         let _span = tracy_span!("map lookup");
         self.charge_binsearch(ctx)?;
         let mut err: Option<HostError> = None;
-        let res = self.map.binary_search_by(|probe| {
+        let res = binary_search_by_pre_rust_182(self.map.as_slice(), |probe| {
             // We've already hit an error, return Ordering::Equal
             // to terminate search asap.
             if err.is_some() {


### PR DESCRIPTION
### What

Ported the implementation of binary search from Rust <=1.81 to Soroban.

Bump the env version to 21.2.2.

### Why

To keep the binary search implementation the same in the future Rust versions.

### Known limitations

N/A
