### PR TITLE
Scale shadow CPU limit in simulation 10x, shadow memory limit 2x.

### DIFF
--- a/soroban-env-host/src/budget.rs
+++ b/soroban-env-host/src/budget.rs
@@ -1130,6 +1130,22 @@ impl Budget {
         )?))))
     }
 
+    /// Initializes the budget from network configuration settings.
+    /// Allows customizing the shadow CPU/memory limits.
+    pub fn try_from_configs_with_shadow_limits(
+        cpu_limit: u64,
+        mem_limit: u64,
+        cpu_shadow_limit: u64,
+        mem_shadow_limit: u64,
+        cpu_cost_params: ContractCostParams,
+        mem_cost_params: ContractCostParams,
+    ) -> Result<Self, HostError> {
+        let budget =
+            Budget::try_from_configs(cpu_limit, mem_limit, cpu_cost_params, mem_cost_params)?;
+        budget.set_shadow_limits(cpu_shadow_limit, mem_shadow_limit)?;
+        Ok(budget)
+    }
+
     // Helper function to avoid panics from multiple borrow_muts
     fn with_mut_budget<T, F>(&self, f: F) -> Result<T, HostError>
     where


### PR DESCRIPTION
### What

Scale shadow CPU limit in simulation 10x, shadow memory limit 2x.

This picks up a commit released in the 22.1.4 release of env.

### Why

Shadow limit has never been meant as a hard limit that would cause the simulation to fail. However, since module cache emulation is now off-loaded to the shadow budget, it became relatively easy to hit the shadow budget limit by doing repeated calls to the same contract (which is now cheap for the actual 'enforcing' mode).

Eventually this may become a setting, but that would be nicer to do with a breaking change in the simulation API in order to not duplicate the interfaces.

### Known limitations

N/A
