### PR TITLE
Allow passing the setting for non-root auth to the simulation.

### DIFF
--- a/soroban-simulation/Cargo.toml
+++ b/soroban-simulation/Cargo.toml
@@ -15,16 +15,17 @@ publish = true
 
 [features]
 testutils = ["soroban-env-host/testutils"]
+unstable-next-api = ["soroban-env-host/unstable-next-api"]
 
 [dependencies]
 anyhow = { version = "1.0.75", features = [] }
 thiserror = "1.0.40"
-soroban-env-host = { workspace = true,  features = ["recording_mode", "unstable-next-api"]}
+soroban-env-host = { workspace = true,  features = ["recording_mode"]}
 static_assertions = "1.1.0"
 rand = "0.8.5"
 
 [dev-dependencies]
-soroban-env-host = { workspace = true,  features = ["recording_mode", "testutils", "unstable-next-api"]}
+soroban-env-host = { workspace = true,  features = ["recording_mode", "testutils"]}
 soroban-test-wasms = { package = "soroban-test-wasms", path = "../soroban-test-wasms" }
 pretty_assertions = "1.4"
 tap = "1.0.1"

--- a/soroban-simulation/src/simulation.rs
+++ b/soroban-simulation/src/simulation.rs
@@ -9,7 +9,7 @@ use crate::snapshot_source::{
 use anyhow::Result;
 use soroban_env_host::{
     e2e_invoke::invoke_host_function_in_recording_mode,
-    e2e_invoke::LedgerEntryChange,
+    e2e_invoke::{LedgerEntryChange, RecordingInvocationAuthMode},
     storage::SnapshotSource,
     xdr::{
         AccountId, ContractEvent, DiagnosticEvent, HostFunction, InvokeHostFunctionOp, LedgerKey,
@@ -100,9 +100,10 @@ pub struct RestoreOpSimulationResult {
 /// relevant payload parts.
 ///
 /// The operation is defined by the host function itself (`host_fn`)
-/// and optionally signed `auth_entries`. In case if `auth_entries` are
-/// omitted, the simulation will use recording authorization mode and
-/// return non-signed recorded authorization entries.
+/// and `auth_mode`. In case if `auth_mode` is `None`, the simulation will
+/// use recording authorization mode and  return non-signed recorded
+/// authorization entries. Otherwise, the signed entries will be used for
+/// authorization and authentication enforcement.
 ///
 /// The rest of parameters define the ledger state (`snapshot_source`,
 /// `network_config`, `ledger_info`), simulation adjustment
@@ -122,7 +123,7 @@ pub fn simulate_invoke_host_function_op(
     adjustment_config: &SimulationAdjustmentConfig,
     ledger_info: &LedgerInfo,
     host_fn: HostFunction,
-    auth_entries: Option<Vec<SorobanAuthorizationEntry>>,
+    auth_mode: RecordingInvocationAuthMode,
     source_account: &AccountId,
     base_prng_seed: [u8; 32],
     enable_diagnostics: bool,
@@ -135,7 +136,7 @@ pub fn simulate_invoke_host_function_op(
         enable_diagnostics,
         &host_fn,
         source_account,
-        auth_entries,
+        auth_mode,
         ledger_info.clone(),
         snapshot_source.clone(),
         base_prng_seed,

--- a/soroban-simulation/src/test/simulation.rs
+++ b/soroban-simulation/src/test/simulation.rs
@@ -6,6 +6,7 @@ use crate::simulation::{
 use crate::testutils::{ledger_entry_to_ledger_key, temp_entry, MockSnapshotSource};
 use crate::NetworkConfig;
 use pretty_assertions::assert_eq;
+use soroban_env_host::e2e_invoke::RecordingInvocationAuthMode;
 use soroban_env_host::e2e_testutils::{
     account_entry, auth_contract_invocation, bytes_sc_val, create_contract_auth,
     default_ledger_info, get_account_id, get_contract_id_preimage, get_wasm_hash, get_wasm_key,
@@ -100,6 +101,16 @@ fn nonce_entry(address: ScAddress, nonce: i64) -> LedgerEntry {
     }))
 }
 
+// NB: this is a temporary helper function that we should remove and embed
+// RecordingInvocationAuthMode into code during the `unstable-next-api` cleanup
+// when switching to v23.
+fn recording_auth_mode() -> RecordingInvocationAuthMode {
+    #[cfg(not(feature = "unstable-next-api"))]
+    return None;
+    #[cfg(feature = "unstable-next-api")]
+    return RecordingInvocationAuthMode::Recording(true);
+}
+
 #[test]
 fn test_simulate_upload_wasm() {
     let source_account = get_account_id([123; 32]);
@@ -114,7 +125,7 @@ fn test_simulate_upload_wasm() {
         &SimulationAdjustmentConfig::no_adjustments(),
         &ledger_info,
         upload_wasm_host_fn(ADD_I32),
-        None,
+        recording_auth_mode(),
         &source_account,
         [1; 32],
         true,
@@ -163,7 +174,7 @@ fn test_simulate_upload_wasm() {
         &test_adjustment_config(),
         &ledger_info,
         upload_wasm_host_fn(ADD_I32),
-        None,
+        recording_auth_mode(),
         &source_account,
         [1; 32],
         true,
@@ -218,7 +229,7 @@ fn test_simulation_returns_insufficient_budget_error() {
         &SimulationAdjustmentConfig::no_adjustments(),
         &ledger_info,
         upload_wasm_host_fn(ADD_I32),
-        None,
+        recording_auth_mode(),
         &source_account,
         [1; 32],
         true,
@@ -253,7 +264,7 @@ fn test_simulation_returns_logic_error() {
         &SimulationAdjustmentConfig::no_adjustments(),
         &ledger_info,
         upload_wasm_host_fn(&bad_wasm),
-        None,
+        recording_auth_mode(),
         &source_account,
         [1; 32],
         true,
@@ -297,7 +308,7 @@ fn test_simulate_create_contract() {
         &SimulationAdjustmentConfig::no_adjustments(),
         &ledger_info,
         contract.host_fn.clone(),
-        None,
+        recording_auth_mode(),
         &source_account,
         [1; 32],
         true,
@@ -430,7 +441,7 @@ fn test_simulate_invoke_contract_with_auth() {
         &SimulationAdjustmentConfig::no_adjustments(),
         &ledger_info,
         host_fn,
-        None,
+        recording_auth_mode(),
         &source_account,
         [1; 32],
         true,
@@ -1003,7 +1014,7 @@ fn test_simulate_successful_sac_call() {
         &SimulationAdjustmentConfig::no_adjustments(),
         &ledger_info,
         host_fn,
-        None,
+        recording_auth_mode(),
         &source_account,
         [1; 32],
         true,
@@ -1103,7 +1114,7 @@ fn test_simulate_unsuccessful_sac_call_with_try_call() {
         &SimulationAdjustmentConfig::no_adjustments(),
         &ledger_info,
         host_fn,
-        None,
+        recording_auth_mode(),
         &source_account,
         [1; 32],
         true,


### PR DESCRIPTION
### What

Allow passing the setting for non-root auth to the simulation.

This is unfortunately a breaking change and thus it needs to be guarded by unstable-next-api feature.

### Why

This allows for more control over the simulation logic - while the default is sufficient 99% of the time, there is still 1% of the cases where non-root auth should be allowed.

### Known limitations

N/A
