### PR TITLE
Update XDR to v23.0.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1727,8 +1727,9 @@ dependencies = [
 
 [[package]]
 name = "stellar-xdr"
-version = "22.1.0"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=1a00274ac9c93d580cc4f5eba787906e759d632a#1a00274ac9c93d580cc4f5eba787906e759d632a"
+version = "23.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11e08476633f75dfda6d41769619d8b54280d6b7807ac36bf09fa9c62afb8cfd"
 dependencies = [
  "arbitrary",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,9 @@ wasmparser = "=0.116.1"
 
 # NB: When updating, also update the version in rs-soroban-env dev-dependencies
 [workspace.dependencies.stellar-xdr]
-version = "=22.1.0"
-git = "https://github.com/stellar/rs-stellar-xdr"
-rev = "1a00274ac9c93d580cc4f5eba787906e759d632a"
+version = "=23.0.0-rc.1"
+# git = "https://github.com/stellar/rs-stellar-xdr"
+# rev = "1a00274ac9c93d580cc4f5eba787906e759d632a"
 default-features = false
 
 [workspace.dependencies.wasmi]

--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -83,9 +83,9 @@ k256 = {version = "0.13.1", default-features = false, features = ["alloc"]}
 p256 = {version = "0.13.2", default-features = false, features = ["alloc"]}
 
 [dev-dependencies.stellar-xdr]
-version = "=22.1.0"
-git = "https://github.com/stellar/rs-stellar-xdr"
-rev = "1a00274ac9c93d580cc4f5eba787906e759d632a"
+version = "=23.0.0-rc.1"
+# git = "https://github.com/stellar/rs-stellar-xdr"
+# rev = "1a00274ac9c93d580cc4f5eba787906e759d632a"
 default-features = false
 features = ["arbitrary"]
 


### PR DESCRIPTION
### What

Update XDR to v23.0.0-rc.1

### Why

Preparing for v23.0.0-rc.1 release

### Known limitations

N/A
