### PR TITLE
Remove check_same_env from EnvBase trait

### DIFF
--- a/soroban-env-common/src/env.rs
+++ b/soroban-env-common/src/env.rs
@@ -133,9 +133,6 @@ pub trait EnvBase: Sized + Clone {
         x
     }
 
-    /// Used to check two environments are the same, returning Error if not.
-    fn check_same_env(&self, other: &Self) -> Result<(), Self::Error>;
-
     // Helpers for methods that wish to pass Rust lifetime-qualified _slices_
     // into the environment. These are _not_ done via Env trait methods to avoid
     // the need to convert, and thus trust (or validate) "raw numbers" coming

--- a/soroban-env-guest/src/guest.rs
+++ b/soroban-env-guest/src/guest.rs
@@ -38,10 +38,6 @@ impl EnvBase for Guest {
         core::arch::wasm32::unreachable()
     }
 
-    fn check_same_env(&self, _other: &Self) -> Result<(), Self::Error> {
-        Ok(())
-    }
-
     fn bytes_copy_from_slice(
         &self,
         b: BytesObject,

--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -732,6 +732,19 @@ impl Host {
         };
         self.create_contract_internal(Some(deployer), args, constructor_args_vec)
     }
+
+    pub fn check_same_env(&self, other: &Self) -> Result<(), HostError> {
+        if Rc::ptr_eq(&self.0, &other.0) {
+            Ok(())
+        } else {
+            Err(self.err(
+                ScErrorType::Context,
+                ScErrorCode::InternalError,
+                "check_same_env on different Hosts",
+                &[],
+            ))
+        }
+    }
 }
 
 macro_rules! call_trace_env_call {
@@ -869,19 +882,6 @@ impl EnvBase for Host {
         res: &Result<&dyn Debug, &HostError>,
     ) -> Result<(), HostError> {
         self.call_any_lifecycle_hook(TraceEvent::EnvRet(fname, res))
-    }
-
-    fn check_same_env(&self, other: &Self) -> Result<(), Self::Error> {
-        if Rc::ptr_eq(&self.0, &other.0) {
-            Ok(())
-        } else {
-            Err(self.err(
-                ScErrorType::Context,
-                ScErrorCode::InternalError,
-                "check_same_env on different Hosts",
-                &[],
-            ))
-        }
     }
 
     fn bytes_copy_from_slice(


### PR DESCRIPTION
### What
Remove the check_same_env function from the EnvBase trait and move it into the Host impl.

### Why
Functions in the EnvBase are implemented by Host and Guest. The check_same_env function is only used by the soroban-sdk. In https://github.com/stellar/rs-soroban-sdk/pull/1436 the soroban-sdk is no longer going to be calling the function on the Guest, and only calling it directly on the Host. So there's no longer a need for it to be part of this trait/interface.