### PR TITLE
Load bucket list size from ledger.

### DIFF
--- a/soroban-simulation/src/test/network_config.rs
+++ b/soroban-simulation/src/test/network_config.rs
@@ -129,12 +129,24 @@ fn test_load_config_from_snapshot() {
         config_entry(ConfigSettingEntry::ContractCostParamsMemoryBytes(
             memory_cost_params.clone(),
         )),
+        config_entry(ConfigSettingEntry::LiveSorobanStateSizeWindow(
+            vec![
+                150_000_000_000_000,
+                100_000_000_000_000,
+                200_000_000_000_000,
+            ]
+            .try_into()
+            .unwrap(),
+        )),
     ])
     .unwrap();
 
-    let network_config =
-        NetworkConfig::load_from_snapshot(&snapshot_source, 150_000_000_000_000).unwrap();
-    // From tests/resources `test_compute_write_fee`
+    #[cfg(not(feature = "unstable-next-api"))]
+    let network_config = NetworkConfig::load_from_snapshot(&snapshot_source, 0).unwrap();
+    #[cfg(feature = "unstable-next-api")]
+    let network_config = NetworkConfig::load_from_snapshot(&snapshot_source).unwrap();
+
+    // From tests/resources `test_compute_rent_write_fee`
     let rent_fee_per_1kb = 1_000_000_000 + 50 * (1_000_000_000_i64 - 1_000_000) / 2;
     assert_eq!(
         network_config,


### PR DESCRIPTION
### What

Load bucket list size from ledger.

Also deprecate the `bucket_list_size` side input, it will be removed in p26 major release.

Resolves https://github.com/stellar/rs-soroban-env/issues/1572

### Why

Simplify the simulation interface, now that RPC is capable of keeping up with all the config entries.

### Known limitations

N/A
