### PR TITLE
Discount code entry rent by 50%

### DIFF
--- a/soroban-env-host/src/e2e_invoke.rs
+++ b/soroban-env-host/src/e2e_invoke.rs
@@ -27,9 +27,10 @@ use crate::{
     storage::{AccessType, Footprint, FootprintMap, SnapshotSource, Storage, StorageMap},
     xdr::{
         AccountId, ContractDataDurability, ContractEventType, DiagnosticEvent, HostFunction,
-        LedgerEntry, LedgerEntryData, LedgerFootprint, LedgerKey, LedgerKeyAccount,
-        LedgerKeyContractCode, LedgerKeyContractData, LedgerKeyTrustLine, ScErrorCode, ScErrorType,
-        SorobanAuthorizationEntry, SorobanResources, SorobanTransactionDataExt, TtlEntry,
+        LedgerEntry, LedgerEntryData, LedgerEntryType, LedgerFootprint, LedgerKey,
+        LedgerKeyAccount, LedgerKeyContractCode, LedgerKeyContractData, LedgerKeyTrustLine,
+        ScErrorCode, ScErrorType, SorobanAuthorizationEntry, SorobanResources,
+        SorobanTransactionDataExt, TtlEntry,
     },
     DiagnosticLevel, Error, Host, HostError, LedgerInfo, MeteredOrdMap,
 };
@@ -127,6 +128,8 @@ pub struct LedgerEntryLiveUntilChange {
     pub key_hash: Vec<u8>,
     /// Durability of the entry.    
     pub durability: ContractDataDurability,
+    /// Type of the entry.
+    pub entry_type: LedgerEntryType,
     /// Live until ledger of the old entry.
     pub old_live_until_ledger: u32,
     /// Live until ledger of the new entry. Guaranteed to always be greater than
@@ -214,6 +217,7 @@ fn get_ledger_changes(
 
             entry_change.ttl_change = Some(LedgerEntryLiveUntilChange {
                 key_hash,
+                entry_type: key.discriminant(),
                 durability,
                 old_live_until_ledger: 0,
                 new_live_until_ledger: 0,
@@ -346,6 +350,7 @@ pub fn extract_rent_changes(ledger_changes: &[LedgerEntryChange]) -> Vec<LedgerE
                         ttl_change.durability,
                         ContractDataDurability::Persistent
                     ),
+                    is_code_entry: matches!(ttl_change.entry_type, LedgerEntryType::ContractCode),
                     old_size_bytes: entry_change.old_entry_size_bytes_for_rent,
                     new_size_bytes: new_size_bytes_for_rent,
                     old_live_until_ledger: ttl_change.old_live_until_ledger,

--- a/soroban-env-host/src/fees.rs
+++ b/soroban-env-host/src/fees.rs
@@ -16,6 +16,8 @@ pub const DATA_SIZE_1KB_INCREMENT: i64 = 1024;
 // minimum effective write fee per 1KB
 pub const MINIMUM_RENT_WRITE_FEE_PER_1KB: i64 = 1000;
 
+pub const CODE_ENTRY_RENT_DISCOUNT_FACTOR: i64 = 2;
+
 /// These are the resource upper bounds specified by the Soroban transaction.
 pub struct TransactionResources {
     /// Number of CPU instructions.
@@ -88,6 +90,8 @@ pub struct RentWriteFeeConfiguration {
 pub struct LedgerEntryRentChange {
     /// Whether this is persistent or temporary entry.
     pub is_persistent: bool,
+    /// Whether this is a contract code entry.
+    pub is_code_entry: bool,
     /// In-memory size of the entry in bytes before it has been modified.
     /// Should be `0` for newly-created entires.
     pub old_size_bytes: u32,
@@ -382,6 +386,9 @@ fn rent_fee_per_entry_change(
             rent_ledgers,
             fee_config,
         ));
+    }
+    if entry_change.is_code_entry {
+        fee /= CODE_ENTRY_RENT_DISCOUNT_FACTOR;
     }
     fee
 }

--- a/soroban-env-host/src/test/e2e_tests.rs
+++ b/soroban-env-host/src/test/e2e_tests.rs
@@ -25,10 +25,11 @@ use crate::{
         ContractExecutable, ContractId, ContractIdPreimage, ContractIdPreimageFromAddress,
         CreateContractArgs, DiagnosticEvent, ExtensionPoint, Hash, HashIdPreimage,
         HashIdPreimageSorobanAuthorization, HostFunction, InvokeContractArgs, LedgerEntry,
-        LedgerEntryData, LedgerFootprint, LedgerKey, LedgerKeyContractCode, LedgerKeyContractData,
-        Limits, ReadXdr, ScAddress, ScContractInstance, ScErrorCode, ScErrorType, ScMap,
-        ScNonceKey, ScVal, ScVec, SorobanAuthorizationEntry, SorobanCredentials, SorobanResources,
-        SorobanResourcesExtV0, SorobanTransactionDataExt, TtlEntry, Uint256, WriteXdr,
+        LedgerEntryData, LedgerEntryType, LedgerFootprint, LedgerKey, LedgerKeyContractCode,
+        LedgerKeyContractData, Limits, ReadXdr, ScAddress, ScContractInstance, ScErrorCode,
+        ScErrorType, ScMap, ScNonceKey, ScVal, ScVec, SorobanAuthorizationEntry,
+        SorobanCredentials, SorobanResources, SorobanResourcesExtV0, SorobanTransactionDataExt,
+        TtlEntry, Uint256, WriteXdr,
     },
     Host, HostError, LedgerInfo,
 };
@@ -191,6 +192,7 @@ impl LedgerEntryChangeHelper {
             ttl_change: if let Some(durability) = durability {
                 Some(LedgerEntryLiveUntilChange {
                     key_hash: compute_key_hash(&ledger_key),
+                    entry_type: entry.data.discriminant(),
                     durability,
                     old_live_until_ledger: live_until_ledger,
                     new_live_until_ledger: live_until_ledger,
@@ -717,6 +719,7 @@ fn test_wasm_upload_success() {
             new_value: Some(wasm_entry(ADD_I32)),
             ttl_change: Some(LedgerEntryLiveUntilChange {
                 key_hash: compute_key_hash(&ledger_key),
+                entry_type: LedgerEntryType::ContractCode,
                 durability: ContractDataDurability::Persistent,
                 old_live_until_ledger: 0,
                 new_live_until_ledger: ledger_info.sequence_number
@@ -785,6 +788,7 @@ fn test_wasm_upload_success_in_recording_mode() {
             new_value: Some(wasm_entry(ADD_I32)),
             ttl_change: Some(LedgerEntryLiveUntilChange {
                 key_hash: compute_key_hash(&ledger_key),
+                entry_type: LedgerEntryType::ContractCode,
                 durability: ContractDataDurability::Persistent,
                 old_live_until_ledger: 0,
                 new_live_until_ledger: ledger_info.sequence_number
@@ -1010,6 +1014,7 @@ fn test_wasm_reupload_is_no_op() {
             new_value: Some(wasm_entry(ADD_I32)),
             ttl_change: Some(LedgerEntryLiveUntilChange {
                 key_hash: compute_key_hash(&get_wasm_key(ADD_I32)),
+                entry_type: LedgerEntryType::ContractCode,
                 durability: ContractDataDurability::Persistent,
                 old_live_until_ledger: ledger_info.sequence_number,
                 new_live_until_ledger: ledger_info.sequence_number,
@@ -1056,6 +1061,7 @@ fn test_wasm_upload_success_with_extra_footprint_entries() {
                 new_value: Some(wasm_entry(ADD_I32)),
                 ttl_change: Some(LedgerEntryLiveUntilChange {
                     key_hash: compute_key_hash(&get_wasm_key(ADD_I32)),
+                    entry_type: LedgerEntryType::ContractCode,
                     durability: ContractDataDurability::Persistent,
                     old_live_until_ledger: 0,
                     new_live_until_ledger: ledger_info.sequence_number
@@ -1074,6 +1080,7 @@ fn test_wasm_upload_success_with_extra_footprint_entries() {
                 new_value: Some(wasm_entry(LINEAR_MEMORY)),
                 ttl_change: Some(LedgerEntryLiveUntilChange {
                     key_hash: compute_key_hash(&get_wasm_key(LINEAR_MEMORY)),
+                    entry_type: LedgerEntryType::ContractCode,
                     durability: ContractDataDurability::Persistent,
                     old_live_until_ledger: ledger_info.sequence_number + 1000,
                     new_live_until_ledger: ledger_info.sequence_number + 1000,
@@ -1086,6 +1093,7 @@ fn test_wasm_upload_success_with_extra_footprint_entries() {
                 new_value: None,
                 ttl_change: Some(LedgerEntryLiveUntilChange {
                     key_hash: compute_key_hash(&get_wasm_key(CONTRACT_STORAGE)),
+                    entry_type: LedgerEntryType::ContractCode,
                     durability: ContractDataDurability::Persistent,
                     old_live_until_ledger: 0,
                     new_live_until_ledger: 0,
@@ -1134,6 +1142,7 @@ fn test_create_contract_success() {
                 new_value: Some(cd.contract_entry),
                 ttl_change: Some(LedgerEntryLiveUntilChange {
                     key_hash: compute_key_hash(&cd.contract_key),
+                    entry_type: LedgerEntryType::ContractData,
                     durability: ContractDataDurability::Persistent,
                     old_live_until_ledger: 0,
                     new_live_until_ledger: ledger_info.sequence_number
@@ -1218,6 +1227,7 @@ fn test_create_contract_with_no_argument_constructor_success() {
                 )),
                 ttl_change: Some(LedgerEntryLiveUntilChange {
                     key_hash: compute_key_hash(&temp_entry_key),
+                    entry_type: LedgerEntryType::ContractData,
                     durability: ContractDataDurability::Temporary,
                     old_live_until_ledger: 0,
                     new_live_until_ledger: ledger_info.sequence_number
@@ -1237,6 +1247,7 @@ fn test_create_contract_with_no_argument_constructor_success() {
                 )),
                 ttl_change: Some(LedgerEntryLiveUntilChange {
                     key_hash: compute_key_hash(&persistent_entry_key),
+                    entry_type: LedgerEntryType::ContractData,
                     durability: ContractDataDurability::Persistent,
                     old_live_until_ledger: 0,
                     new_live_until_ledger: ledger_info.sequence_number
@@ -1251,6 +1262,7 @@ fn test_create_contract_with_no_argument_constructor_success() {
                 new_value: Some(expected_contract_entry),
                 ttl_change: Some(LedgerEntryLiveUntilChange {
                     key_hash: compute_key_hash(&cd.contract_key),
+                    entry_type: LedgerEntryType::ContractData,
                     durability: ContractDataDurability::Persistent,
                     old_live_until_ledger: 0,
                     new_live_until_ledger: ledger_info.sequence_number
@@ -1301,6 +1313,7 @@ fn test_create_contract_success_in_recording_mode() {
                 new_value: Some(cd.contract_entry),
                 ttl_change: Some(LedgerEntryLiveUntilChange {
                     key_hash: compute_key_hash(&cd.contract_key),
+                    entry_type: LedgerEntryType::ContractData,
                     durability: ContractDataDurability::Persistent,
                     old_live_until_ledger: 0,
                     new_live_until_ledger: ledger_info.sequence_number
@@ -1406,6 +1419,7 @@ fn test_create_contract_success_in_recording_mode_with_custom_account() {
                 new_value: Some(cd.contract_entry),
                 ttl_change: Some(LedgerEntryLiveUntilChange {
                     key_hash: compute_key_hash(&cd.contract_key),
+                    entry_type: LedgerEntryType::ContractData,
                     durability: ContractDataDurability::Persistent,
                     old_live_until_ledger: 0,
                     new_live_until_ledger: ledger_info.sequence_number
@@ -1432,6 +1446,7 @@ fn test_create_contract_success_in_recording_mode_with_custom_account() {
                 ))),
                 ttl_change: Some(LedgerEntryLiveUntilChange {
                     key_hash: compute_key_hash(&nonce_entry_key),
+                    entry_type: LedgerEntryType::ContractData,
                     durability: ContractDataDurability::Temporary,
                     old_live_until_ledger: 0,
                     new_live_until_ledger: ledger_info.sequence_number + ledger_info.max_entry_ttl
@@ -1503,6 +1518,7 @@ fn test_create_contract_success_in_recording_mode_with_enforced_auth() {
                 new_value: Some(cd.contract_entry),
                 ttl_change: Some(LedgerEntryLiveUntilChange {
                     key_hash: compute_key_hash(&cd.contract_key),
+                    entry_type: LedgerEntryType::ContractData,
                     durability: ContractDataDurability::Persistent,
                     old_live_until_ledger: 0,
                     new_live_until_ledger: ledger_info.sequence_number
@@ -1596,6 +1612,7 @@ fn test_create_contract_success_with_extra_footprint_entries() {
                 new_value: Some(cd.contract_entry),
                 ttl_change: Some(LedgerEntryLiveUntilChange {
                     key_hash: compute_key_hash(&cd.contract_key),
+                    entry_type: LedgerEntryType::ContractData,
                     durability: ContractDataDurability::Persistent,
                     old_live_until_ledger: 0,
                     new_live_until_ledger: ledger_info.sequence_number
@@ -1610,6 +1627,7 @@ fn test_create_contract_success_with_extra_footprint_entries() {
                 new_value: None,
                 ttl_change: Some(LedgerEntryLiveUntilChange {
                     key_hash: compute_key_hash(&cd2.contract_key),
+                    entry_type: LedgerEntryType::ContractData,
                     durability: ContractDataDurability::Persistent,
                     old_live_until_ledger: 0,
                     new_live_until_ledger: 0,
@@ -1803,6 +1821,7 @@ fn test_invoke_contract_with_storage_ops_success() {
                 new_value: Some(new_entry.clone()),
                 ttl_change: Some(LedgerEntryLiveUntilChange {
                     key_hash: compute_key_hash(&data_key),
+                    entry_type: LedgerEntryType::ContractData,
                     durability: ContractDataDurability::Temporary,
                     old_live_until_ledger: 0,
                     new_live_until_ledger: ledger_info.sequence_number
@@ -1862,6 +1881,7 @@ fn test_invoke_contract_with_storage_ops_success() {
                 new_value: None,
                 ttl_change: Some(LedgerEntryLiveUntilChange {
                     key_hash: compute_key_hash(&data_key),
+                    entry_type: LedgerEntryType::ContractData,
                     durability: ContractDataDurability::Temporary,
                     old_live_until_ledger: ledger_info.sequence_number + 500,
                     new_live_until_ledger: ledger_info.sequence_number + 5000,
@@ -1937,6 +1957,7 @@ fn test_invoke_contract_with_storage_ops_success_in_recording_mode() {
                 new_value: Some(new_entry.clone()),
                 ttl_change: Some(LedgerEntryLiveUntilChange {
                     key_hash: compute_key_hash(&data_key),
+                    entry_type: LedgerEntryType::ContractData,
                     durability: ContractDataDurability::Temporary,
                     old_live_until_ledger: 0,
                     new_live_until_ledger: ledger_info.sequence_number
@@ -2004,6 +2025,7 @@ fn test_invoke_contract_with_storage_ops_success_in_recording_mode() {
                 new_value: None,
                 ttl_change: Some(LedgerEntryLiveUntilChange {
                     key_hash: compute_key_hash(&data_key),
+                    entry_type: LedgerEntryType::ContractData,
                     durability: ContractDataDurability::Temporary,
                     old_live_until_ledger: ledger_info.sequence_number + 500,
                     new_live_until_ledger: ledger_info.sequence_number + 5000,
@@ -2073,6 +2095,7 @@ fn test_create_contract_success_with_autorestore() {
                 new_value: Some(cd.contract_entry),
                 ttl_change: Some(LedgerEntryLiveUntilChange {
                     key_hash: compute_key_hash(&cd.contract_key),
+                    entry_type: LedgerEntryType::ContractData,
                     durability: ContractDataDurability::Persistent,
                     old_live_until_ledger: 0,
                     new_live_until_ledger: ledger_info.sequence_number
@@ -2087,6 +2110,7 @@ fn test_create_contract_success_with_autorestore() {
                 new_value: Some(cd.wasm_entry),
                 ttl_change: Some(LedgerEntryLiveUntilChange {
                     key_hash: compute_key_hash(&cd.wasm_key),
+                    entry_type: LedgerEntryType::ContractCode,
                     durability: ContractDataDurability::Persistent,
                     old_live_until_ledger: 0,
                     new_live_until_ledger: ledger_info.sequence_number
@@ -2169,6 +2193,7 @@ fn test_invoke_contract_with_storage_extension_and_autorestore() {
         new_value: Some(cd.contract_entry.clone()),
         ttl_change: Some(LedgerEntryLiveUntilChange {
             key_hash: compute_key_hash(&cd.contract_key),
+            entry_type: LedgerEntryType::ContractData,
             durability: ContractDataDurability::Persistent,
             old_live_until_ledger: 0,
             new_live_until_ledger: ledger_info.sequence_number
@@ -2183,6 +2208,7 @@ fn test_invoke_contract_with_storage_extension_and_autorestore() {
         new_value: Some(data_entry.clone()),
         ttl_change: Some(LedgerEntryLiveUntilChange {
             key_hash: compute_key_hash(&data_key),
+            entry_type: LedgerEntryType::ContractData,
             durability: ContractDataDurability::Persistent,
             old_live_until_ledger: 0,
             new_live_until_ledger: ledger_info.sequence_number + ttl_extension,
@@ -2267,6 +2293,7 @@ fn test_auto_restore_with_extension_in_recording_mode() {
                 new_value: Some(persistent_data_entry.clone()),
                 ttl_change: Some(LedgerEntryLiveUntilChange {
                     key_hash: compute_key_hash(&data_key),
+                    entry_type: LedgerEntryType::ContractData,
                     durability: ContractDataDurability::Persistent,
                     old_live_until_ledger: 0,
                     new_live_until_ledger: ledger_info.sequence_number
@@ -2280,6 +2307,7 @@ fn test_auto_restore_with_extension_in_recording_mode() {
                 new_value: Some(cd.contract_entry.clone()),
                 ttl_change: Some(LedgerEntryLiveUntilChange {
                     key_hash: compute_key_hash(&cd.contract_key),
+                    entry_type: LedgerEntryType::ContractData,
                     durability: ContractDataDurability::Persistent,
                     old_live_until_ledger: 0,
                     new_live_until_ledger: ledger_info.sequence_number
@@ -2294,6 +2322,7 @@ fn test_auto_restore_with_extension_in_recording_mode() {
                 new_value: Some(cd.wasm_entry.clone()),
                 ttl_change: Some(LedgerEntryLiveUntilChange {
                     key_hash: compute_key_hash(&cd.wasm_key),
+                    entry_type: LedgerEntryType::ContractCode,
                     durability: ContractDataDurability::Persistent,
                     old_live_until_ledger: 0,
                     new_live_until_ledger: ledger_info.sequence_number
@@ -2405,6 +2434,7 @@ fn test_auto_restore_with_overwrite_in_recording_mode() {
                 new_value: Some(new_persistent_data_entry.clone()),
                 ttl_change: Some(LedgerEntryLiveUntilChange {
                     key_hash: compute_key_hash(&data_key),
+                    entry_type: LedgerEntryType::ContractData,
                     durability: ContractDataDurability::Persistent,
                     old_live_until_ledger: 0,
                     new_live_until_ledger: ledger_info.sequence_number
@@ -2419,6 +2449,7 @@ fn test_auto_restore_with_overwrite_in_recording_mode() {
                 new_value: Some(cd.contract_entry.clone()),
                 ttl_change: Some(LedgerEntryLiveUntilChange {
                     key_hash: compute_key_hash(&cd.contract_key),
+                    entry_type: LedgerEntryType::ContractData,
                     durability: ContractDataDurability::Persistent,
                     old_live_until_ledger: 0,
                     new_live_until_ledger: ledger_info.sequence_number
@@ -2516,6 +2547,7 @@ fn test_auto_restore_with_expired_temp_entry_in_recording_mode() {
                 new_value: None,
                 ttl_change: Some(LedgerEntryLiveUntilChange {
                     key_hash: compute_key_hash(&data_key),
+                    entry_type: LedgerEntryType::ContractData,
                     durability: ContractDataDurability::Temporary,
                     old_live_until_ledger: 0,
                     new_live_until_ledger: 0,
@@ -2528,6 +2560,7 @@ fn test_auto_restore_with_expired_temp_entry_in_recording_mode() {
                 new_value: Some(cd.contract_entry.clone()),
                 ttl_change: Some(LedgerEntryLiveUntilChange {
                     key_hash: compute_key_hash(&cd.contract_key),
+                    entry_type: LedgerEntryType::ContractData,
                     durability: ContractDataDurability::Persistent,
                     old_live_until_ledger: 0,
                     new_live_until_ledger: ledger_info.sequence_number
@@ -2542,6 +2575,7 @@ fn test_auto_restore_with_expired_temp_entry_in_recording_mode() {
                 new_value: Some(cd.wasm_entry.clone()),
                 ttl_change: Some(LedgerEntryLiveUntilChange {
                     key_hash: compute_key_hash(&cd.wasm_key),
+                    entry_type: LedgerEntryType::ContractCode,
                     durability: ContractDataDurability::Persistent,
                     old_live_until_ledger: 0,
                     new_live_until_ledger: ledger_info.sequence_number
@@ -2644,6 +2678,7 @@ fn test_auto_restore_with_recreated_temp_entry_in_recording_mode() {
                 new_value: Some(updated_temp_data_entry),
                 ttl_change: Some(LedgerEntryLiveUntilChange {
                     key_hash: compute_key_hash(&data_key),
+                    entry_type: LedgerEntryType::ContractData,
                     durability: ContractDataDurability::Temporary,
                     old_live_until_ledger: 0,
                     new_live_until_ledger: ledger_info.sequence_number
@@ -2662,6 +2697,7 @@ fn test_auto_restore_with_recreated_temp_entry_in_recording_mode() {
                 new_value: Some(cd.wasm_entry.clone()),
                 ttl_change: Some(LedgerEntryLiveUntilChange {
                     key_hash: compute_key_hash(&cd.wasm_key),
+                    entry_type: LedgerEntryType::ContractCode,
                     durability: ContractDataDurability::Persistent,
                     old_live_until_ledger: 0,
                     new_live_until_ledger: ledger_info.sequence_number

--- a/soroban-env-host/tests/fees.rs
+++ b/soroban-env-host/tests/fees.rs
@@ -453,6 +453,7 @@ fn test_rent_extend_fees_with_only_extend() {
         compute_rent_fee(
             &[LedgerEntryRentChange {
                 is_persistent: true,
+                is_code_entry: false,
                 old_size_bytes: 1,
                 new_size_bytes: 1,
                 old_live_until_ledger: 100_000,
@@ -472,6 +473,7 @@ fn test_rent_extend_fees_with_only_extend() {
         compute_rent_fee(
             &[LedgerEntryRentChange {
                 is_persistent: true,
+                is_code_entry: false,
                 old_size_bytes: 10 * 1024,
                 new_size_bytes: 10 * 1024,
                 old_live_until_ledger: 100_000,
@@ -490,6 +492,7 @@ fn test_rent_extend_fees_with_only_extend() {
         compute_rent_fee(
             &[LedgerEntryRentChange {
                 is_persistent: true,
+                is_code_entry: false,
                 old_size_bytes: 1,
                 new_size_bytes: 1,
                 old_live_until_ledger: 100_000,
@@ -508,6 +511,7 @@ fn test_rent_extend_fees_with_only_extend() {
         compute_rent_fee(
             &[LedgerEntryRentChange {
                 is_persistent: true,
+                is_code_entry: false,
                 old_size_bytes: 10 * 1024,
                 new_size_bytes: 10 * 1024,
                 old_live_until_ledger: 100_000,
@@ -526,6 +530,7 @@ fn test_rent_extend_fees_with_only_extend() {
         compute_rent_fee(
             &[LedgerEntryRentChange {
                 is_persistent: true,
+                is_code_entry: false,
                 old_size_bytes: 10 * 1024,
                 new_size_bytes: 5 * 1024,
                 old_live_until_ledger: 100_000,
@@ -544,6 +549,7 @@ fn test_rent_extend_fees_with_only_extend() {
         compute_rent_fee(
             &[LedgerEntryRentChange {
                 is_persistent: false,
+                is_code_entry: false,
                 old_size_bytes: 10 * 1024,
                 new_size_bytes: 10 * 1024,
                 old_live_until_ledger: 100_000,
@@ -563,6 +569,7 @@ fn test_rent_extend_fees_with_only_extend() {
             &[
                 LedgerEntryRentChange {
                     is_persistent: false,
+                    is_code_entry: false,
                     old_size_bytes: 10 * 1024,
                     new_size_bytes: 10 * 1024,
                     old_live_until_ledger: 100_000,
@@ -570,6 +577,7 @@ fn test_rent_extend_fees_with_only_extend() {
                 },
                 LedgerEntryRentChange {
                     is_persistent: true,
+                    is_code_entry: false,
                     old_size_bytes: 10 * 1024,
                     new_size_bytes: 10 * 1024,
                     old_live_until_ledger: 100_000,
@@ -577,6 +585,7 @@ fn test_rent_extend_fees_with_only_extend() {
                 },
                 LedgerEntryRentChange {
                     is_persistent: true,
+                    is_code_entry: false,
                     old_size_bytes: 1,
                     new_size_bytes: 1,
                     old_live_until_ledger: 100_000,
@@ -584,6 +593,7 @@ fn test_rent_extend_fees_with_only_extend() {
                 },
                 LedgerEntryRentChange {
                     is_persistent: true,
+                    is_code_entry: false,
                     old_size_bytes: 1,
                     new_size_bytes: 1,
                     old_live_until_ledger: 100_000,
@@ -591,6 +601,7 @@ fn test_rent_extend_fees_with_only_extend() {
                 },
                 LedgerEntryRentChange {
                     is_persistent: true,
+                    is_code_entry: false,
                     old_size_bytes: 10 * 1024,
                     new_size_bytes: 10 * 1024,
                     old_live_until_ledger: 100_000,
@@ -598,6 +609,7 @@ fn test_rent_extend_fees_with_only_extend() {
                 },
                 LedgerEntryRentChange {
                     is_persistent: false,
+                    is_code_entry: false,
                     old_size_bytes: 10 * 1024,
                     new_size_bytes: 10 * 1024,
                     old_live_until_ledger: 100_000,
@@ -629,6 +641,7 @@ fn test_rent_extend_fees_with_only_size_change() {
         compute_rent_fee(
             &[LedgerEntryRentChange {
                 is_persistent: true,
+                is_code_entry: false,
                 old_size_bytes: 1,
                 new_size_bytes: 100_000,
                 old_live_until_ledger: 100_000,
@@ -646,6 +659,7 @@ fn test_rent_extend_fees_with_only_size_change() {
         compute_rent_fee(
             &[LedgerEntryRentChange {
                 is_persistent: false,
+                is_code_entry: false,
                 old_size_bytes: 1,
                 new_size_bytes: 100_000,
                 old_live_until_ledger: 100_000,
@@ -663,6 +677,7 @@ fn test_rent_extend_fees_with_only_size_change() {
         compute_rent_fee(
             &[LedgerEntryRentChange {
                 is_persistent: true,
+                is_code_entry: false,
                 old_size_bytes: 99_999,
                 new_size_bytes: 100_000,
                 old_live_until_ledger: 100_000,
@@ -680,6 +695,7 @@ fn test_rent_extend_fees_with_only_size_change() {
         compute_rent_fee(
             &[LedgerEntryRentChange {
                 is_persistent: true,
+                is_code_entry: false,
                 old_size_bytes: 1,
                 new_size_bytes: 100_000,
                 old_live_until_ledger: 100_000,
@@ -698,6 +714,7 @@ fn test_rent_extend_fees_with_only_size_change() {
             &[
                 LedgerEntryRentChange {
                     is_persistent: true,
+                    is_code_entry: false,
                     old_size_bytes: 1,
                     new_size_bytes: 100_000,
                     old_live_until_ledger: 100_000,
@@ -705,6 +722,7 @@ fn test_rent_extend_fees_with_only_size_change() {
                 },
                 LedgerEntryRentChange {
                     is_persistent: false,
+                    is_code_entry: false,
                     old_size_bytes: 1,
                     new_size_bytes: 100_000,
                     old_live_until_ledger: 100_000,
@@ -734,6 +752,7 @@ fn test_rent_extend_with_size_change_and_extend() {
         compute_rent_fee(
             &[LedgerEntryRentChange {
                 is_persistent: true,
+                is_code_entry: false,
                 old_size_bytes: 1,
                 new_size_bytes: 100_000,
                 old_live_until_ledger: 100_000,
@@ -753,6 +772,7 @@ fn test_rent_extend_with_size_change_and_extend() {
         compute_rent_fee(
             &[LedgerEntryRentChange {
                 is_persistent: false,
+                is_code_entry: false,
                 old_size_bytes: 1,
                 new_size_bytes: 100_000,
                 old_live_until_ledger: 100_000,
@@ -773,6 +793,7 @@ fn test_rent_extend_with_size_change_and_extend() {
             &[
                 LedgerEntryRentChange {
                     is_persistent: true,
+                    is_code_entry: false,
                     old_size_bytes: 1,
                     new_size_bytes: 100_000,
                     old_live_until_ledger: 100_000,
@@ -780,6 +801,7 @@ fn test_rent_extend_with_size_change_and_extend() {
                 },
                 LedgerEntryRentChange {
                     is_persistent: false,
+                    is_code_entry: false,
                     old_size_bytes: 1,
                     new_size_bytes: 100_000,
                     old_live_until_ledger: 100_000,
@@ -800,6 +822,7 @@ fn test_rent_extend_with_size_change_and_extend() {
         compute_rent_fee(
             &[LedgerEntryRentChange {
                 is_persistent: true,
+                is_code_entry: false,
                 old_size_bytes: 1,
                 new_size_bytes: 2,
                 old_live_until_ledger: 100_000,
@@ -830,6 +853,7 @@ fn test_rent_extend_without_old_entry() {
         compute_rent_fee(
             &[LedgerEntryRentChange {
                 is_persistent: true,
+                is_code_entry: false,
                 old_size_bytes: 0,
                 new_size_bytes: 100_000,
                 old_live_until_ledger: 0,
@@ -848,6 +872,7 @@ fn test_rent_extend_without_old_entry() {
         compute_rent_fee(
             &[LedgerEntryRentChange {
                 is_persistent: false,
+                is_code_entry: false,
                 old_size_bytes: 0,
                 new_size_bytes: 100_000,
                 old_live_until_ledger: 0,

--- a/soroban-simulation/src/resources.rs
+++ b/soroban-simulation/src/resources.rs
@@ -12,11 +12,11 @@ use soroban_env_host::{
     storage::SnapshotSource,
     xdr::{
         BytesM, ContractDataDurability, DecoratedSignature, Duration, Hash, LedgerBounds,
-        LedgerFootprint, LedgerKey, Memo, MuxedAccount, MuxedAccountMed25519, Operation,
-        OperationBody, Preconditions, PreconditionsV2, SequenceNumber, Signature, SignatureHint,
-        SignerKey, SignerKeyEd25519SignedPayload, SorobanResources, SorobanResourcesExtV0,
-        SorobanTransactionData, SorobanTransactionDataExt, TimeBounds, TimePoint, Transaction,
-        TransactionExt, TransactionV1Envelope, Uint256, WriteXdr,
+        LedgerEntryType, LedgerFootprint, LedgerKey, Memo, MuxedAccount, MuxedAccountMed25519,
+        Operation, OperationBody, Preconditions, PreconditionsV2, SequenceNumber, Signature,
+        SignatureHint, SignerKey, SignerKeyEd25519SignedPayload, SorobanResources,
+        SorobanResourcesExtV0, SorobanTransactionData, SorobanTransactionDataExt, TimeBounds,
+        TimePoint, Transaction, TransactionExt, TransactionV1Envelope, Uint256, WriteXdr,
     },
     LedgerInfo, DEFAULT_XDR_RW_LIMITS,
 };
@@ -158,6 +158,7 @@ pub(crate) fn simulate_extend_ttl_op_resources(
         let entry_size: u32 = entry_size_for_rent(&budget, &entry, entry_xdr_size)?;
         rent_changes.push(LedgerEntryRentChange {
             is_persistent: durability == ContractDataDurability::Persistent,
+            is_code_entry: matches!(key.discriminant(), LedgerEntryType::ContractCode),
             old_size_bytes: entry_size,
             new_size_bytes: entry_size,
             old_live_until_ledger: current_live_until_ledger,
@@ -218,6 +219,7 @@ pub(crate) fn simulate_restore_op_resources(
         restored_bytes = restored_bytes.saturating_add(entry_xdr_size);
         rent_changes.push(LedgerEntryRentChange {
             is_persistent: true,
+            is_code_entry: matches!(key.discriminant(), LedgerEntryType::ContractCode),
             old_size_bytes: 0,
             new_size_bytes: entry_rent_size,
             old_live_until_ledger: 0,

--- a/soroban-simulation/src/test/simulation.rs
+++ b/soroban-simulation/src/test/simulation.rs
@@ -146,7 +146,7 @@ fn test_simulate_upload_wasm() {
                 disk_read_bytes: 0,
                 write_bytes: expected_write_bytes,
             },
-            resource_fee: 14073265,
+            resource_fee: 7037718,
         })
     );
     assert_eq!(res.simulated_instructions, expected_instructions);
@@ -200,7 +200,7 @@ fn test_simulate_upload_wasm() {
                 disk_read_bytes: 0,
                 write_bytes: expected_write_bytes + 300,
             },
-            resource_fee: 21109151,
+            resource_fee: 10555830,
         })
     );
 }
@@ -589,7 +589,7 @@ fn test_simulate_invoke_contract_with_autorestore() {
                 disk_read_bytes: wasm_entry_size + contract_1_size,
                 write_bytes: wasm_entry_size + contract_1_size,
             },
-            resource_fee: 17966912,
+            resource_fee: 8994109,
         })
     );
     assert_eq!(res.simulated_instructions, expected_instructions);
@@ -704,7 +704,7 @@ fn test_simulate_extend_ttl_op() {
                     disk_read_bytes: 0,
                     write_bytes: 0,
                 },
-                resource_fee: 17929120,
+                resource_fee: 8965129,
             }
         }
     );
@@ -732,7 +732,7 @@ fn test_simulate_extend_ttl_op() {
                     disk_read_bytes: 0,
                     write_bytes: 0,
                 },
-                resource_fee: 306142974,
+                resource_fee: 153103833,
             }
         }
     );
@@ -777,7 +777,7 @@ fn test_simulate_extend_ttl_op() {
                     disk_read_bytes: 0,
                     write_bytes: 0,
                 },
-                resource_fee: 459214436,
+                resource_fee: 229655724,
             }
         }
     );
@@ -878,7 +878,7 @@ fn test_simulate_restore_op() {
                     disk_read_bytes: expected_rw_bytes,
                     write_bytes: expected_rw_bytes,
                 },
-                resource_fee: 32017829,
+                resource_fee: 16009479,
             }
         }
     );
@@ -907,7 +907,7 @@ fn test_simulate_restore_op() {
                     disk_read_bytes: expected_rw_bytes,
                     write_bytes: expected_rw_bytes,
                 },
-                resource_fee: 32615677,
+                resource_fee: 16313577,
             }
         }
     );
@@ -935,7 +935,7 @@ fn test_simulate_restore_op() {
                     disk_read_bytes: (expected_rw_bytes as f64 * 1.2) as u32,
                     write_bytes: (expected_rw_bytes as f64 * 1.3) as u32,
                 },
-                resource_fee: 48923232,
+                resource_fee: 24470082,
             }
         }
     );


### PR DESCRIPTION
### What

Discount code entry rent by 50%.

That's an experimental change for p23 rent.

### Why

The idea is to reduce the effective rent cost for the code entries, as they have in-memory size metered for rent now (instead of just the Wasm size)

### Known limitations

N/A