### PR TITLE
Bump XDR for env.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1693,8 +1693,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "22.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce69db907e64d1e70a3dce8d4824655d154749426a6132b25395c49136013e4"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=28391e81229ad20a3d9ec56e1e1f382205335085#28391e81229ad20a3d9ec56e1e1f382205335085"
 dependencies = [
  "arbitrary",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,8 @@ wasmparser = "=0.116.1"
 # NB: When updating, also update the version in rs-soroban-env dev-dependencies
 [workspace.dependencies.stellar-xdr]
 version = "=22.1.0"
-#git = "https://github.com/stellar/rs-stellar-xdr"
-#rev = "67be5955a15f1d3a4df83fe86e6ae107f687141b"
+git = "https://github.com/stellar/rs-stellar-xdr"
+rev = "28391e81229ad20a3d9ec56e1e1f382205335085"
 default-features = false
 
 [workspace.dependencies.wasmi]

--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -84,8 +84,8 @@ p256 = {version = "0.13.2", default-features = false, features = ["alloc"]}
 
 [dev-dependencies.stellar-xdr]
 version = "=22.1.0"
-#git = "https://github.com/stellar/rs-stellar-xdr"
-#rev = "67be5955a15f1d3a4df83fe86e6ae107f687141b"
+git = "https://github.com/stellar/rs-stellar-xdr"
+rev = "28391e81229ad20a3d9ec56e1e1f382205335085"
 default-features = false
 features = ["arbitrary"]
 


### PR DESCRIPTION
### What

Bump XDR for env.

This currently only affects the vnext of XDR.

### Why

Preparing for Core changes.

### Known limitations

N/A
