### PR TITLE
Update version to 23.0.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1532,7 +1532,7 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "soroban-bench-utils"
-version = "23.0.0"
+version = "23.0.0-rc.1"
 dependencies = [
  "perf-event",
  "soroban-env-common",
@@ -1542,7 +1542,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "23.0.0"
+version = "23.0.0-rc.1"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1552,7 +1552,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "23.0.0"
+version = "23.0.0-rc.1"
 dependencies = [
  "arbitrary",
  "crate-git-revision",
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "23.0.0"
+version = "23.0.0-rc.1"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -1579,7 +1579,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "23.0.0"
+version = "23.0.0-rc.1"
 dependencies = [
  "arbitrary",
  "ark-bls12-381",
@@ -1638,7 +1638,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "23.0.0"
+version = "23.0.0-rc.1"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1651,7 +1651,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-simulation"
-version = "23.0.0"
+version = "23.0.0-rc.1"
 dependencies = [
  "anyhow",
  "pretty_assertions",
@@ -1665,7 +1665,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-synth-wasm"
-version = "23.0.0"
+version = "23.0.0-rc.1"
 dependencies = [
  "arbitrary",
  "expect-test",
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-test-wasms"
-version = "23.0.0"
+version = "23.0.0-rc.1"
 
 [[package]]
 name = "soroban-wasmi"
@@ -1794,7 +1794,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "test_no_std"
-version = "23.0.0"
+version = "23.0.0-rc.1"
 dependencies = [
  "soroban-env-common",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,15 +20,15 @@ exclude = ["soroban-test-wasms/wasm-workspace"]
 # NB: When bumping the major version make sure to clean up the
 # code guarded by `unstable-*` features to make it enabled
 # unconditionally.
-version = "23.0.0"
+version = "23.0.0-rc.1"
 rust-version = "1.84.0"
 
 [workspace.dependencies]
-soroban-env-common = { version = "=23.0.0", path = "soroban-env-common", default-features = false }
-soroban-env-guest = { version = "=23.0.0", path = "soroban-env-guest" }
-soroban-env-host = { version = "=23.0.0", path = "soroban-env-host" }
-soroban-env-macros = { version = "=23.0.0", path = "soroban-env-macros" }
-soroban-builtin-sdk-macros = { version = "=23.0.0", path = "soroban-builtin-sdk-macros" }
+soroban-env-common = { version = "=23.0.0-rc.1", path = "soroban-env-common", default-features = false }
+soroban-env-guest = { version = "=23.0.0-rc.1", path = "soroban-env-guest" }
+soroban-env-host = { version = "=23.0.0-rc.1", path = "soroban-env-host" }
+soroban-env-macros = { version = "=23.0.0-rc.1", path = "soroban-env-macros" }
+soroban-builtin-sdk-macros = { version = "=23.0.0-rc.1", path = "soroban-builtin-sdk-macros" }
 # NB: this must match the wasmparser version wasmi is using
 wasmparser = "=0.116.1"
 


### PR DESCRIPTION
### What

Update version to 23.0.0-rc.1

It's not possible to prepare this PR via bump-version action. I've opened https://github.com/stellar/rs-soroban-env/pull/1551 PR with 23.0.1-rc.1 bump via the action in order to make sure CI for publish-dry-run runs fine. I think it's better to stick to v23.0.0 for clarity.

### Why

It was an oversight to make it a 'stable' 23.0.0. 

### Known limitations

N/A
