### PR TITLE
Disable tracing for the code executed in debug mode.

### DIFF
--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -145,6 +145,10 @@ struct HostImpl {
     // interface, it exists strictly for internal testing of the host.
     #[doc(hidden)]
     trace_hook: RefCell<Option<TraceHook>>,
+    // A flag for temporarily disabling tracing. This is used to avoid tracing
+    // calls in debug mode.
+    #[doc(hidden)]
+    disable_tracing: RefCell<bool>,
     // Store a simple contract invocation hook for public usage.
     // The hook triggers when the top-level contract invocation
     // starts and when it ends.
@@ -368,6 +372,7 @@ impl Host {
             #[cfg(any(test, feature = "testutils"))]
             previous_authorization_manager: RefCell::new(None),
             trace_hook: RefCell::new(None),
+            disable_tracing: RefCell::new(false),
             #[cfg(any(test, feature = "testutils"))]
             top_contract_invocation_hook: RefCell::new(None),
             #[cfg(any(test, feature = "testutils"))]
@@ -656,15 +661,51 @@ impl Host {
     /// debug-level _only_ flows into other functions that are themselves
     /// debug-mode-guarded and/or only write results into debug state (eg.
     /// diagnostic events).
-    pub(crate) fn with_debug_mode<F>(&self, f: F)
+    /// When `allow_new_objects` flag is `false` the tests will assert that no
+    /// new objects have been created. This should be the default behavior for
+    /// most of the use cases of `with_debug_mode`, which is why it's the
+    /// default setting. The callers that do need to create new objects should
+    /// set this to `true` and should also have a justification for why it's
+    /// safe (usually because we're in the error code path).
+    pub(crate) fn with_debug_mode_allowing_new_objects<F>(&self, f: F, _allow_new_objects: bool)
     where
         F: FnOnce() -> Result<(), HostError>,
     {
         if let Ok(cell) = self.0.diagnostic_level.try_borrow_or_err() {
             if matches!(*cell, DiagnosticLevel::Debug) {
-                return self.budget_ref().with_shadow_mode(f);
+                // Temporarily disable tracing as debug mode operations are
+                // meant to be not observable and thus make no sense to snapshot
+                // for traces.
+                if let Ok(mut disable_tracing) = self.0.disable_tracing.try_borrow_mut() {
+                    *disable_tracing = true;
+                }
+                // Sanity check for tests: make sure that we don't add new
+                // objects in debug mode. Since objects are immutable, this
+                // should be sufficient to make sure no object changes happened.
+                // Note, that we could also sanity check that storage and events
+                // haven't  been modified as well, but unlike objects it's much
+                // less likely to accidentally modify them in debug mode.
+                #[cfg(test)]
+                let init_global_objs_size = self.global_objs_size();
+                self.budget_ref().with_shadow_mode(f);
+                #[cfg(test)]
+                if !_allow_new_objects {
+                    assert_eq!(init_global_objs_size, self.global_objs_size());
+                }
+                if let Ok(mut disable_tracing) = self.0.disable_tracing.try_borrow_mut() {
+                    *disable_tracing = false;
+                }
             }
         }
+    }
+
+    /// Default version of `with_debug_mode_allowing_new_objects` that disallows
+    /// creating new objects (only enforced in tests).
+    pub(crate) fn with_debug_mode<F>(&self, f: F)
+    where
+        F: FnOnce() -> Result<(), HostError>,
+    {
+        self.with_debug_mode_allowing_new_objects(f, false);
     }
 
     /// Calls the provided function while ensuring that no diagnostic events are
@@ -871,6 +912,11 @@ impl EnvBase for Host {
     }
 
     fn tracing_enabled(&self) -> bool {
+        if let Ok(disable_tracing) = self.0.disable_tracing.try_borrow() {
+            if *disable_tracing {
+                return false;
+            }
+        }
         match self.try_borrow_trace_hook() {
             Ok(hook) => hook.is_some(),
             Err(_) => false,

--- a/soroban-env-host/src/host/trace.rs
+++ b/soroban-env-host/src/host/trace.rs
@@ -207,7 +207,7 @@ impl Host {
         }
         0
     }
-    fn global_objs_size(&self) -> usize {
+    pub(crate) fn global_objs_size(&self) -> usize {
         if let Ok(objs) = self.0.objects.try_borrow() {
             objs.len()
         } else {

--- a/soroban-env-host/src/storage.rs
+++ b/soroban-env-host/src/storage.rs
@@ -658,45 +658,49 @@ impl Host {
         key_val: Option<Val>,
     ) -> HostError {
         let mut err = err;
-        self.with_debug_mode(|| {
-            if !err.error.is_type(ScErrorType::Storage) {
-                return Ok(());
-            }
-            if !err.error.is_code(ScErrorCode::ExceededLimit)
-                && !err.error.is_code(ScErrorCode::MissingValue)
-            {
-                return Ok(());
-            }
+        self.with_debug_mode_allowing_new_objects(
+            || {
+                if !err.error.is_type(ScErrorType::Storage) {
+                    return Ok(());
+                }
+                if !err.error.is_code(ScErrorCode::ExceededLimit)
+                    && !err.error.is_code(ScErrorCode::MissingValue)
+                {
+                    return Ok(());
+                }
 
-            let key_type_str = get_key_type_string_for_error(lk);
-            // Accessing an entry outside of the footprint is a non-recoverable error, thus
-            // there is no way to observe the object pool being changed (host will continue
-            // propagating an error until there are no frames left and control is never
-            // returned to guest). This allows us to build a nicer error message.
-            // For the missing values we unfortunately can only safely use the existing `Val`s
-            // to enhance errors.
-            let can_create_new_objects = err.error.is_code(ScErrorCode::ExceededLimit);
-            let args = self
-                .get_args_for_error(lk, key_val, can_create_new_objects)
-                .unwrap_or_else(|_| vec![]);
-            if err.error.is_code(ScErrorCode::ExceededLimit) {
-                err = self.err(
-                    ScErrorType::Storage,
-                    ScErrorCode::ExceededLimit,
-                    format!("trying to access {} outside of the footprint", key_type_str).as_str(),
-                    args.as_slice(),
-                );
-            } else if err.error.is_code(ScErrorCode::MissingValue) {
-                err = self.err(
-                    ScErrorType::Storage,
-                    ScErrorCode::MissingValue,
-                    format!("trying to get non-existing value for {}", key_type_str).as_str(),
-                    args.as_slice(),
-                );
-            }
+                let key_type_str = get_key_type_string_for_error(lk);
+                // Accessing an entry outside of the footprint is a non-recoverable error, thus
+                // there is no way to observe the object pool being changed (host will continue
+                // propagating an error until there are no frames left and control is never
+                // returned to guest). This allows us to build a nicer error message.
+                // For the missing values we unfortunately can only safely use the existing `Val`s
+                // to enhance errors.
+                let can_create_new_objects = err.error.is_code(ScErrorCode::ExceededLimit);
+                let args = self
+                    .get_args_for_error(lk, key_val, can_create_new_objects)
+                    .unwrap_or_else(|_| vec![]);
+                if err.error.is_code(ScErrorCode::ExceededLimit) {
+                    err = self.err(
+                        ScErrorType::Storage,
+                        ScErrorCode::ExceededLimit,
+                        format!("trying to access {} outside of the footprint", key_type_str)
+                            .as_str(),
+                        args.as_slice(),
+                    );
+                } else if err.error.is_code(ScErrorCode::MissingValue) {
+                    err = self.err(
+                        ScErrorType::Storage,
+                        ScErrorCode::MissingValue,
+                        format!("trying to get non-existing value for {}", key_type_str).as_str(),
+                        args.as_slice(),
+                    );
+                }
 
-            Ok(())
-        });
+                Ok(())
+            },
+            true,
+        );
         err
     }
 


### PR DESCRIPTION
### What

Currently this produces no observation diffs, because apparently we only call debug mode within host functions, and we don't trace host functions calling another host functions. This may change soon with the invocation metering changes.

This also adds a test-only check asserting that debug mode does not create new objects. Since we do create new objects when producing errors, I've also added a way to explicitly bypass that check.

### Why

Provide a clean way to write debug mode code that doesn't create bogus observation diffs.

### Known limitations

N/A
