### PR TITLE
Rename Host::check_same_env to Host::is_same

### DIFF
--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -744,7 +744,8 @@ impl Host {
         self.create_contract_internal(Some(deployer), args, constructor_args_vec)
     }
 
-    /// Returns true if the Host contains the same instance of HostImpl.
+    /// Returns true if the Host contains the same instance of HostImpl and therefore changes to
+    /// one will be observable via the other. If true, both are essentially the same Host.
     pub fn is_same(&self, other: &Self) -> bool {
         Rc::ptr_eq(&self.0, &other.0)
     }

--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -744,17 +744,9 @@ impl Host {
         self.create_contract_internal(Some(deployer), args, constructor_args_vec)
     }
 
-    pub fn check_same_env(&self, other: &Self) -> Result<(), HostError> {
-        if Rc::ptr_eq(&self.0, &other.0) {
-            Ok(())
-        } else {
-            Err(self.err(
-                ScErrorType::Context,
-                ScErrorCode::InternalError,
-                "check_same_env on different Hosts",
-                &[],
-            ))
-        }
+    /// Returns true if the Host contains the same instance of HostImpl.
+    pub fn is_same(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.0, &other.0)
     }
 }
 

--- a/soroban-env-host/src/test/host.rs
+++ b/soroban-env-host/src/test/host.rs
@@ -8,6 +8,17 @@ use crate::{
 };
 
 #[test]
+fn is_same_host_impl() {
+    let host1 = Host::default();
+    let host1_clone = host1.clone();
+    let host2 = Host::default();
+
+    assert!(host1.is_same(&host1));
+    assert!(host1.is_same(&host1_clone));
+    assert!(!host1.is_same(&host2));
+}
+
+#[test]
 fn invalid_object_handles() -> Result<(), HostError> {
     let create_host = || -> Result<Host, HostError> {
         let budget = Budget::default();


### PR DESCRIPTION
### What
  Rename the host comparison method from check_same_env to is_same, changing it to return a boolean instead of a Result.

  ### Why
  The new name better reflects the method's purpose of being used by the SDK to compare two Hosts and determine if they in fact are the same underlying host implementation. The check function returns a result with the host assuming that there is in fact an error, whilst the is function returns a bool, merely providing information to the SDK so that the SDK can then decide in the context of its use whether there is an error or a change in behaviour is required.

Close #1554 

Related:
- https://github.com/stellar/rs-soroban-sdk/pull/1467#discussion_r2094183786