### PR TITLE
Add invocation resource metering to check auth testutil.

### DIFF
--- a/soroban-env-host/src/auth.rs
+++ b/soroban-env-host/src/auth.rs
@@ -2307,6 +2307,8 @@ impl Host {
         contract: AddressObject,
         args: VecObject,
     ) -> Result<Val, HostError> {
+        let _invocation_meter_scope = self.maybe_meter_invocation()?;
+
         use crate::builtin_contracts::account_contract::ACCOUNT_CONTRACT_CHECK_AUTH_FN_NAME;
         let contract_id = self.contract_id_from_address(contract)?;
         let args_vec = self.call_args_from_obj(args)?;


### PR DESCRIPTION
### What

Add invocation resource metering to check auth testutil.

Also harden the unit tests a bit to ensure that budget matches the CPU/memory we report in invocation resources and add a test case for a failed call.

### Why

Fix for https://github.com/stellar/rs-soroban-sdk/issues/1421, still needs to be picked up by the SDK.

### Known limitations

N/A
