### PR TITLE
Split EnvBase testutils-gated stuff into its own trait

### DIFF
--- a/soroban-env-common/src/lib.rs
+++ b/soroban-env-common/src/lib.rs
@@ -119,6 +119,8 @@ pub use val::{Bool, Void};
 pub use compare::Compare;
 pub use convert::{Convert, TryFromVal, TryIntoVal};
 pub use env::{call_macro_with_all_host_functions, CheckedEnvArg, Env, EnvBase};
+#[cfg(feature = "testutils")]
+pub use env::EnvBaseTestUtils;
 pub use vmcaller_env::{VmCaller, VmCallerEnv};
 
 pub use bytes::BytesObject;

--- a/soroban-env-guest/src/guest.rs
+++ b/soroban-env-guest/src/guest.rs
@@ -9,6 +9,8 @@ use super::{
     Void,
 };
 use super::{Env, EnvBase, Symbol};
+#[cfg(feature = "testutils")]
+use super::EnvBaseTestUtils;
 use static_assertions as sa;
 
 // Just the smallest possible version of a runtime assertion-or-panic.
@@ -31,11 +33,6 @@ impl EnvBase for Guest {
     type Error = Infallible;
 
     fn error_from_error_val(&self, _e: crate::Error) -> Self::Error {
-        core::arch::wasm32::unreachable()
-    }
-
-    #[cfg(feature = "testutils")]
-    fn escalate_error_to_panic(&self, _e: Self::Error) -> ! {
         core::arch::wasm32::unreachable()
     }
 
@@ -184,6 +181,13 @@ impl EnvBase for Guest {
     }
 
     fn check_protocol_version_upper_bound(&self, _upper_bound: u32) -> Result<(), Self::Error> {
+        core::arch::wasm32::unreachable()
+    }
+}
+
+#[cfg(feature = "testutils")]
+impl EnvBaseTestUtils for Guest {
+    fn escalate_error_to_panic(&self, _e: Self::Error) -> ! {
         core::arch::wasm32::unreachable()
     }
 }

--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -893,19 +893,6 @@ impl EnvBase for Host {
     // To get it to do that, we have to call `panic!()`, not `panic_any`.
     // Personally I think this is a glaring weakness of `panic_any` but we are
     // not in a position to improve it.
-    #[cfg(feature = "testutils")]
-    fn escalate_error_to_panic(&self, e: Self::Error) -> ! {
-        let _ = self.with_current_frame_opt(|f| {
-            if let Some(Frame::TestContract(frame)) = f {
-                if let Ok(mut panic) = frame.panic.try_borrow_mut() {
-                    *panic = Some(e.error);
-                }
-            }
-            Ok(())
-        });
-        let escalation = self.error(e.error, "escalating error to panic", &[]);
-        panic!("{:?}", escalation)
-    }
 
     fn augment_err_result<T>(&self, mut x: Result<T, Self::Error>) -> Result<T, Self::Error> {
         if let Err(e) = &mut x {
@@ -1180,6 +1167,22 @@ impl EnvBase for Host {
                 Ok(())
             }
         })
+    }
+}
+
+#[cfg(feature = "testutils")]
+impl crate::EnvBaseTestUtils for Host {
+    fn escalate_error_to_panic(&self, e: Self::Error) -> ! {
+        let _ = self.with_current_frame_opt(|f| {
+            if let Some(Frame::TestContract(frame)) = f {
+                if let Ok(mut panic) = frame.panic.try_borrow_mut() {
+                    *panic = Some(e.error);
+                }
+            }
+            Ok(())
+        });
+        let escalation = self.error(e.error, "escalating error to panic", &[]);
+        panic!("{:?}", escalation)
     }
 }
 


### PR DESCRIPTION
Superficial fix for https://github.com/stellar/rs-soroban-env/issues/1570 lazily composed by claude. Whether this is actually a thing we want remains to be seen! Asking followup in the bug.