### PR TITLE
Fix the restored_rw_ids indexing in recording mode.

### DIFF
--- a/soroban-env-host/src/e2e_invoke.rs
+++ b/soroban-env-host/src/e2e_invoke.rs
@@ -766,9 +766,9 @@ pub fn invoke_host_function_in_recording_mode(
                     } else {
                         encoded_ttl_entries.push(vec![]);
                     }
-                    if matches!(*access_type, AccessType::ReadWrite) {
-                        current_rw_id += 1;
-                    }
+                }
+                if matches!(*access_type, AccessType::ReadWrite) {
+                    current_rw_id += 1;
                 }
             }
             let (init_storage, init_ttl_map) = build_storage_map_from_xdr_ledger_entries(


### PR DESCRIPTION
### What

Fix the restored_rw_ids indexing in recording mode.

This incorrectly increased the counter only for the existent entries. Unfortunately, this hasn't been caught by any tests before because no tests created new entries in combination with autorestore.

### Why

Simulation fix.

### Known limitations

N/A
