### PR TITLE
Update stellar-xdr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,9 +1692,9 @@ dependencies = [
 
 [[package]]
 name = "stellar-xdr"
-version = "22.0.0"
+version = "22.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c2130275cc730d042b3082f51145f0486f5a543d6d72fced02ed9048b82b57"
+checksum = "2ce69db907e64d1e70a3dce8d4824655d154749426a6132b25395c49136013e4"
 dependencies = [
  "arbitrary",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ wasmparser = "=0.116.1"
 
 # NB: When updating, also update the version in rs-soroban-env dev-dependencies
 [workspace.dependencies.stellar-xdr]
-version = "=22.0.0"
+version = "=22.1.0"
 #git = "https://github.com/stellar/rs-stellar-xdr"
 #rev = "67be5955a15f1d3a4df83fe86e6ae107f687141b"
 default-features = false

--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -83,7 +83,7 @@ k256 = {version = "0.13.1", default-features = false, features = ["alloc"]}
 p256 = {version = "0.13.2", default-features = false, features = ["alloc"]}
 
 [dev-dependencies.stellar-xdr]
-version = "=22.0.0"
+version = "=22.1.0"
 #git = "https://github.com/stellar/rs-stellar-xdr"
 #rev = "67be5955a15f1d3a4df83fe86e6ae107f687141b"
 default-features = false


### PR DESCRIPTION
### What
Update stellar-xdr

### Why
To get the recent changes in stellar-xdr available in a compatible env that pins to a specific version of stellar-xdr.