### PR TITLE
Update stellar-xdr dependency to latest commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,12 +224,6 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
@@ -1734,10 +1728,10 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "22.1.0"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=8f65f811c9253b437a3b4aec742a6db7c82aa0dc#8f65f811c9253b437a3b4aec742a6db7c82aa0dc"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=323f7de1cc2b956dde2de9da8622a261baf2977e#323f7de1cc2b956dde2de9da8622a261baf2977e"
 dependencies = [
  "arbitrary",
- "base64 0.13.1",
+ "base64 0.22.1",
  "cfg_eval",
  "crate-git-revision",
  "escape-bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ wasmparser = "=0.116.1"
 [workspace.dependencies.stellar-xdr]
 version = "=22.1.0"
 git = "https://github.com/stellar/rs-stellar-xdr"
-rev = "8f65f811c9253b437a3b4aec742a6db7c82aa0dc"
+rev = "323f7de1cc2b956dde2de9da8622a261baf2977e"
 default-features = false
 
 [workspace.dependencies.wasmi]

--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -85,7 +85,7 @@ p256 = {version = "0.13.2", default-features = false, features = ["alloc"]}
 [dev-dependencies.stellar-xdr]
 version = "=22.1.0"
 git = "https://github.com/stellar/rs-stellar-xdr"
-rev = "8f65f811c9253b437a3b4aec742a6db7c82aa0dc"
+rev = "323f7de1cc2b956dde2de9da8622a261baf2977e"
 default-features = false
 features = ["arbitrary"]
 


### PR DESCRIPTION
### What
Updates the stellar-xdr dependency to the latest commit from the default branch (323f7de1cc2b956dde2de9da8622a261baf2977e).

### Why
Keep the repository in sync with the latest stellar-xdr changes.