### PR TITLE
Temporarily disable semver checks.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,11 @@ jobs:
     # temporarily disabling publish-dry-run, it appears to be broken with recent
     # changes to dependency specifications?
     # needs: [fmt, cackle, cargo-deny, check-git-rev-deps, build-and-test, publish-dry-run]
-    needs: [fmt, cackle, cargo-deny, check-git-rev-deps, semver-checks, build-and-test]
+    # needs: [fmt, cackle, cargo-deny, check-git-rev-deps, semver-checks, build-and-test]
+    # semver-checks is currently broken due to incompatible `arbitrary` crate 
+    # update (https://github.com/rust-fuzz/arbitrary/issues/203).
+    # TODO: re-enable this as soon as the check has been fixed.
+    needs: [fmt, cackle, cargo-deny, check-git-rev-deps, build-and-test]
     runs-on: ubuntu-latest
     steps:
     - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
@@ -58,7 +62,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: stellar/actions/rust-check-git-rev-deps@main
 
-  semver-checks:
+  semver-checks:    
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
### What

Disable semver checks temporarily.

### Why

The check is broken due to `arbitrary` crate update (https://github.com/rust-fuzz/arbitrary/issues/203).

### Known limitations

N/A
