### PR TITLE
Bump env and xdr to v22.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1496,7 +1496,7 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "soroban-bench-utils"
-version = "22.0.0-rc.3"
+version = "22.0.0"
 dependencies = [
  "perf-event",
  "soroban-env-common",
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "22.0.0-rc.3"
+version = "22.0.0"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1516,7 +1516,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "22.0.0-rc.3"
+version = "22.0.0"
 dependencies = [
  "arbitrary",
  "crate-git-revision",
@@ -1535,7 +1535,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "22.0.0-rc.3"
+version = "22.0.0"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -1543,7 +1543,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "22.0.0-rc.3"
+version = "22.0.0"
 dependencies = [
  "arbitrary",
  "ark-bls12-381",
@@ -1602,7 +1602,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "22.0.0-rc.3"
+version = "22.0.0"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1615,7 +1615,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-simulation"
-version = "22.0.0-rc.3"
+version = "22.0.0"
 dependencies = [
  "anyhow",
  "pretty_assertions",
@@ -1629,7 +1629,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-synth-wasm"
-version = "22.0.0-rc.3"
+version = "22.0.0"
 dependencies = [
  "arbitrary",
  "expect-test",
@@ -1643,7 +1643,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-test-wasms"
-version = "22.0.0-rc.3"
+version = "22.0.0"
 
 [[package]]
 name = "soroban-wasmi"
@@ -1692,9 +1692,9 @@ dependencies = [
 
 [[package]]
 name = "stellar-xdr"
-version = "22.0.0-rc.1.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c88dc0e928b9cb65ea43836b52560bb4ead3e32895f5019ca223dc7cd1966cbf"
+checksum = "20c2130275cc730d042b3082f51145f0486f5a543d6d72fced02ed9048b82b57"
 dependencies = [
  "arbitrary",
  "base64 0.13.1",
@@ -1757,7 +1757,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "test_no_std"
-version = "22.0.0-rc.3"
+version = "22.0.0"
 dependencies = [
  "soroban-env-common",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,21 +20,21 @@ exclude = ["soroban-test-wasms/wasm-workspace"]
 # NB: When bumping the major version make sure to clean up the
 # code guarded by `unstable-*` features to make it enabled
 # unconditionally.
-version = "22.0.0-rc.3"
+version = "22.0.0"
 rust-version = "1.79.0"
 
 [workspace.dependencies]
-soroban-env-common = { version = "=22.0.0-rc.3", path = "soroban-env-common", default-features = false }
-soroban-env-guest = { version = "=22.0.0-rc.3", path = "soroban-env-guest" }
-soroban-env-host = { version = "=22.0.0-rc.3", path = "soroban-env-host" }
-soroban-env-macros = { version = "=22.0.0-rc.3", path = "soroban-env-macros" }
-soroban-builtin-sdk-macros = { version = "=22.0.0-rc.3", path = "soroban-builtin-sdk-macros" }
+soroban-env-common = { version = "=22.0.0", path = "soroban-env-common", default-features = false }
+soroban-env-guest = { version = "=22.0.0", path = "soroban-env-guest" }
+soroban-env-host = { version = "=22.0.0", path = "soroban-env-host" }
+soroban-env-macros = { version = "=22.0.0", path = "soroban-env-macros" }
+soroban-builtin-sdk-macros = { version = "=22.0.0", path = "soroban-builtin-sdk-macros" }
 # NB: this must match the wasmparser version wasmi is using
 wasmparser = "=0.116.1"
 
 # NB: When updating, also update the version in rs-soroban-env dev-dependencies
 [workspace.dependencies.stellar-xdr]
-version = "=22.0.0-rc.1.1"
+version = "=22.0.0"
 #git = "https://github.com/stellar/rs-stellar-xdr"
 #rev = "67be5955a15f1d3a4df83fe86e6ae107f687141b"
 default-features = false

--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -83,7 +83,7 @@ k256 = {version = "0.13.1", default-features = false, features = ["alloc"]}
 p256 = {version = "0.13.2", default-features = false, features = ["alloc"]}
 
 [dev-dependencies.stellar-xdr]
-version = "=22.0.0-rc.1.1"
+version = "=22.0.0"
 #git = "https://github.com/stellar/rs-stellar-xdr"
 #rev = "67be5955a15f1d3a4df83fe86e6ae107f687141b"
 default-features = false


### PR DESCRIPTION
### What
Bump env and xdr version to 22.0.0

### What is next

See the release instructions for a full rundown on the release process:
https://github.com/stellar/actions/blob/main/README-rust-release.md

Commit any changes to the `release/v22.0.0` branch that are needed in this release.

If this is a backport or patch release of a past version, see the release instructions. When ready to release this branch create a release by going to this link: 
https://github.com/stellar/rs-soroban-env/releases/new?tag=v22.0.0&title=22.0.0&target=release/v22.0.0