### PR TITLE
Bump TRACE_STATE_SHADOW_*_LIMIT_FACTORs by 10x to avoid exhaustion

### DIFF
--- a/soroban-env-host/src/host/trace.rs
+++ b/soroban-env-host/src/host/trace.rs
@@ -17,8 +17,8 @@ mod fmt;
 // than normal; not so high that it will run forever but high enough that we can manage
 // to actually record the quantity of detail that tracing records (eg. hashing everything
 // in the host on every host function call and return!).
-const TRACE_STATE_SHADOW_CPU_LIMIT_FACTOR: u64 = 500;
-const TRACE_STATE_SHADOW_MEM_LIMIT_FACTOR: u64 = 30;
+const TRACE_STATE_SHADOW_CPU_LIMIT_FACTOR: u64 = 5000;
+const TRACE_STATE_SHADOW_MEM_LIMIT_FACTOR: u64 = 300;
 
 pub type TraceHook = Rc<dyn for<'a> Fn(&'a Host, TraceEvent<'a>) -> Result<(), HostError>>;
 


### PR DESCRIPTION
Part of https://github.com/stellar/rs-soroban-env/issues/1578 -- diagnostic events were being eaten in trace mode due to exhaustion of shadow budget.