### PR TITLE
Pass actual restored entry ids into invoke_host_function.

### DIFF
--- a/soroban-env-host/src/bin/main.rs
+++ b/soroban-env-host/src/bin/main.rs
@@ -14,7 +14,7 @@ fn main() {
     let enable_diagnostics = true;
     let encoded_host_fn = &[0u8];
     let encoded_resources = &[0u8];
-    let encoded_resoures_ext = &[0u8];
+    let restored_rw_entry_ids = &[0u32];
     let encoded_source_account = &[0u8];
     let encoded_auth_entries = [[0u8]].iter();
     let ledger_info = LedgerInfo::default();
@@ -27,7 +27,7 @@ fn main() {
         enable_diagnostics,
         encoded_host_fn,
         encoded_resources,
-        encoded_resoures_ext,
+        restored_rw_entry_ids,
         encoded_source_account,
         encoded_auth_entries,
         ledger_info,

--- a/soroban-env-host/src/e2e_invoke.rs
+++ b/soroban-env-host/src/e2e_invoke.rs
@@ -140,14 +140,14 @@ pub struct LedgerEntryLiveUntilChange {
 fn build_restored_key_set(
     budget: &Budget,
     resources: &SorobanResources,
-    restored_rw_entry_ids: &[u32],
+    restored_rw_entry_indices: &[u32],
 ) -> Result<Option<RestoredKeySet>, HostError> {
-    if restored_rw_entry_ids.is_empty() {
+    if restored_rw_entry_indices.is_empty() {
         return Ok(None);
     }
     let rw_footprint = &resources.footprint.read_write;
     let mut key_set = RestoredKeySet::default();
-    for e in restored_rw_entry_ids {
+    for e in restored_rw_entry_indices {
         key_set = key_set.insert(
             Rc::new(
                 rw_footprint
@@ -395,7 +395,7 @@ pub fn invoke_host_function<T: AsRef<[u8]>, I: ExactSizeIterator<Item = T>>(
     enable_diagnostics: bool,
     encoded_host_fn: T,
     encoded_resources: T,
-    restored_rw_entry_ids: &[u32],
+    restored_rw_entry_indices: &[u32],
     encoded_source_account: T,
     encoded_auth_entries: I,
     ledger_info: LedgerInfo,
@@ -410,7 +410,7 @@ pub fn invoke_host_function<T: AsRef<[u8]>, I: ExactSizeIterator<Item = T>>(
 
     let resources: SorobanResources =
         metered_from_xdr_with_budget(encoded_resources.as_ref(), &budget)?;
-    let restored_keys = build_restored_key_set(&budget, &resources, &restored_rw_entry_ids)?;
+    let restored_keys = build_restored_key_set(&budget, &resources, &restored_rw_entry_indices)?;
     let footprint = build_storage_footprint_from_xdr(&budget, resources.footprint)?;
     let current_ledger_seq = ledger_info.sequence_number;
     let min_live_until_ledger = ledger_info

--- a/soroban-env-host/src/e2e_invoke.rs
+++ b/soroban-env-host/src/e2e_invoke.rs
@@ -8,10 +8,7 @@ use std::{cmp::max, rc::Rc};
 use crate::{
     auth::RecordedAuthPayload,
     storage::is_persistent_key,
-    xdr::{
-        ContractEvent, ReadXdr, ScVal, SorobanAddressCredentials, SorobanCredentials,
-        SorobanResourcesExtV0, WriteXdr,
-    },
+    xdr::{ContractEvent, ReadXdr, ScVal, SorobanAddressCredentials, SorobanCredentials, WriteXdr},
     DEFAULT_XDR_RW_LIMITS,
 };
 use crate::{
@@ -29,7 +26,7 @@ use crate::{
         AccountId, ContractDataDurability, ContractEventType, DiagnosticEvent, HostFunction,
         LedgerEntry, LedgerEntryData, LedgerFootprint, LedgerKey, LedgerKeyAccount,
         LedgerKeyContractCode, LedgerKeyContractData, LedgerKeyTrustLine, ScErrorCode, ScErrorType,
-        SorobanAuthorizationEntry, SorobanResources, SorobanTransactionDataExt, TtlEntry,
+        SorobanAuthorizationEntry, SorobanResources, TtlEntry,
     },
     DiagnosticLevel, Error, Host, HostError, LedgerInfo, MeteredOrdMap,
 };
@@ -143,36 +140,31 @@ pub struct LedgerEntryLiveUntilChange {
 fn build_restored_key_set(
     budget: &Budget,
     resources: &SorobanResources,
-    resource_ext: &SorobanTransactionDataExt,
+    restored_rw_entry_ids: &[u32],
 ) -> Result<Option<RestoredKeySet>, HostError> {
-    match resource_ext {
-        SorobanTransactionDataExt::V0 => Ok(None),
-        SorobanTransactionDataExt::V1(soroban_resources_ext_v0) => {
-            if soroban_resources_ext_v0.archived_soroban_entries.is_empty() {
-                return Ok(None);
-            }
-            let rw_footprint = &resources.footprint.read_write;
-            let mut key_set = RestoredKeySet::default();
-            for e in soroban_resources_ext_v0.archived_soroban_entries.iter() {
-                key_set = key_set.insert(
-                    Rc::new(
-                        rw_footprint
-                            .get(*e as usize)
-                            .ok_or_else(|| {
-                                HostError::from(Error::from_type_and_code(
-                                    ScErrorType::Storage,
-                                    ScErrorCode::InternalError,
-                                ))
-                            })?
-                            .metered_clone(budget)?,
-                    ),
-                    (),
-                    budget,
-                )?;
-            }
-            Ok(Some(key_set))
-        }
+    if restored_rw_entry_ids.is_empty() {
+        return Ok(None);
     }
+    let rw_footprint = &resources.footprint.read_write;
+    let mut key_set = RestoredKeySet::default();
+    for e in restored_rw_entry_ids {
+        key_set = key_set.insert(
+            Rc::new(
+                rw_footprint
+                    .get(*e as usize)
+                    .ok_or_else(|| {
+                        HostError::from(Error::from_type_and_code(
+                            ScErrorType::Storage,
+                            ScErrorCode::InternalError,
+                        ))
+                    })?
+                    .metered_clone(budget)?,
+            ),
+            (),
+            budget,
+        )?;
+    }
+    Ok(Some(key_set))
 }
 
 /// Returns the difference between the `storage` and its initial snapshot as
@@ -403,7 +395,7 @@ pub fn invoke_host_function<T: AsRef<[u8]>, I: ExactSizeIterator<Item = T>>(
     enable_diagnostics: bool,
     encoded_host_fn: T,
     encoded_resources: T,
-    encoded_resources_ext: T,
+    restored_rw_entry_ids: &[u32],
     encoded_source_account: T,
     encoded_auth_entries: I,
     ledger_info: LedgerInfo,
@@ -418,9 +410,7 @@ pub fn invoke_host_function<T: AsRef<[u8]>, I: ExactSizeIterator<Item = T>>(
 
     let resources: SorobanResources =
         metered_from_xdr_with_budget(encoded_resources.as_ref(), &budget)?;
-    let resources_ext: SorobanTransactionDataExt =
-        metered_from_xdr_with_budget(encoded_resources_ext.as_ref(), &budget)?;
-    let restored_keys = build_restored_key_set(&budget, &resources, &resources_ext)?;
+    let restored_keys = build_restored_key_set(&budget, &resources, &restored_rw_entry_ids)?;
     let footprint = build_storage_footprint_from_xdr(&budget, resources.footprint)?;
     let current_ledger_seq = ledger_info.sequence_number;
     let min_live_until_ledger = ledger_info
@@ -802,14 +792,6 @@ pub fn invoke_host_function_in_recording_mode(
     };
     let _resources_roundtrip: SorobanResources =
         host.metered_from_xdr(host.to_xdr_non_metered(&resources)?.as_slice())?;
-    let resources_ext = SorobanTransactionDataExt::V1(SorobanResourcesExtV0 {
-        archived_soroban_entries: restored_rw_entry_ids
-            .clone()
-            .try_into()
-            .map_err(|_| HostError::from((ScErrorType::Context, ScErrorCode::InternalError)))?,
-    });
-    let _resources_ext_roundtrip: SorobanTransactionDataExt =
-        host.metered_from_xdr(host.to_xdr_non_metered(&resources_ext)?.as_slice())?;
     let (storage, events) = host.try_finish()?;
     if enable_diagnostics {
         extract_diagnostic_events(&events, diagnostic_events);

--- a/soroban-simulation/src/test/simulation.rs
+++ b/soroban-simulation/src/test/simulation.rs
@@ -131,7 +131,7 @@ fn test_simulate_upload_wasm() {
     assert!(res.contract_events.is_empty());
     assert!(res.diagnostic_events.is_empty());
 
-    let expected_instructions = 1684151;
+    let expected_instructions = 1676095;
     let expected_write_bytes = 684;
     assert_eq!(
         res.transaction_data,
@@ -146,11 +146,11 @@ fn test_simulate_upload_wasm() {
                 disk_read_bytes: 0,
                 write_bytes: expected_write_bytes,
             },
-            resource_fee: 14073245,
+            resource_fee: 14073237,
         })
     );
     assert_eq!(res.simulated_instructions, expected_instructions);
-    assert_eq!(res.simulated_memory, 842074);
+    assert_eq!(res.simulated_memory, 838046);
     assert_eq!(
         res.modified_entries,
         vec![LedgerEntryDiff {
@@ -200,7 +200,7 @@ fn test_simulate_upload_wasm() {
                 disk_read_bytes: 0,
                 write_bytes: expected_write_bytes + 300,
             },
-            resource_fee: 21109131,
+            resource_fee: 21109122,
         })
     );
 }
@@ -268,8 +268,8 @@ fn test_simulation_returns_logic_error() {
     assert!(!res.diagnostic_events.is_empty());
 
     assert_eq!(res.transaction_data, None);
-    assert_eq!(res.simulated_instructions, 162624);
-    assert_eq!(res.simulated_memory, 81312);
+    assert_eq!(res.simulated_instructions, 154568);
+    assert_eq!(res.simulated_memory, 77284);
     assert_eq!(res.modified_entries, vec![]);
 }
 
@@ -314,7 +314,7 @@ fn test_simulate_create_contract() {
     );
     assert!(res.contract_events.is_empty());
     assert!(res.diagnostic_events.is_empty());
-    let expected_instructions = 2747746;
+    let expected_instructions = 2739690;
     assert_eq!(
         res.transaction_data,
         Some(SorobanTransactionData {
@@ -328,11 +328,11 @@ fn test_simulate_create_contract() {
                 disk_read_bytes: 0,
                 write_bytes: 104,
             },
-            resource_fee: 13301,
+            resource_fee: 13293,
         })
     );
     assert_eq!(res.simulated_instructions, expected_instructions);
-    assert_eq!(res.simulated_memory, 1373871);
+    assert_eq!(res.simulated_memory, 1369843);
     assert_eq!(
         res.modified_entries,
         vec![LedgerEntryDiff {
@@ -457,7 +457,7 @@ fn test_simulate_invoke_contract_with_auth() {
     assert!(res.contract_events.is_empty());
     assert!(!res.diagnostic_events.is_empty());
 
-    let expected_instructions = 40790869;
+    let expected_instructions = 40782813;
     assert_eq!(
         res.transaction_data,
         Some(SorobanTransactionData {
@@ -486,11 +486,11 @@ fn test_simulate_invoke_contract_with_auth() {
                 disk_read_bytes: 144,
                 write_bytes: 76,
             },
-            resource_fee: 115734,
+            resource_fee: 115726,
         })
     );
     assert_eq!(res.simulated_instructions, expected_instructions);
-    assert_eq!(res.simulated_memory, 20395408);
+    assert_eq!(res.simulated_memory, 20391380);
     assert_eq!(
         res.modified_entries,
         vec![LedgerEntryDiff {
@@ -557,7 +557,7 @@ fn test_simulate_invoke_contract_with_autorestore() {
     assert!(res.contract_events.is_empty());
     assert!(!res.diagnostic_events.is_empty());
 
-    let expected_instructions = 9944232;
+    let expected_instructions = 9936120;
     let wasm_entry_size = contracts[0]
         .wasm_entry
         .to_xdr(Limits::none())
@@ -589,11 +589,11 @@ fn test_simulate_invoke_contract_with_autorestore() {
                 disk_read_bytes: wasm_entry_size + contract_1_size,
                 write_bytes: wasm_entry_size + contract_1_size,
             },
-            resource_fee: 17966872,
+            resource_fee: 17966864,
         })
     );
     assert_eq!(res.simulated_instructions, expected_instructions);
-    assert_eq!(res.simulated_memory, 4972109);
+    assert_eq!(res.simulated_memory, 4968053);
     assert_eq!(
         res.modified_entries,
         vec![
@@ -1147,11 +1147,11 @@ fn test_simulate_successful_sac_call() {
                         .try_into()
                         .unwrap()
                 },
-                instructions: 3451359,
+                instructions: 3443303,
                 disk_read_bytes: 116,
                 write_bytes: 116,
             },
-            resource_fee: 52987,
+            resource_fee: 52979,
         })
     );
 }
@@ -1247,11 +1247,11 @@ fn test_simulate_unsuccessful_sac_call_with_try_call() {
                     // No entries should be actually modified.
                     read_write: Default::default(),
                 },
-                instructions: 5572823,
+                instructions: 5564767,
                 disk_read_bytes: 0,
                 write_bytes: 0,
             },
-            resource_fee: 5921,
+            resource_fee: 5913,
         })
     );
 }


### PR DESCRIPTION
### What

Pass actual restored entry ids into invoke_host_function.

Previously we've passed the full resource extension into it, which might result in treating an already restored entry as being restored again (and charging the respective rent fee for it).

### Why

Bug fix.

### Known limitations

N/A
