### PR TITLE
Stop adding write entry count to disk read entry count

### DIFF
--- a/soroban-env-host/src/fees.rs
+++ b/soroban-env-host/src/fees.rs
@@ -147,12 +147,9 @@ pub fn compute_transaction_resource_fee(
         fee_config.fee_per_instruction_increment,
         INSTRUCTIONS_INCREMENT,
     );
-    let ledger_read_entry_fee: i64 = fee_config.fee_per_disk_read_entry.saturating_mul(
-        tx_resources
-            .disk_read_entries
-            .saturating_add(tx_resources.write_entries)
-            .into(),
-    );
+    let ledger_read_entry_fee: i64 = fee_config
+        .fee_per_disk_read_entry
+        .saturating_mul(tx_resources.disk_read_entries.into());
     let ledger_write_entry_fee = fee_config
         .fee_per_write_entry
         .saturating_mul(tx_resources.write_entries.into());

--- a/soroban-env-host/tests/fees.rs
+++ b/soroban-env-host/tests/fees.rs
@@ -136,8 +136,8 @@ fn resource_fee_computation_with_single_resource() {
             }),
             &fee_config,
         ),
-        // Write entries are also counted towards the read entry fee.
-        (2000 + 3000 + BASE_HISTORICAL_FEE, 0)
+        // Write entries are not counted towards the read entry fee unless they were on disk.
+        (3000 + BASE_HISTORICAL_FEE, 0)
     );
     assert_eq!(
         compute_transaction_resource_fee(
@@ -146,7 +146,18 @@ fn resource_fee_computation_with_single_resource() {
             }),
             &fee_config,
         ),
-        ((2000 + 3000) * 5 + BASE_HISTORICAL_FEE, 0)
+        (3000 * 5 + BASE_HISTORICAL_FEE, 0)
+    );
+    // Read and Write entries
+    assert_eq!(
+        compute_transaction_resource_fee(
+            &change_resource(|res: &mut TransactionResources| {
+                res.write_entries = 1;
+                res.disk_read_entries = 1;
+            }),
+            &fee_config,
+        ),
+        (2000 + 3000 + BASE_HISTORICAL_FEE, 0)
     );
     assert_eq!(
         compute_transaction_resource_fee(
@@ -155,10 +166,7 @@ fn resource_fee_computation_with_single_resource() {
             }),
             &fee_config,
         ),
-        (
-            8_589_934_590_000 + 12_884_901_885_000 + BASE_HISTORICAL_FEE,
-            0
-        )
+        (12_884_901_885_000 + BASE_HISTORICAL_FEE, 0)
     );
 
     // Read bytes
@@ -376,9 +384,9 @@ fn resource_fee_computation() {
                 fee_per_transaction_size_1kb: 100,
             },
         ),
-        // 2 entry read + 1 write + 30 from TX_BASE_RESULT_SIZE + 1 for
+        // 1 entry read + 1 write + 30 from TX_BASE_RESULT_SIZE + 1 for
         // everything else
-        (334, 1)
+        (234, 1)
     );
 
     // Different resource/fee values
@@ -404,7 +412,7 @@ fn resource_fee_computation() {
                 fee_per_transaction_size_1kb: 900,
             },
         ),
-        (1_242_089, 62824)
+        (1_222_089, 62824)
     );
 
     // Integer limits

--- a/soroban-simulation/src/test/simulation.rs
+++ b/soroban-simulation/src/test/simulation.rs
@@ -146,7 +146,7 @@ fn test_simulate_upload_wasm() {
                 disk_read_bytes: 0,
                 write_bytes: expected_write_bytes,
             },
-            resource_fee: 14073265,
+            resource_fee: 14073245,
         })
     );
     assert_eq!(res.simulated_instructions, expected_instructions);
@@ -200,7 +200,7 @@ fn test_simulate_upload_wasm() {
                 disk_read_bytes: 0,
                 write_bytes: expected_write_bytes + 300,
             },
-            resource_fee: 21109151,
+            resource_fee: 21109131,
         })
     );
 }
@@ -328,7 +328,7 @@ fn test_simulate_create_contract() {
                 disk_read_bytes: 0,
                 write_bytes: 104,
             },
-            resource_fee: 13321,
+            resource_fee: 13301,
         })
     );
     assert_eq!(res.simulated_instructions, expected_instructions);
@@ -486,7 +486,7 @@ fn test_simulate_invoke_contract_with_auth() {
                 disk_read_bytes: 144,
                 write_bytes: 76,
             },
-            resource_fee: 115754,
+            resource_fee: 115734,
         })
     );
     assert_eq!(res.simulated_instructions, expected_instructions);
@@ -589,7 +589,7 @@ fn test_simulate_invoke_contract_with_autorestore() {
                 disk_read_bytes: wasm_entry_size + contract_1_size,
                 write_bytes: wasm_entry_size + contract_1_size,
             },
-            resource_fee: 17966912,
+            resource_fee: 17966872,
         })
     );
     assert_eq!(res.simulated_instructions, expected_instructions);
@@ -878,7 +878,7 @@ fn test_simulate_restore_op() {
                     disk_read_bytes: expected_rw_bytes,
                     write_bytes: expected_rw_bytes,
                 },
-                resource_fee: 32017829,
+                resource_fee: 32017789,
             }
         }
     );
@@ -907,7 +907,7 @@ fn test_simulate_restore_op() {
                     disk_read_bytes: expected_rw_bytes,
                     write_bytes: expected_rw_bytes,
                 },
-                resource_fee: 32615677,
+                resource_fee: 32615597,
             }
         }
     );
@@ -935,7 +935,7 @@ fn test_simulate_restore_op() {
                     disk_read_bytes: (expected_rw_bytes as f64 * 1.2) as u32,
                     write_bytes: (expected_rw_bytes as f64 * 1.3) as u32,
                 },
-                resource_fee: 48923232,
+                resource_fee: 48923152,
             }
         }
     );
@@ -1151,7 +1151,7 @@ fn test_simulate_successful_sac_call() {
                 disk_read_bytes: 116,
                 write_bytes: 116,
             },
-            resource_fee: 53007,
+            resource_fee: 52987,
         })
     );
 }

--- a/soroban-simulation/src/test/snapshot_source.rs
+++ b/soroban-simulation/src/test/snapshot_source.rs
@@ -169,7 +169,7 @@ fn test_automatic_restoration() {
                     disk_read_bytes: 112,
                     write_bytes: 112,
                 },
-                resource_fee: 6044,
+                resource_fee: 5044,
             }
         })
     );


### PR DESCRIPTION
disk_read_entries should already be set to `numClassic(readOnly) + numClassic(readWrite) + sizeof(archivedSorobanEntries)` when passed in, so adding readWrite.size() is incorrect.