### PR TITLE
switch to wasm32v1-none for contract wasm target

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,10 +63,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: rustup update
-    - uses: stellar/binaries@v33
+    - uses: stellar/binaries@v37
       with:
         name: cargo-semver-checks
-        version: 0.37.0
+        version: 0.40.0
     - run: cargo semver-checks --exclude soroban-simulation
 
   build-and-test:
@@ -77,9 +77,15 @@ jobs:
         sys:
         - os: ubuntu-latest
           target: wasm32-unknown-unknown
+          guest-only: false
+          test: false
+        - os: ubuntu-latest
+          target: wasm32v1-none
+          guest-only: true
           test: false
         - os: ubuntu-latest-16-cores
           target: x86_64-unknown-linux-gnu
+          guest-only: false
           test: true
         # TODO: Re-enable these builds if we see value in doing so.
         # - os: macos-latest
@@ -104,11 +110,14 @@ jobs:
     - run: rustup update
     - run: cargo version
     - run: rustup target add ${{ matrix.sys.target }}
-    - uses: stellar/binaries@v18
+    - uses: stellar/binaries@v37
       with:
         name: cargo-hack
-        version: 0.5.28
-    - run: cargo hack --each-feature clippy --locked --target ${{ matrix.sys.target }}
+        version: 0.6.35
+    - if: ${{ matrix.sys.guest-only }}
+      run: cargo clippy --locked --package soroban-env-guest --target ${{ matrix.sys.target }}
+    - if: ${{ ! matrix.sys.guest-only }}
+      run: cargo hack --each-feature clippy --locked --target ${{ matrix.sys.target }}
     - if: matrix.sys.test
       run: cargo hack --each-feature test --profile test-opt --locked --target ${{ matrix.sys.target }}
       env:
@@ -119,6 +128,11 @@ jobs:
     strategy:
       matrix:
         sys:
+          # Note: we use wasm32-unknown-unknown here not wasm32v1-none because
+          # we are testing the ability to build the soroban host for use in a
+          # browser, which requires a target with a stdlib. wasm32v1-none does
+          # not have a stdlib and is the target used for building _contracts
+          # that run in soroban_, not the host itself.
         - os: ubuntu-latest
           target: wasm32-unknown-unknown
         - os: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = ["soroban-test-wasms/wasm-workspace"]
 # code guarded by `unstable-*` features to make it enabled
 # unconditionally.
 version = "23.0.0"
-rust-version = "1.81.0"
+rust-version = "1.84.0"
 
 [workspace.dependencies]
 soroban-env-common = { version = "=23.0.0", path = "soroban-env-common", default-features = false }

--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,15 @@ test-all-protocols:
 		TEST_PROTOCOL=$$i cargo hack test -p soroban-simulation --locked --features testutils,next; \
 	done
 
+# Note: we use wasm32-unknown-unknown here for the workspace build, not
+# wasm32v1-none, because we are testing the ability to build the soroban host
+# for use in a browser, which requires a target with a stdlib. wasm32v1-none
+# does not have a stdlib and is the target used for building _contracts that run
+# in soroban_, not the host itself. So we only check the guest package with it.
 build:
 	cargo hack --locked --each-feature clippy
-	cargo hack --locked clippy --target wasm32-unknown-unknown
+	cargo --locked clippy --target wasm32-unknown-unknown
+	cargo --locked clippy --package soroban-env-guest --target wasm32v1-none
 
 # We use "run" to run the soroban-env-host/src/bin/main.rs
 # entrypoint, which both excludes dev-deps (noisy) and

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,7 @@
 [toolchain]
 channel = "stable"
-targets = ["wasm32-unknown-unknown"]
+# Note: we want toolchains for _both_ wasm32-unknown-unknown here _and_
+# wasm32v1-none. We use the former for building the host in a mode that lets it
+# run in a web browser, and the latter for building the contracts.
+targets = ["wasm32-unknown-unknown", "wasm32v1-none"]
 components = ["rustc", "cargo", "rustfmt", "clippy", "rust-src"]

--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 version.workspace = true
 readme = "../README.md"
 edition = "2021"
-rust-version = "1.81.0"
+rust-version = "1.84.0"
 build = "build.rs"
 
 exclude = ["observations/"]

--- a/soroban-test-wasms/wasm-workspace/Cargo.toml
+++ b/soroban-test-wasms/wasm-workspace/Cargo.toml
@@ -64,7 +64,7 @@ codegen-units = 1
 lto = true
 
 [workspace.package]
-rust-version = "1.81.0"
+rust-version = "1.84.0"
 
 [workspace.dependencies.soroban-sdk]
 version = "=21.4.0"

--- a/soroban-test-wasms/wasm-workspace/Makefile
+++ b/soroban-test-wasms/wasm-workspace/Makefile
@@ -18,12 +18,12 @@ endif
 regenerate-test-wasms:
 	for i in $(wildcard */Cargo.toml); do \
 		(cd $$(dirname $$i) && cargo rustc \
-			--target wasm32-unknown-unknown \
+			--target wasm32v1-none \
 			--release \
 			--crate-type=cdylib); \
 	done
 	mkdir -p opt/$(PROTOCOL_VERSION)
-	for i in target/wasm32-unknown-unknown/release/*.wasm ; do \
+	for i in target/wasm32v1-none/release/*.wasm ; do \
 		wasm-opt -Oz "$$i" -o "opt/$(PROTOCOL_VERSION)/$$(basename $$i)"; \
 		ls -l "opt/$(PROTOCOL_VERSION)/$$(basename $$i)"; \
 	done


### PR DESCRIPTION
Part of wrapping up https://github.com/stellar/rs-soroban-sdk/issues/1428 -- just supporting wasm32v1-none