### PR TITLE
Remove `unstable-next-api` feature guards.

### DIFF
--- a/soroban-env-host/src/test/e2e_tests.rs
+++ b/soroban-env-host/src/test/e2e_tests.rs
@@ -196,28 +196,6 @@ impl LedgerEntryChangeHelper {
     }
 }
 
-// NB: this is a temporary helper function that we should remove and embed
-// RecordingInvocationAuthMode into code during the `unstable-next-api` cleanup
-// when switching to v23.
-fn recording_auth_mode() -> RecordingInvocationAuthMode {
-    #[cfg(not(feature = "unstable-next-api"))]
-    return None;
-    #[cfg(feature = "unstable-next-api")]
-    return RecordingInvocationAuthMode::Recording(true);
-}
-
-// NB: this is a temporary helper function that we should remove and embed
-// RecordingInvocationAuthMode into code during the `unstable-next-api` cleanup
-// when switching to v23.
-fn enforcing_auth_mode(
-    auth_entries: Vec<SorobanAuthorizationEntry>,
-) -> RecordingInvocationAuthMode {
-    #[cfg(not(feature = "unstable-next-api"))]
-    return Some(auth_entries);
-    #[cfg(feature = "unstable-next-api")]
-    return RecordingInvocationAuthMode::Enforcing(auth_entries);
-}
-
 struct InvokeHostFunctionHelperResult {
     invoke_result: Result<ScVal, HostError>,
     ledger_changes: Vec<LedgerEntryChangeHelper>,
@@ -438,7 +416,7 @@ fn invoke_host_function_using_simulation_with_signers(
         enable_diagnostics,
         host_fn,
         source_account,
-        recording_auth_mode(),
+        RecordingInvocationAuthMode::Recording(true),
         ledger_info,
         ledger_entries_with_ttl.clone(),
         prng_seed,
@@ -456,7 +434,7 @@ fn invoke_host_function_using_simulation_with_signers(
         enable_diagnostics,
         host_fn,
         source_account,
-        enforcing_auth_mode(signed_auth.clone()),
+        RecordingInvocationAuthMode::Enforcing(signed_auth.clone()),
         ledger_info,
         ledger_entries_with_ttl.clone(),
         prng_seed,
@@ -654,7 +632,7 @@ fn test_run_out_of_budget_before_calling_host_in_recording_mode() {
         true,
         &upload_wasm_host_fn(ADD_I32),
         &get_account_id([0; 32]),
-        recording_auth_mode(),
+        RecordingInvocationAuthMode::Recording(true),
         &default_ledger_info(),
         vec![],
         &prng_seed(),
@@ -743,7 +721,7 @@ fn test_wasm_upload_success_in_recording_mode() {
         false,
         &upload_wasm_host_fn(ADD_I32),
         &get_account_id([123; 32]),
-        recording_auth_mode(),
+        RecordingInvocationAuthMode::Recording(true),
         &ledger_info,
         vec![],
         &prng_seed(),
@@ -796,7 +774,7 @@ fn test_wasm_upload_failure_in_recording_mode() {
         true,
         &upload_wasm_host_fn(&[0_u8; 1000]),
         &get_account_id([123; 32]),
-        recording_auth_mode(),
+        RecordingInvocationAuthMode::Recording(true),
         &ledger_info,
         vec![],
         &prng_seed(),
@@ -834,7 +812,7 @@ fn test_unsupported_wasm_upload_failure_in_recording_mode() {
         true,
         &upload_wasm_host_fn(ADD_F32),
         &get_account_id([123; 32]),
-        recording_auth_mode(),
+        RecordingInvocationAuthMode::Recording(true),
         &ledger_info,
         vec![],
         &prng_seed(),
@@ -1246,7 +1224,7 @@ fn test_create_contract_success_in_recording_mode() {
         true,
         &cd.host_fn,
         &cd.deployer,
-        recording_auth_mode(),
+        RecordingInvocationAuthMode::Recording(true),
         &ledger_info,
         vec![(
             cd.wasm_entry.clone(),
@@ -1332,7 +1310,7 @@ fn test_create_contract_success_in_recording_mode_with_custom_account() {
         true,
         &cd.host_fn,
         &cd.deployer,
-        recording_auth_mode(),
+        RecordingInvocationAuthMode::Recording(true),
         &ledger_info,
         vec![
             (
@@ -1448,7 +1426,7 @@ fn test_create_contract_success_in_recording_mode_with_enforced_auth() {
         true,
         &cd.host_fn,
         &cd.deployer,
-        enforcing_auth_mode(vec![cd.auth_entry.clone()]),
+        RecordingInvocationAuthMode::Enforcing(vec![cd.auth_entry.clone()]),
         &ledger_info,
         vec![(
             cd.wasm_entry.clone(),
@@ -1864,7 +1842,7 @@ fn test_invoke_contract_with_storage_ops_success_in_recording_mode() {
         true,
         &host_fn,
         &cd.deployer,
-        recording_auth_mode(),
+        RecordingInvocationAuthMode::Recording(true),
         &ledger_info,
         vec![
             (
@@ -1939,7 +1917,7 @@ fn test_invoke_contract_with_storage_ops_success_in_recording_mode() {
         true,
         &extend_host_fn,
         &cd.deployer,
-        recording_auth_mode(),
+        RecordingInvocationAuthMode::Recording(true),
         &ledger_info,
         vec![
             (
@@ -2042,7 +2020,7 @@ fn test_invoke_contract_with_storage_ops_success_using_simulation() {
         true,
         &extend_host_fn,
         &cd.deployer,
-        recording_auth_mode(),
+        RecordingInvocationAuthMode::Recording(true),
         &ledger_info,
         vec![
             (

--- a/soroban-simulation/src/test/simulation.rs
+++ b/soroban-simulation/src/test/simulation.rs
@@ -101,16 +101,6 @@ fn nonce_entry(address: ScAddress, nonce: i64) -> LedgerEntry {
     }))
 }
 
-// NB: this is a temporary helper function that we should remove and embed
-// RecordingInvocationAuthMode into code during the `unstable-next-api` cleanup
-// when switching to v23.
-fn recording_auth_mode() -> RecordingInvocationAuthMode {
-    #[cfg(not(feature = "unstable-next-api"))]
-    return None;
-    #[cfg(feature = "unstable-next-api")]
-    return RecordingInvocationAuthMode::Recording(true);
-}
-
 #[test]
 fn test_simulate_upload_wasm() {
     let source_account = get_account_id([123; 32]);
@@ -125,7 +115,7 @@ fn test_simulate_upload_wasm() {
         &SimulationAdjustmentConfig::no_adjustments(),
         &ledger_info,
         upload_wasm_host_fn(ADD_I32),
-        recording_auth_mode(),
+        RecordingInvocationAuthMode::Recording(true),
         &source_account,
         [1; 32],
         true,
@@ -174,7 +164,7 @@ fn test_simulate_upload_wasm() {
         &test_adjustment_config(),
         &ledger_info,
         upload_wasm_host_fn(ADD_I32),
-        recording_auth_mode(),
+        RecordingInvocationAuthMode::Recording(true),
         &source_account,
         [1; 32],
         true,
@@ -229,7 +219,7 @@ fn test_simulation_returns_insufficient_budget_error() {
         &SimulationAdjustmentConfig::no_adjustments(),
         &ledger_info,
         upload_wasm_host_fn(ADD_I32),
-        recording_auth_mode(),
+        RecordingInvocationAuthMode::Recording(true),
         &source_account,
         [1; 32],
         true,
@@ -264,7 +254,7 @@ fn test_simulation_returns_logic_error() {
         &SimulationAdjustmentConfig::no_adjustments(),
         &ledger_info,
         upload_wasm_host_fn(&bad_wasm),
-        recording_auth_mode(),
+        RecordingInvocationAuthMode::Recording(true),
         &source_account,
         [1; 32],
         true,
@@ -308,7 +298,7 @@ fn test_simulate_create_contract() {
         &SimulationAdjustmentConfig::no_adjustments(),
         &ledger_info,
         contract.host_fn.clone(),
-        recording_auth_mode(),
+        RecordingInvocationAuthMode::Recording(true),
         &source_account,
         [1; 32],
         true,
@@ -441,7 +431,7 @@ fn test_simulate_invoke_contract_with_auth() {
         &SimulationAdjustmentConfig::no_adjustments(),
         &ledger_info,
         host_fn,
-        recording_auth_mode(),
+        RecordingInvocationAuthMode::Recording(true),
         &source_account,
         [1; 32],
         true,
@@ -1014,7 +1004,7 @@ fn test_simulate_successful_sac_call() {
         &SimulationAdjustmentConfig::no_adjustments(),
         &ledger_info,
         host_fn,
-        recording_auth_mode(),
+        RecordingInvocationAuthMode::Recording(true),
         &source_account,
         [1; 32],
         true,
@@ -1114,7 +1104,7 @@ fn test_simulate_unsuccessful_sac_call_with_try_call() {
         &SimulationAdjustmentConfig::no_adjustments(),
         &ledger_info,
         host_fn,
-        recording_auth_mode(),
+        RecordingInvocationAuthMode::Recording(true),
         &source_account,
         [1; 32],
         true,


### PR DESCRIPTION
### What

Remove `unstable-next-api` feature guards.

### Why

We don't need these anymore as host has already been switched to v23.

### Known limitations

N/A
