### PR TITLE
Small bench related fixes

### DIFF
--- a/soroban-env-host/benches/common/cost_types/bls12_381.rs
+++ b/soroban-env-host/benches/common/cost_types/bls12_381.rs
@@ -31,7 +31,7 @@ impl HostCostMeasurement for Bls12381EncodeFpMeasure {
     type Runner = Bls12381EncodeFpRun;
 
     fn new_random_case(_host: &Host, rng: &mut StdRng, _input: u64) -> Bls12381EncodeFpSample {
-        let buf = vec![0; 1000];
+        let buf = vec![0; 48]; // FP_SERIALIZED_SIZE (the crypto module isn't exposed here)
         let fp = Fq::rand(rng);
         Bls12381EncodeFpSample(buf, fp)
     }

--- a/soroban-env-host/benches/common/cost_types/val_deser.rs
+++ b/soroban-env-host/benches/common/cost_types/val_deser.rs
@@ -53,7 +53,7 @@ impl HostCostMeasurement for ValDeserMeasure {
         let mut v = ScVal::U64(0);
         let mut rem = input;
         for _i in 0..MAX_DEPTH {
-            if rem == 0 {
+            if rem == 0 || rem < elem_per_level {
                 break;
             }
             let mut inner = vec![v; 1];


### PR DESCRIPTION
### What

1. Fp encoding checks the buffer size.
2. Prevent `rem` from going negative.
