### PR TITLE
WIP: Add Bn254 precompiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-bn254"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a22f4561524cd949590d78d7d4c5df8f592430d221f7f3c9497bbafd8972120f"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
+]
+
+[[package]]
 name = "ark-ec"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1583,6 +1594,7 @@ version = "23.0.1"
 dependencies = [
  "arbitrary",
  "ark-bls12-381",
+ "ark-bn254",
  "ark-ec",
  "ark-ff",
  "ark-serialize",

--- a/soroban-env-common/env.json
+++ b/soroban-env-common/env.json
@@ -2358,6 +2358,36 @@
                     "return": "U256Val",
                     "docs": "performs inversion of a BLS12-381 scalar element (Fr) modulo r (the subgroup order)",
                     "min_supported_protocol": 22
+                },
+                {
+                    "export": "m",
+                    "name": "bn254_g1_add",
+                    "args": [
+                        { "name": "point1", "type": "BytesObject" },
+                        { "name": "point2", "type": "BytesObject" }
+                    ],
+                    "return": "BytesObject",
+                    "docs": "Adds two BN254 G1 points; encoding is 64-byte be_bytes(X)||be_bytes(Y); infinity is all-zeroes. No subgroup check."
+                },
+                {
+                    "export": "n",
+                    "name": "bn254_g1_mul",
+                    "args": [
+                        { "name": "point", "type": "BytesObject" },
+                        { "name": "scalar", "type": "U256Val" }
+                    ],
+                    "return": "BytesObject",
+                    "docs": "Multiplies a BN254 G1 point by a scalar (Fr); same encoding as bn254_g1_add."
+                },
+                {
+                    "export": "o",
+                    "name": "bn254_multi_pairing_check",
+                    "args": [
+                        { "name": "vp1", "type": "VecObject" },
+                        { "name": "vp2", "type": "VecObject" }
+                    ],
+                    "return": "Bool",
+                    "docs": "Performs BN254 pairings over vectors of G1 and G2 points; returns true iff product equals 1 in Fq12."
                 }
             ]
         },

--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -48,6 +48,7 @@ sha3 = "0.10.8"
 # above used only for calibration
 curve25519-dalek = { version = ">=4.1.3", default-features = false, features = ["digest"]}
 ark-bls12-381 = { version = "0.4.0"}
+ark-bn254 = { version = "0.4.0"}
 ark-serialize = { version = "0.4.2"}
 ark-ff = { version = "0.4.2"}
 ark-ec = { version = "0.4.2"}

--- a/soroban-env-host/src/crypto/bn254.rs
+++ b/soroban-env-host/src/crypto/bn254.rs
@@ -1,0 +1,313 @@
+use std::cmp::Ordering;
+use std::ops::{Add, Mul};
+
+use ark_bn254::{Bn254, Fq, Fq12, Fq2, Fr, G1Affine, G1Projective, G2Affine, G2Projective};
+use ark_ec::{
+    pairing::{Pairing, PairingOutput},
+    short_weierstrass::{Affine, SWCurveConfig},
+    AffineRepr, CurveGroup,
+};
+use ark_ff::{BigInteger, Field, PrimeField};
+use ark_serialize::{CanonicalDeserialize, Compress, Validate};
+use num_traits::Zero;
+
+use crate::{
+    host_object::HostVec,
+    xdr::{ContractCostType, ScBytes, ScErrorCode, ScErrorType},
+    Bool, BytesObject, Host, HostError, TryFromVal, U256Object, U256Small, U256Val, Val, VecObject,
+    U256,
+};
+
+pub(crate) const BN254_FP_SERIALIZED_SIZE: usize = 32;
+pub(crate) const BN254_FP2_SERIALIZED_SIZE: usize = BN254_FP_SERIALIZED_SIZE * 2;
+pub(crate) const BN254_G1_SERIALIZED_SIZE: usize = BN254_FP_SERIALIZED_SIZE * 2;
+pub(crate) const BN254_G2_SERIALIZED_SIZE: usize = BN254_FP2_SERIALIZED_SIZE * 2;
+
+impl Host {
+    fn bn254_err_invalid_input(&self, msg: &str) -> HostError {
+        self.err(ScErrorType::Crypto, ScErrorCode::InvalidInput, msg, &[])
+    }
+
+    fn bn254_deserialize_unchecked<T: CanonicalDeserialize>(
+        &self,
+        le_bytes: &[u8],
+        tag: &str,
+    ) -> Result<T, HostError> {
+        T::deserialize_with_mode(le_bytes, Compress::No, Validate::No).map_err(|_| {
+            self.bn254_err_invalid_input(format!("bn254: unable to deserialize {tag}").as_str())
+        })
+    }
+
+    pub(crate) fn bn254_check_point_is_on_curve<P: SWCurveConfig>(
+        &self,
+        pt: &Affine<P>,
+    ) -> Result<bool, HostError> {
+        // FIXME: Probably incorrect charge
+        self.charge_budget(ContractCostType::MemCmp, None)?;
+        Ok(pt.is_on_curve())
+    }
+
+    pub(crate) fn bn254_check_point_is_in_subgroup<P: SWCurveConfig>(
+        &self,
+        pt: &Affine<P>,
+    ) -> Result<bool, HostError> {
+        // FIXME: Probably incorrect charge
+        self.charge_budget(ContractCostType::MemCmp, None)?;
+        Ok(pt.is_in_correct_subgroup_assuming_on_curve())
+    }
+
+    pub(crate) fn bn254_g1_affine_deserialize_from_bytesobj(
+        &self,
+        bo: BytesObject,
+        subgroup_check: bool,
+    ) -> Result<G1Affine, HostError> {
+        let pt = self.visit_obj(bo, |bytes: &ScBytes| {
+            if bytes.len() != BN254_G1_SERIALIZED_SIZE {
+                return Err(self.err(
+                    ScErrorType::Crypto,
+                    ScErrorCode::InvalidInput,
+                    "bn254 G1: invalid input length to deserialize",
+                    &[
+                        Val::from_u32(bytes.len() as u32).into(),
+                        Val::from_u32(BN254_G1_SERIALIZED_SIZE as u32).into(),
+                    ],
+                ));
+            }
+            if bytes.iter().all(|b| b.is_zero()) {
+                return Ok(G1Projective::zero().into_affine());
+            }
+            // Split the 64-byte big-endian encoding into 32-byte X and Y limbs.
+            let mut x_be = [0u8; BN254_FP_SERIALIZED_SIZE];
+            let mut y_be = [0u8; BN254_FP_SERIALIZED_SIZE];
+            x_be.copy_from_slice(&bytes[0..32]);
+            y_be.copy_from_slice(&bytes[32..64]);
+
+            // Convert from big-endian to little-endian, which the field deserializer expects.
+            let mut x_le = x_be;
+            let mut y_le = y_be;
+            x_le.reverse();
+            y_le.reverse();
+            // Deserialize coordinates into field elements without validating curve/subgroup membership.
+            let x: Fq = self.bn254_deserialize_unchecked(&x_le, "G1.x")?;
+            let y: Fq = self.bn254_deserialize_unchecked(&y_le, "G1.y")?;
+            // Construct the affine point without checks; on-curve and subgroup checks follow below.
+            Ok(G1Affine::new_unchecked(x, y))
+        })?;
+
+        if !self.bn254_check_point_is_on_curve(&pt)? {
+            return Err(self.bn254_err_invalid_input("bn254 G1: point not on curve"));
+        }
+
+        if subgroup_check && !self.bn254_check_point_is_in_subgroup(&pt)? {
+            return Err(self.bn254_err_invalid_input("bn254 G1: point not in the correct subgroup"));
+        }
+        Ok(pt)
+    }
+
+    pub(crate) fn bn254_g2_affine_deserialize_from_bytesobj(
+        &self,
+        bo: BytesObject,
+        subgroup_check: bool,
+    ) -> Result<G2Affine, HostError> {
+        let pt = self.visit_obj(bo, |bytes: &ScBytes| {
+            if bytes.len() != BN254_G2_SERIALIZED_SIZE {
+                return Err(self.err(
+                    ScErrorType::Crypto,
+                    ScErrorCode::InvalidInput,
+                    "bn254 G2: invalid input length to deserialize",
+                    &[
+                        Val::from_u32(bytes.len() as u32).into(),
+                        Val::from_u32(BN254_G2_SERIALIZED_SIZE as u32).into(),
+                    ],
+                ));
+            }
+            if bytes.iter().all(|b| b.is_zero()) {
+                return Ok(G2Projective::zero().into_affine());
+            }
+            let mut x_c1_be = [0u8; 32];
+            let mut x_c0_be = [0u8; 32];
+            let mut y_c1_be = [0u8; 32];
+            let mut y_c0_be = [0u8; 32];
+
+            x_c1_be.copy_from_slice(&bytes[0..32]);
+            x_c0_be.copy_from_slice(&bytes[32..64]);
+            y_c1_be.copy_from_slice(&bytes[64..96]);
+            y_c0_be.copy_from_slice(&bytes[96..128]);
+
+            let mut x_c1_le = x_c1_be;
+            let mut x_c0_le = x_c0_be;
+            let mut y_c1_le = y_c1_be;
+            let mut y_c0_le = y_c0_be;
+            x_c1_le.reverse();
+            x_c0_le.reverse();
+            y_c1_le.reverse();
+            y_c0_le.reverse();
+
+            let x_c1: Fq = self.bn254_deserialize_unchecked(&x_c1_le, "G2.x.c1")?;
+            let x_c0: Fq = self.bn254_deserialize_unchecked(&x_c0_le, "G2.x.c0")?;
+            let y_c1: Fq = self.bn254_deserialize_unchecked(&y_c1_le, "G2.y.c1")?;
+            let y_c0: Fq = self.bn254_deserialize_unchecked(&y_c0_le, "G2.y.c0")?;
+            let x = Fq2::new(x_c0, x_c1);
+            let y = Fq2::new(y_c0, y_c1);
+            Ok(G2Affine::new_unchecked(x, y))
+        })?;
+
+        if !self.bn254_check_point_is_on_curve(&pt)? {
+            return Err(self.bn254_err_invalid_input("bn254 G2: point not on curve"));
+        }
+
+        if subgroup_check && !self.bn254_check_point_is_in_subgroup(&pt)? {
+            return Err(self.bn254_err_invalid_input("bn254 G2: point not in the correct subgroup"));
+        }
+
+        Ok(pt)
+    }
+
+    pub(crate) fn bn254_g1_projective_into_affine(
+        &self,
+        g1: G1Projective,
+    ) -> Result<G1Affine, HostError> {
+        self.charge_budget(ContractCostType::MemCmp, None)?;
+        Ok(g1.into_affine())
+    }
+
+    pub(crate) fn bn254_g1_affine_serialize_uncompressed(
+        &self,
+        g1: &G1Affine,
+    ) -> Result<BytesObject, HostError> {
+        let mut buf = [0u8; BN254_G1_SERIALIZED_SIZE];
+        if g1.is_zero() {
+            return self.add_host_object(self.scbytes_from_slice(&buf)?);
+        }
+        let (x, y) = g1
+            .xy()
+            .ok_or_else(|| self.bn254_err_invalid_input("bn254 G1: infinity"))?;
+
+        let x_be: [u8; 32] = x
+            .into_bigint()
+            .to_bytes_be()
+            .try_into()
+            .map_err(|_| self.bn254_err_invalid_input("bn254 G1: invalid x"))?;
+        let y_be: [u8; 32] = y
+            .into_bigint()
+            .to_bytes_be()
+            .try_into()
+            .map_err(|_| self.bn254_err_invalid_input("bn254 G1: invalid y"))?;
+        buf[0..32].copy_from_slice(&x_be);
+        buf[32..64].copy_from_slice(&y_be);
+        self.add_host_object(self.scbytes_from_slice(&buf)?)
+    }
+
+    pub(crate) fn bn254_g1_projective_serialize_uncompressed(
+        &self,
+        g1: G1Projective,
+    ) -> Result<BytesObject, HostError> {
+        let g1_affine = self.bn254_g1_projective_into_affine(g1)?;
+        self.bn254_g1_affine_serialize_uncompressed(&g1_affine)
+    }
+
+    pub(crate) fn bn254_g1_add_internal(
+        &self,
+        p0: G1Affine,
+        p1: G1Affine,
+    ) -> Result<G1Projective, HostError> {
+        self.charge_budget(ContractCostType::MemCmp, None)?;
+        Ok(p0.add(p1))
+    }
+
+    pub(crate) fn bn254_g1_mul_internal(
+        &self,
+        p0: G1Affine,
+        scalar: Fr,
+    ) -> Result<G1Projective, HostError> {
+        self.charge_budget(ContractCostType::MemCmp, None)?;
+        Ok(p0.mul(scalar))
+    }
+
+    pub(crate) fn bn254_checked_g1_vec_from_vecobj(
+        &self,
+        vp: VecObject,
+    ) -> Result<Vec<G1Affine>, HostError> {
+        let mut points: Vec<G1Affine> = Vec::new();
+        let _ = self.visit_obj(vp, |vp: &HostVec| {
+            for p in vp.iter() {
+                let pp = self.bn254_g1_affine_deserialize_from_bytesobj(
+                    BytesObject::try_from_val(self, p)?,
+                    true,
+                )?;
+                points.push(pp);
+            }
+            Ok(())
+        })?;
+        Ok(points)
+    }
+
+    pub(crate) fn bn254_checked_g2_vec_from_vecobj(
+        &self,
+        vp: VecObject,
+    ) -> Result<Vec<G2Affine>, HostError> {
+        let mut points: Vec<G2Affine> = Vec::new();
+        let _ = self.visit_obj(vp, |vp: &HostVec| {
+            for p in vp.iter() {
+                let pp = self.bn254_g2_affine_deserialize_from_bytesobj(
+                    BytesObject::try_from_val(self, p)?,
+                    true,
+                )?;
+                points.push(pp);
+            }
+            Ok(())
+        })?;
+        Ok(points)
+    }
+
+    pub(crate) fn bn254_fr_from_u256val(&self, sv: U256Val) -> Result<Fr, HostError> {
+        self.charge_budget(ContractCostType::MemCpy, None)?;
+        let fr = if let Ok(small) = U256Small::try_from(sv) {
+            Fr::from_le_bytes_mod_order(&u64::from(small).to_le_bytes())
+        } else {
+            let obj: U256Object = sv.try_into()?;
+            self.visit_obj(obj, |u: &U256| {
+                Ok(Fr::from_le_bytes_mod_order(&u.to_le_bytes()))
+            })?
+        };
+        Ok(fr)
+    }
+
+    pub(crate) fn bn254_pairing_internal(
+        &self,
+        vp1: &Vec<G1Affine>,
+        vp2: &Vec<G2Affine>,
+    ) -> Result<PairingOutput<Bn254>, HostError> {
+        self.charge_budget(ContractCostType::MemCmp, Some(vp1.len() as u64))?;
+        if vp1.len() != vp2.len() || vp1.is_empty() {
+            return Err(self.bn254_err_invalid_input(
+                format!(
+                    "pairing: invalid input vector lengths ({}, {})",
+                    vp1.len(),
+                    vp2.len()
+                )
+                .as_str(),
+            ));
+        }
+        let mlo = Bn254::multi_miller_loop(vp1, vp2);
+        Bn254::final_exponentiation(mlo).ok_or_else(|| {
+            self.bn254_err_invalid_input(
+                "final_exponentiation has failed, most likely multi_miller_loop produced infinity",
+            )
+        })
+    }
+
+    pub(crate) fn bn254_check_pairing_output(
+        &self,
+        output: &PairingOutput<Bn254>,
+    ) -> Result<Bool, HostError> {
+        self.charge_budget(
+            ContractCostType::MemCmp,
+            Some(12 * BN254_FP_SERIALIZED_SIZE as u64),
+        )?;
+        match output.0.cmp(&Fq12::ONE) {
+            Ordering::Equal => Ok(true.into()),
+            _ => Ok(false.into()),
+        }
+    }
+}

--- a/soroban-env-host/src/crypto/mod.rs
+++ b/soroban-env-host/src/crypto/mod.rs
@@ -18,6 +18,7 @@ use ecdsa::{signature::hazmat::PrehashVerifier, PrimeCurve, Signature, Signature
 use elliptic_curve::CurveArithmetic;
 use generic_array::ArrayLength;
 pub(crate) mod bls12_381;
+pub(crate) mod bn254;
 
 impl Host {
     // Ed25519 functions

--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -3221,6 +3221,52 @@ impl VmCallerEnv for Host {
         self.fr_to_u256val(res)
     }
 
+    fn bn254_g1_add(
+        &self,
+        _vmcaller: &mut VmCaller<Host>,
+        p0: BytesObject,
+        p1: BytesObject,
+    ) -> Result<BytesObject, HostError> {
+        let p0 = self.bn254_g1_affine_deserialize_from_bytesobj(p0, false)?;
+        let p1 = self.bn254_g1_affine_deserialize_from_bytesobj(p1, false)?;
+        let res = self.bn254_g1_add_internal(p0, p1)?;
+        self.bn254_g1_projective_serialize_uncompressed(res)
+    }
+
+    fn bn254_g1_mul(
+        &self,
+        _vmcaller: &mut VmCaller<Host>,
+        p0: BytesObject,
+        scalar: U256Val,
+    ) -> Result<BytesObject, HostError> {
+        let p0 = self.bn254_g1_affine_deserialize_from_bytesobj(p0, true)?;
+        let scalar = self.bn254_fr_from_u256val(scalar)?;
+        let res = self.bn254_g1_mul_internal(p0, scalar)?;
+        self.bn254_g1_projective_serialize_uncompressed(res)
+    }
+
+    fn bn254_multi_pairing_check(
+        &self,
+        vmcaller: &mut VmCaller<Host>,
+        vp1: VecObject,
+        vp2: VecObject,
+    ) -> Result<Bool, HostError> {
+        let l1: u32 = self.vec_len(vmcaller, vp1)?.into();
+        let l2: u32 = self.vec_len(vmcaller, vp2)?.into();
+        if l1 != l2 || l1 == 0 {
+            return Err(self.err(
+                ScErrorType::Crypto,
+                ScErrorCode::InvalidInput,
+                format!("multi-pairing-check: invalid input vector lengths {l1} and {l2}").as_str(),
+                &[],
+            ));
+        }
+        let vp1 = self.bn254_checked_g1_vec_from_vecobj(vp1)?;
+        let vp2 = self.bn254_checked_g2_vec_from_vecobj(vp2)?;
+        let output = self.bn254_pairing_internal(&vp1, &vp2)?;
+        self.bn254_check_pairing_output(&output)
+    }
+
     // endregion: "crypto" module functions
     // region: "test" module functions
 


### PR DESCRIPTION
### What

This PR wants to add the bn254 precompiles to `soroban-env-host`. In particular, the precompiles added are:
- `bn254_g1_add`
- `bn254_g1_mul`
- `bn254_multi_pairing_check`

### Why

This precompiles are required for building products that require bn254 curve.

### Known limitations

Still a draft an