### PR TITLE
Use v0 instantiation VM costs for cached Wasms.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,10 +63,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: rustup update
-    - uses: stellar/binaries@v40
+    - uses: stellar/binaries@v47
       with:
         name: cargo-semver-checks
-        version: 0.42.0
+        version: 0.44.0
     - run: cargo semver-checks --exclude soroban-simulation
 
   build-and-test:
@@ -110,7 +110,7 @@ jobs:
     - run: rustup update
     - run: cargo version
     - run: rustup target add ${{ matrix.sys.target }}
-    - uses: stellar/binaries@v40
+    - uses: stellar/binaries@v47
       with:
         name: cargo-hack
         version: 0.6.35

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ahash"
@@ -203,17 +203,17 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-link",
 ]
 
 [[package]]
@@ -702,9 +702,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.0"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "group"
@@ -895,9 +895,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libm"
@@ -966,11 +966,11 @@ checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]
@@ -1094,9 +1094,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.1"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
@@ -1325,9 +1325,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc_version"
@@ -2206,6 +2206,12 @@ dependencies = [
  "quote",
  "syn 2.0.39",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 
 [[package]]
 name = "windows-result"

--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -32,7 +32,7 @@ rand_chacha = "0.3.1"
 num-traits = "0.2.17"
 num-integer = "0.1.45"
 num-derive = "0.4.1"
-backtrace = { version = "0.3.69", optional = true }
+backtrace = { version = "0.3.75", optional = true }
 k256 = {version = "0.13.3", default-features = false, features = ["ecdsa", "arithmetic"]}
 p256 = {version = "0.13.2", default-features = false, features = ["ecdsa", "arithmetic"]}
 ecdsa = {version = "0.16.7", default-features = false}
@@ -70,7 +70,7 @@ wasmprinter = "0.2.72"
 expect-test = "1.4.1"
 more-asserts = "0.3.1"
 pretty_assertions = "1.4.0"
-backtrace = "0.3.69"
+backtrace = "0.3.75"
 serde_json = "1.0.108"
 serde = "1.0.192"
 arbitrary = "1.3.2"

--- a/soroban-env-host/src/auth.rs
+++ b/soroban-env-host/src/auth.rs
@@ -1724,6 +1724,11 @@ impl InvocationTracker {
                 &[],
             ));
         }
+        // Emulate the function comparison that happens in the enforcing mode
+        // when we're matching a `require_auth` invocation to the authorized
+        // function from XDR.
+        let function_for_comparison = AuthorizedFunction::from_xdr(host, function.to_xdr(host)?)?;
+        let _ = host.compare(&function, &function_for_comparison)?;
         if let Some(curr_invocation) = self.last_authorized_invocation_mut()? {
             curr_invocation
                 .sub_invocations

--- a/soroban-simulation/src/test/simulation.rs
+++ b/soroban-simulation/src/test/simulation.rs
@@ -314,7 +314,7 @@ fn test_simulate_create_contract() {
     );
     assert!(res.contract_events.is_empty());
     assert!(res.diagnostic_events.is_empty());
-    let expected_instructions = 2739690;
+    let expected_instructions = 2374206;
     assert_eq!(
         res.transaction_data,
         Some(SorobanTransactionData {
@@ -328,11 +328,11 @@ fn test_simulate_create_contract() {
                 disk_read_bytes: 0,
                 write_bytes: 104,
             },
-            resource_fee: 13293,
+            resource_fee: 12928,
         })
     );
     assert_eq!(res.simulated_instructions, expected_instructions);
-    assert_eq!(res.simulated_memory, 1369843);
+    assert_eq!(res.simulated_memory, 1187102);
     assert_eq!(
         res.modified_entries,
         vec![LedgerEntryDiff {
@@ -457,7 +457,7 @@ fn test_simulate_invoke_contract_with_auth() {
     assert!(res.contract_events.is_empty());
     assert!(!res.diagnostic_events.is_empty());
 
-    let expected_instructions = 40782813;
+    let expected_instructions = 39114574;
     assert_eq!(
         res.transaction_data,
         Some(SorobanTransactionData {
@@ -486,11 +486,11 @@ fn test_simulate_invoke_contract_with_auth() {
                 disk_read_bytes: 144,
                 write_bytes: 76,
             },
-            resource_fee: 115726,
+            resource_fee: 114058,
         })
     );
     assert_eq!(res.simulated_instructions, expected_instructions);
-    assert_eq!(res.simulated_memory, 20391380);
+    assert_eq!(res.simulated_memory, 19557271);
     assert_eq!(
         res.modified_entries,
         vec![LedgerEntryDiff {
@@ -557,7 +557,7 @@ fn test_simulate_invoke_contract_with_autorestore() {
     assert!(res.contract_events.is_empty());
     assert!(!res.diagnostic_events.is_empty());
 
-    let expected_instructions = 10942546;
+    let expected_instructions = 10998010;
     let wasm_entry_size = contracts[0]
         .wasm_entry
         .to_xdr(Limits::none())
@@ -589,11 +589,11 @@ fn test_simulate_invoke_contract_with_autorestore() {
                 disk_read_bytes: wasm_entry_size + contract_1_size,
                 write_bytes: wasm_entry_size + contract_1_size,
             },
-            resource_fee: 6231346,
+            resource_fee: 6231402,
         })
     );
     assert_eq!(res.simulated_instructions, expected_instructions);
-    assert_eq!(res.simulated_memory, 5471262);
+    assert_eq!(res.simulated_memory, 5498994);
     assert_eq!(
         res.modified_entries,
         vec![
@@ -1247,11 +1247,11 @@ fn test_simulate_unsuccessful_sac_call_with_try_call() {
                     // No entries should be actually modified.
                     read_write: Default::default(),
                 },
-                instructions: 5564767,
+                instructions: 5199245,
                 disk_read_bytes: 0,
                 write_bytes: 0,
             },
-            resource_fee: 5913,
+            resource_fee: 5548,
         })
     );
 }


### PR DESCRIPTION
### What

That reflects the actual on-chain behavior of the module cache, which always unconditionally charges v0 VM instantiation costs.

Curiously, this change causes the recording and enforcing mode instruction counts to go *down* in the e2e tests, which is visible in the PR. However, the intention of the change is to actually fix simulation for the rare cases where v0 cost are higher than v1 cost. 

Note, that in case of the enforcing mode the change happens due to a fix that replicates the inter-ledger module cache logic in the test setup. Specifically, we always unconditionally charge v0 instantiation cost when instantiating a module from the cache, while previously the test setup usually used v1 instantiation cost. The simulation change replicates that behavior in the recording mode. 

I've also made a small improvement to the auth simulation accuracy, as it fell outside of our 2% simulation accuracy tolerance window.

### Why

Improving simulation accuracy.

### Known limitations

N/A
