### PR TITLE
Remove enabling of base64 feature in stellar-xdr dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,12 +224,6 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
@@ -1737,7 +1731,6 @@ version = "22.1.0"
 source = "git+https://github.com/stellar/rs-stellar-xdr?rev=8f65f811c9253b437a3b4aec742a6db7c82aa0dc#8f65f811c9253b437a3b4aec742a6db7c82aa0dc"
 dependencies = [
  "arbitrary",
- "base64 0.13.1",
  "cfg_eval",
  "crate-git-revision",
  "escape-bytes",

--- a/soroban-env-common/Cargo.toml
+++ b/soroban-env-common/Cargo.toml
@@ -33,7 +33,7 @@ num_enum = "0.7.1"
 num-traits = "0.2.17"
 
 [features]
-std = ["stellar-xdr/std", "stellar-xdr/base64"]
+std = ["stellar-xdr/std"]
 serde = ["dep:serde", "stellar-xdr/serde"]
 wasmi = ["dep:wasmi", "dep:wasmparser"]
 testutils = ["dep:arbitrary", "stellar-xdr/arbitrary"]


### PR DESCRIPTION
### What
  Remove enabling of base64 feature from in stellar-xdr dep.

  ### Why
  I can't see a use for it in the crates outside tests.

Looks like it was added in https://github.com/stellar/rs-soroban-env/pull/375 to make it more convenient to import the env and have base64 already enabled in the xdr lib also imported, which I approved. However, downstream deps should be able to import the stellar-xdr crate themselves at the same version and enable the base64 feature in the same way they do for other features like the serde feature.

### Why not

If core is also using the base64 feature then there's not really any value removing it here.