### PR TITLE
Turn on debug=true for release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ rev = "0ed3f3dee30dc41ebe21972399e0a73a41944aa0"
 
 [profile.release]
 lto = true
+debug = true
 
 [profile.test-opt]
 inherits = "test"


### PR DESCRIPTION
This just adds `debug=true` to the release profile. I am not 100% sure we want to do this, but I think we probably do.

The default build of stellar-core is already opt-with-debug and this is typically what both devs and I think even ops folks want: the ability to run at full speed but also place breakpoints in a few places and get a not-terrible backtrace in a pinch.

So this change just sets soroban's default to the same, such that when stellar-core builds a soroban submodule with release profile, it gets the same opt-with-debug experience.

For a full non-opt-with-debug build, the `dev` profile already works and will continue to work. This is just related to the release profile.

The counterargument to landing this might be like "we want the release binary to be small" or "we want it to build fast". In terms of size, you can still strip it. In terms of build speed it will be slower (especially to link) but I think not catastrophically so.