### PR TITLE
Improve the error message for bad invoker auth.

### DIFF
--- a/soroban-env-host/src/auth.rs
+++ b/soroban-env-host/src/auth.rs
@@ -1092,7 +1092,7 @@ impl AuthorizationManager {
                     ScErrorType::Auth,
                     ScErrorCode::InvalidAction,
                     "[recording authorization only] encountered unauthorized call for a \
-                    contract higher up in the call stack, make sure that you have called \
+                    contract earlier in the call stack, make sure that you have called \
                     `authorize_as_current_contract()` with the appropriate arguments for it.",
                     &[address.into()],
                 ));


### PR DESCRIPTION
### What

Improve the error message for bad invoker auth.

### Why

Frequently the users would forget about authorize_as_current_contract for non-direct invokers, or have incorrect arguments. When non-root auth is disabled (which is the default), this ends up with the blanket 'non-root auth' error, which is confusing and makes it appear as if the invoker contract should be made into custom account and have `require_auth` called for it at the top level. With this change we will return a different error if the contract is a non-direct invoker.

Note, that in the scenario where non-root auth is allowed, we will record a detached auth entry for the offending contract. This is expected and we can't do much about that - since the mode is meant for the advanced users, the hope is that they will notice the unexpected extra payload during testing.

### Known limitations

N/A