### PR TITLE
Add test utilities to compensate hiding the storage interface.

### DIFF
--- a/soroban-env-host/src/builtin_contracts/stellar_asset_contract/balance.rs
+++ b/soroban-env-host/src/builtin_contracts/stellar_asset_contract/balance.rs
@@ -453,7 +453,7 @@ fn transfer_account_balance(
         if new_balance >= min_balance && new_balance <= max_balance {
             ae.balance = new_balance;
             le = Host::modify_ledger_entry_data(host, &le, LedgerEntryData::Account(ae))?;
-            storage.put_with_host(&lk, &le, None, &host, None)
+            storage.put(&lk, &le, None, &host, None)
         } else {
             Err(err!(
                 host,
@@ -535,7 +535,7 @@ fn transfer_trustline_balance(
         if new_balance >= min_balance && new_balance <= max_balance {
             tl.balance = new_balance;
             le = Host::modify_ledger_entry_data(host, &le, LedgerEntryData::Trustline(tl))?;
-            storage.put_with_host(&lk, &le, None, &host, None)
+            storage.put(&lk, &le, None, &host, None)
         } else {
             Err(err!(
                 host,
@@ -805,7 +805,7 @@ fn set_trustline_authorization(
             tl.flags |= TrustLineFlags::AuthorizedToMaintainLiabilitiesFlag as u32;
         }
         le = Host::modify_ledger_entry_data(host, &le, LedgerEntryData::Trustline(tl))?;
-        storage.put_with_host(&lk, &le, None, &host, None)
+        storage.put(&lk, &le, None, &host, None)
     })
 }
 

--- a/soroban-env-host/src/e2e_invoke.rs
+++ b/soroban-env-host/src/e2e_invoke.rs
@@ -652,7 +652,7 @@ pub fn invoke_host_function_in_recording_mode(
     base_prng_seed: [u8; 32],
     diagnostic_events: &mut Vec<DiagnosticEvent>,
 ) -> Result<InvokeHostFunctionRecordingModeResult, HostError> {
-    let storage = Storage::with_recording_footprint(ledger_snapshot.clone())?;
+    let storage = Storage::with_recording_footprint(ledger_snapshot.clone());
     let host = Host::with_storage_and_budget(storage, budget.clone());
     let is_recording_auth = matches!(auth_mode, RecordingInvocationAuthMode::Recording(_));
     let ledger_seq = ledger_info.sequence_number;

--- a/soroban-env-host/src/host/data_helper.rs
+++ b/soroban-env-host/src/host/data_helper.rs
@@ -547,6 +547,7 @@ impl Host {
     }
 
     /// Returns all the ledger entries stored in the storage as key-value pairs.
+    #[allow(clippy::type_complexity)]
     pub fn get_stored_entries(
         &self,
     ) -> Result<Vec<(Rc<LedgerKey>, Option<EntryWithLiveUntil>)>, HostError> {

--- a/soroban-env-host/src/host/data_helper.rs
+++ b/soroban-env-host/src/host/data_helper.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 impl Host {
-    pub fn with_mut_storage<F, U>(&self, f: F) -> Result<U, HostError>
+    pub(crate) fn with_mut_storage<F, U>(&self, f: F) -> Result<U, HostError>
     where
         F: FnOnce(&mut Storage) -> Result<U, HostError>,
     {
@@ -115,9 +115,7 @@ impl Host {
         &self,
         key: &Rc<LedgerKey>,
     ) -> Result<ScContractInstance, HostError> {
-        let entry = self
-            .try_borrow_storage_mut()?
-            .get_with_host(key, self, None)?;
+        let entry = self.try_borrow_storage_mut()?.get(key, self, None)?;
         self.extract_contract_instance_from_ledger_entry(&entry)
     }
 
@@ -137,11 +135,7 @@ impl Host {
         wasm_hash: &Hash,
     ) -> Result<(BytesM, VersionedContractCodeCostInputs), HostError> {
         let key = self.contract_code_ledger_key(wasm_hash)?;
-        match &self
-            .try_borrow_storage_mut()?
-            .get_with_host(&key, self, None)?
-            .data
-        {
+        match &self.try_borrow_storage_mut()?.get(&key, self, None)?.data {
             LedgerEntryData::ContractCode(e) => {
                 let code = e.code.metered_clone(self)?;
                 let costs = match &e.ext {
@@ -167,8 +161,7 @@ impl Host {
 
     pub(crate) fn wasm_exists(&self, wasm_hash: &Hash) -> Result<bool, HostError> {
         let key = self.contract_code_ledger_key(wasm_hash)?;
-        self.try_borrow_storage_mut()?
-            .has_with_host(&key, self, None)
+        self.try_borrow_storage_mut()?.has(&key, self, None)
     }
 
     // Stores the contract instance specified with its parts (executable and
@@ -184,10 +177,7 @@ impl Host {
         contract_id: ContractId,
         key: &Rc<LedgerKey>,
     ) -> Result<(), HostError> {
-        if self
-            .try_borrow_storage_mut()?
-            .has_with_host(key, self, None)?
-        {
+        if self.try_borrow_storage_mut()?.has(key, self, None)? {
             let (current, live_until_ledger) = self
                 .try_borrow_storage_mut()?
                 .get_with_live_until_ledger(key, self, None)?;
@@ -218,7 +208,7 @@ impl Host {
                 ));
             }
 
-            self.try_borrow_storage_mut()?.put_with_host(
+            self.try_borrow_storage_mut()?.put(
                 &key,
                 &Rc::metered_new(current, self)?,
                 live_until_ledger,
@@ -243,7 +233,7 @@ impl Host {
                 durability: ContractDataDurability::Persistent,
                 ext: ExtensionPoint::V0,
             };
-            self.try_borrow_storage_mut()?.put_with_host(
+            self.try_borrow_storage_mut()?.put(
                 key,
                 &Host::new_contract_data(self, data)?,
                 Some(self.get_min_live_until_ledger(ContractDataDurability::Persistent)?),
@@ -305,17 +295,15 @@ impl Host {
     // notes on metering: `get` from storage is covered. Rest are free.
     pub(crate) fn load_account(&self, account_id: AccountId) -> Result<AccountEntry, HostError> {
         let acc = self.to_account_key(account_id)?;
-        self.with_mut_storage(
-            |storage| match &storage.get_with_host(&acc, self, None)?.data {
-                LedgerEntryData::Account(ae) => ae.metered_clone(self),
-                e => Err(err!(
-                    self,
-                    (ScErrorType::Storage, ScErrorCode::InternalError),
-                    "ledger entry is not account",
-                    e.name()
-                )),
-            },
-        )
+        self.with_mut_storage(|storage| match &storage.get(&acc, self, None)?.data {
+            LedgerEntryData::Account(ae) => ae.metered_clone(self),
+            e => Err(err!(
+                self,
+                (ScErrorType::Storage, ScErrorCode::InternalError),
+                "ledger entry is not account",
+                e.name()
+            )),
+        })
     }
 
     pub(crate) fn to_account_key(&self, account_id: AccountId) -> Result<Rc<LedgerKey>, HostError> {
@@ -485,10 +473,7 @@ impl Host {
         // operation might only modify the internal `ScVal` value. Thus we
         // need to only overwrite the value in case if there is already an
         // existing ledger entry value for the key in the storage.
-        if self
-            .try_borrow_storage_mut()?
-            .has_with_host(&key, self, Some(k))?
-        {
+        if self.try_borrow_storage_mut()?.has(&key, self, Some(k))? {
             let (current, live_until_ledger) = self
                 .try_borrow_storage_mut()?
                 .get_with_live_until_ledger(&key, self, Some(k))?;
@@ -506,7 +491,7 @@ impl Host {
                     ));
                 }
             }
-            self.try_borrow_storage_mut()?.put_with_host(
+            self.try_borrow_storage_mut()?.put(
                 &key,
                 &Rc::metered_new(current, self)?,
                 live_until_ledger,
@@ -521,7 +506,7 @@ impl Host {
                 durability,
                 ext: ExtensionPoint::V0,
             };
-            self.try_borrow_storage_mut()?.put_with_host(
+            self.try_borrow_storage_mut()?.put(
                 &key,
                 &Host::new_contract_data(self, data)?,
                 Some(self.get_min_live_until_ledger(durability)?),
@@ -537,20 +522,35 @@ impl Host {
 #[cfg(any(test, feature = "testutils"))]
 use crate::crypto;
 #[cfg(any(test, feature = "testutils"))]
-use crate::storage::{AccessType, Footprint};
+use crate::storage::{AccessType, EntryWithLiveUntil, Footprint};
 
 #[cfg(any(test, feature = "testutils"))]
 impl Host {
-    // Writes an arbitrary ledger entry to storage.
+    /// Writes an arbitrary ledger entry to storage.
     pub fn add_ledger_entry(
         &self,
         key: &Rc<LedgerKey>,
         val: &Rc<soroban_env_common::xdr::LedgerEntry>,
         live_until_ledger: Option<u32>,
     ) -> Result<(), HostError> {
-        self.with_mut_storage(|storage| {
-            storage.put_with_host(key, val, live_until_ledger, self, None)
-        })
+        self.with_mut_storage(|storage| storage.put(key, val, live_until_ledger, self, None))
+    }
+
+    /// Reads an arbitrary ledger entry from the storage.
+    ///
+    /// Returns `None` if the entry does not exist.
+    pub fn get_ledger_entry(
+        &self,
+        key: &Rc<LedgerKey>,
+    ) -> Result<Option<EntryWithLiveUntil>, HostError> {
+        self.with_mut_storage(|storage| storage.try_get_full(key, self, None))
+    }
+
+    /// Returns all the ledger entries stored in the storage as key-value pairs.
+    pub fn get_stored_entries(
+        &self,
+    ) -> Result<Vec<(Rc<LedgerKey>, Option<EntryWithLiveUntil>)>, HostError> {
+        self.with_mut_storage(|storage| Ok(storage.map.map.clone()))
     }
 
     // Performs the necessary setup to access the provided ledger key/entry in

--- a/soroban-env-host/src/host/frame.rs
+++ b/soroban-env-host/src/host/frame.rs
@@ -697,10 +697,7 @@ impl Host {
             // checking the cache: this seems like overkill but it
             // provides some future-proofing, see below.
             let wasm_key = self.contract_code_ledger_key(wasm_hash)?;
-            if self
-                .try_borrow_storage_mut()?
-                .has_with_host(&wasm_key, self, None)?
-            {
+            if self.try_borrow_storage_mut()?.has(&wasm_key, self, None)? {
                 if let Some(parsed_module) = cache.get_module(wasm_hash)? {
                     return Vm::from_parsed_module_and_wasmi_linker(
                         self,

--- a/soroban-env-host/src/host/invocation_metering.rs
+++ b/soroban-env-host/src/host/invocation_metering.rs
@@ -323,7 +323,7 @@ impl InvocationMeter {
             let mut entry_size = 0;
             let mut new_entry_size_for_rent = 0;
             let mut entry_live_until_ledger = None;
-            let maybe_entry = curr_storage.try_get_full_with_host(key, host, None)?;
+            let maybe_entry = curr_storage.try_get_full(key, host, None)?;
             if let Some((entry, entry_live_until)) = maybe_entry {
                 let mut buf = Vec::<u8>::new();
                 metered_write_xdr(host.budget_ref(), entry.as_ref(), &mut buf)?;

--- a/soroban-env-host/src/host/lifecycle.rs
+++ b/soroban-env-host/src/host/lifecycle.rs
@@ -27,7 +27,7 @@ impl Host {
         let storage_key = self.contract_instance_ledger_key(&contract_id)?;
         if self
             .try_borrow_storage_mut()?
-            .has_with_host(&storage_key, self, None)?
+            .has(&storage_key, self, None)?
         {
             return Err(self.err(
                 ScErrorType::Storage,
@@ -275,11 +275,11 @@ impl Host {
 
         // We will definitely put the contract in the ledger if it isn't there yet.
         #[allow(unused_mut)]
-        let mut should_put_contract = !storage.has_with_host(&code_key, self, None)?;
+        let mut should_put_contract = !storage.has(&code_key, self, None)?;
 
         // We may also, in the cache-supporting protocol, overwrite the contract if its ext field changed.
         if !should_put_contract {
-            let entry = storage.get_with_host(&code_key, self, None)?;
+            let entry = storage.get(&code_key, self, None)?;
             if let crate::xdr::LedgerEntryData::ContractCode(ContractCodeEntry {
                 ext: old_ext,
                 ..
@@ -295,7 +295,7 @@ impl Host {
                 ext,
                 code: wasm_bytes_m,
             };
-            storage.put_with_host(
+            storage.put(
                 &code_key,
                 &Host::new_contract_code(self, data)?,
                 Some(self.get_min_live_until_ledger(ContractDataDurability::Persistent)?),

--- a/soroban-env-host/src/test/auth.rs
+++ b/soroban-env-host/src/test/auth.rs
@@ -299,7 +299,7 @@ impl AuthTest {
             .unwrap();
         self.host
             .with_mut_storage(|storage| {
-                if !storage.has_with_host(&nonce_key, &self.host, None)? {
+                if !storage.has(&nonce_key, &self.host, None)? {
                     return Ok(None);
                 }
                 let (_, live_until_ledger) =
@@ -550,7 +550,7 @@ fn test_single_authorized_call() {
             let key = test.host.to_account_key(account_id)?;
             // Note, that this represents 'correct footprint, missing value' scenario.
             // Incorrect footprint scenario is not covered (it's not auth specific).
-            storage.del_with_host(&key, &test.host, None)
+            storage.del(&key, &test.host, None)
         })
         .unwrap();
 

--- a/soroban-env-host/src/test/lifecycle.rs
+++ b/soroban-env-host/src/test/lifecycle.rs
@@ -23,9 +23,9 @@ use crate::testutils::{generate_account_id, generate_bytes_array};
 fn get_contract_wasm_ref(host: &Host, contract_id: ContractId) -> Hash {
     let storage_key = host.contract_instance_ledger_key(&contract_id).unwrap();
     host.with_mut_storage(|s: &mut Storage| {
-        assert!(s.has_with_host(&storage_key, &host, None).unwrap());
+        assert!(s.has(&storage_key, &host, None).unwrap());
 
-        match &s.get_with_host(&storage_key, host, None).unwrap().data {
+        match &s.get(&storage_key, host, None).unwrap().data {
             LedgerEntryData::ContractData(e) => match &e.val {
                 ScVal::ContractInstance(i) => match &i.executable {
                     ContractExecutable::Wasm(h) => Ok(h.clone()),
@@ -42,9 +42,9 @@ fn get_contract_wasm_ref(host: &Host, contract_id: ContractId) -> Hash {
 fn get_contract_wasm(host: &Host, wasm_hash: Hash) -> Vec<u8> {
     let storage_key = host.contract_code_ledger_key(&wasm_hash).unwrap();
     host.with_mut_storage(|s: &mut Storage| {
-        assert!(s.has_with_host(&storage_key, &host, None).unwrap());
+        assert!(s.has(&storage_key, &host, None).unwrap());
 
-        match &s.get_with_host(&storage_key, host, None).unwrap().data {
+        match &s.get(&storage_key, host, None).unwrap().data {
             LedgerEntryData::ContractCode(code_entry) => Ok(code_entry.code.to_vec()),
             _ => panic!("expected contract WASM code"),
         }
@@ -771,8 +771,8 @@ mod cap_54_55_56 {
         }
         fn reload(self, host: &Host) -> Result<Self, HostError> {
             host.with_mut_storage(|storage| {
-                let contract_entry = storage.get_with_host(&self.contract_key, host, None)?;
-                let wasm_entry = storage.get_with_host(&self.wasm_key, host, None)?;
+                let contract_entry = storage.get(&self.contract_key, host, None)?;
+                let wasm_entry = storage.get(&self.wasm_key, host, None)?;
                 Ok(ContractAndWasmEntries {
                     contract_key: self.contract_key,
                     contract_entry,
@@ -787,8 +787,8 @@ mod cap_54_55_56 {
             let wasm_key = host.contract_code_ledger_key(&wasm_hash)?;
 
             host.with_mut_storage(|storage| {
-                let contract_entry = storage.get_with_host(&contract_key, host, None)?;
-                let wasm_entry = storage.get_with_host(&wasm_key, host, None)?;
+                let contract_entry = storage.get(&contract_key, host, None)?;
+                let wasm_entry = storage.get(&wasm_key, host, None)?;
                 Ok(ContractAndWasmEntries {
                     contract_key,
                     contract_entry,
@@ -917,7 +917,7 @@ mod cap_54_55_56 {
             }),
             ..(*entry).clone()
         });
-        storage.put_with_host(&code_key, &new_entry, live_until_ledger, &host, None)?;
+        storage.put(&code_key, &new_entry, live_until_ledger, &host, None)?;
         Ok(())
     }
 

--- a/soroban-env-host/src/test/stellar_asset_contract.rs
+++ b/soroban-env-host/src/test/stellar_asset_contract.rs
@@ -146,12 +146,10 @@ impl StellarAssetContractTest {
 
     fn get_trustline_balance(&self, key: &Rc<LedgerKey>) -> i64 {
         self.host
-            .with_mut_storage(
-                |s| match &s.get_with_host(key, &self.host, None).unwrap().data {
-                    LedgerEntryData::Trustline(trustline) => Ok(trustline.balance),
-                    _ => unreachable!(),
-                },
-            )
+            .with_mut_storage(|s| match &s.get(key, &self.host, None).unwrap().data {
+                LedgerEntryData::Trustline(trustline) => Ok(trustline.balance),
+                _ => unreachable!(),
+            })
             .unwrap()
     }
     #[allow(clippy::too_many_arguments)]
@@ -184,7 +182,7 @@ impl StellarAssetContractTest {
     fn update_account_flags(&self, key: &Rc<LedgerKey>, new_flags: u32) {
         self.host
             .with_mut_storage(|s| {
-                let entry = s.get_with_host(key, &self.host, None).unwrap();
+                let entry = s.get(key, &self.host, None).unwrap();
                 match entry.data.clone() {
                     LedgerEntryData::Account(mut account) => {
                         account.flags = new_flags;
@@ -193,7 +191,7 @@ impl StellarAssetContractTest {
                             &entry,
                             LedgerEntryData::Account(account),
                         )?;
-                        s.put_with_host(key, &update, None, &self.host, None)
+                        s.put(key, &update, None, &self.host, None)
                     }
                     _ => unreachable!(),
                 }
@@ -262,7 +260,7 @@ impl StellarAssetContractTest {
     fn update_trustline_flags(&self, key: &Rc<LedgerKey>, new_flags: u32) {
         self.host
             .with_mut_storage(|s| {
-                let entry = s.get_with_host(key, &self.host, None).unwrap();
+                let entry = s.get(key, &self.host, None).unwrap();
                 match entry.data.clone() {
                     LedgerEntryData::Trustline(mut trustline) => {
                         trustline.flags = new_flags;
@@ -271,7 +269,7 @@ impl StellarAssetContractTest {
                             &entry,
                             LedgerEntryData::Trustline(trustline),
                         )?;
-                        s.put_with_host(key, &update, None, &self.host, None)
+                        s.put(key, &update, None, &self.host, None)
                     }
                     _ => unreachable!(),
                 }
@@ -3394,7 +3392,7 @@ fn test_custom_account_auth() {
             let key = test.host.contract_instance_ledger_key(&contract_id)?;
             // Note, that this represents 'correct footprint, missing value' scenario.
             // Incorrect footprint scenario is not covered (it's not auth specific).
-            storage.del_with_host(&key, &test.host, None)
+            storage.del(&key, &test.host, None)
         })
         .unwrap();
 

--- a/soroban-env-host/src/testutils.rs
+++ b/soroban-env-host/src/testutils.rs
@@ -221,7 +221,7 @@ impl Host {
 
     pub fn test_host_with_recording_footprint() -> Self {
         let snapshot_source = Rc::<MockSnapshotSource>::new(MockSnapshotSource::new());
-        let storage = Storage::with_recording_footprint(snapshot_source).unwrap();
+        let storage = Storage::with_recording_footprint(snapshot_source);
         let host = Host::with_storage_and_budget(storage, Budget::default());
         host.set_test_ledger_info_with_current_test_protocol();
         host.set_test_prng();


### PR DESCRIPTION
### What

Add test utilities to compensate hiding the storage interface.

Also do a small passing-by cleanup for the storage function names.

### Why

There generally should not be a need to expose the Storage implementation to the env users; the interface is pretty complex and we want to be able to change it (as we did e.g. for the error handling). The test utilities make sure the Storage remains mostly encapsulated in host, while SDK gets the necessary tools to read/write the arbitrary ledger entries (which is mostly useful for SAC setup - maybe eventually this should be moved to host as well, as this is protocol level logic).

### Known limitations

N/A