### PR TITLE
Fix local build targeting `wasm32-unknown-unknown`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test-all-protocols:
 # in soroban_, not the host itself. So we only check the guest package with it.
 build:
 	cargo hack --locked --each-feature clippy
-	cargo --locked clippy --target wasm32-unknown-unknown
+	cargo hack --locked --each-feature clippy --target wasm32-unknown-unknown
 	cargo --locked clippy --package soroban-env-guest --target wasm32v1-none
 
 # We use "run" to run the soroban-env-host/src/bin/main.rs


### PR DESCRIPTION
### What

Fix local builds via `make build`

### Why
The `std` dependency is included in the dependency tree when building the entire workspace with `cargo --locked clippy --target wasm32-unknown-unknown`, which results in the "duplicate `panic_impl`" error on the test_no_std crate.

`cargo hack` builds each package separately and avoids the `std` inclusion when building test_no_std.

### Known limitations

[TODO or N/A]
