### PR TITLE
Support simulating restore with entries with no live until (backport to v22)

### DIFF
--- a/soroban-simulation/src/snapshot_source.rs
+++ b/soroban-simulation/src/snapshot_source.rs
@@ -93,11 +93,7 @@ impl<T: SnapshotSourceWithArchive> SnapshotSource for AutoRestoringSnapshotSourc
         let entry_with_live_until = self.snapshot_source.get_including_archived(key)?;
         if let Some((entry, live_until)) = entry_with_live_until {
             if let Some(durability) = get_key_durability(key.as_ref()) {
-                let live_until = live_until.ok_or_else(|| {
-                    // Entries with durability must have TTL.
-                    HostError::from((ScErrorType::Storage, ScErrorCode::InternalError))
-                })?;
-                if live_until < self.current_ledger_sequence {
+                if live_until < Some(self.current_ledger_sequence) {
                     return match durability {
                         ContractDataDurability::Temporary => Ok(None),
                         ContractDataDurability::Persistent => {

--- a/soroban-simulation/src/test/snapshot_source.rs
+++ b/soroban-simulation/src/test/snapshot_source.rs
@@ -31,6 +31,7 @@ fn test_automatic_restoration() {
                 (temp_entry(b"5"), Some(299)),               // temp, removed
                 (temp_entry(b"6"), Some(300)),               // temp, live
                 (temp_entry(b"7"), Some(400)),               // temp, live
+                (wasm_entry_non_validated(b"8"), None),      // persistent, expired (no live-until)
             ],
             ledger_seq,
         )
@@ -145,6 +146,17 @@ fn test_automatic_restoration() {
             .unwrap(),
         Some((Rc::new(temp_entry(b"7")), Some(400)))
     );
+    assert_eq!(
+        auto_restoring_snapshot
+            .get(&Rc::new(
+                ledger_entry_to_ledger_key(&wasm_entry_non_validated(b"8")).unwrap()
+            ))
+            .unwrap(),
+        Some((
+            Rc::new(wasm_entry_non_validated(b"8")),
+            Some(restored_entry_expiration)
+        ))
+    );
 
     assert_eq!(
         auto_restoring_snapshot
@@ -161,6 +173,7 @@ fn test_automatic_restoration() {
                     footprint: LedgerFootprint {
                         read_only: Default::default(),
                         read_write: vec![
+                            ledger_entry_to_ledger_key(&wasm_entry_non_validated(b"8")).unwrap(),
                             ledger_entry_to_ledger_key(&wasm_entry_non_validated(b"1")).unwrap(),
                             ledger_entry_to_ledger_key(&wasm_entry_non_validated(b"2")).unwrap(),
                         ]
@@ -168,10 +181,10 @@ fn test_automatic_restoration() {
                         .unwrap()
                     },
                     instructions: 0,
-                    read_bytes: 112,
-                    write_bytes: 112,
+                    read_bytes: 168,
+                    write_bytes: 168,
                 },
-                resource_fee: 62192,
+                resource_fee: 92793,
             }
         })
     );


### PR DESCRIPTION
### What
  Support in simulation a restore operation with entries that do not have a live until value.

  ### Why
  Accommodating snapshot sources that no longer track a live until for an archived entry. Stellar-rpc won't provide a live until for archived entries because stellar-core's getledgerentries endpoint also won't provide a live until for archived entries.
  
Related:
- https://github.com/stellar/rs-soroban-env/pull/1565

Unblocks:
- https://github.com/stellar/stellar-rpc/pull/435