### PR TITLE
Round the contract code rent discount up.

### DIFF
--- a/soroban-env-host/src/fees.rs
+++ b/soroban-env-host/src/fees.rs
@@ -389,7 +389,7 @@ fn rent_fee_per_entry_change(
         ));
     }
     if entry_change.is_code_entry {
-        fee /= CODE_ENTRY_RENT_DISCOUNT_FACTOR;
+        fee = num_integer::div_ceil(fee, CODE_ENTRY_RENT_DISCOUNT_FACTOR);
     }
     fee
 }

--- a/soroban-env-host/tests/fees.rs
+++ b/soroban-env-host/tests/fees.rs
@@ -547,9 +547,9 @@ fn test_rent_extend_fees_with_only_extend() {
             &fee_config,
             50_000,
         ),
-        // Rent: ceil(10 * 1024 * 1000 * 200_000 / (10_000 * 1024)) / 3 (=66_666)
+        // Rent: ceil(10 * 1024 * 1000 * 200_000 / (10_000 * 1024)) / 3 (=66_667)
         // Expiration entry write entry/bytes: 34
-        66_666 + 34
+        66_667 + 34
     );
 
     // Size decrease
@@ -654,10 +654,10 @@ fn test_rent_extend_fees_with_only_extend() {
             &fee_config,
             50_000,
         ),
-        // Rent: 20_000 + 200_000 + 66_666 + 1 + 20 + 200_000 + 20_000 (=506_687) +
+        // Rent: 20_000 + 200_000 + 66_667 + 1 + 20 + 200_000 + 20_000 (=506_688) +
         // Expiration entry write bytes: ceil(7 * 500 * 48 / 1024) (=165) +
         // Expiration entry write: 10 * 7
-        506_687 + 165 + 70
+        506_688 + 165 + 70
     );
 }
 
@@ -704,7 +704,7 @@ fn test_rent_extend_fees_with_only_size_change() {
             25_000,
         ),
         // 99_999 * 1000 * (100_000 - 25_000 + 1) / (10_000 * 1024) / 3
-        732_425 / 3
+        num_integer::div_ceil(732_425, 3)
     );
 
     // Large size increase, temp storage
@@ -794,7 +794,7 @@ fn test_rent_extend_fees_with_only_size_change() {
             25_000,
         ),
         // 732_425 + 732_425 / 3 + 73_243
-        1_049_809
+        1_049_810
     );
 }
 
@@ -845,7 +845,7 @@ fn test_rent_extend_with_size_change_and_extend() {
         // Rent: 100_000 * 1000 * 200_000 / (10_000 * 1024) / 2 +
         // 99_999 * 1000 * (100_000 - 25_000 + 1) / (10_000 * 1024)
         // Expiration entry write entry/bytes: 34
-        2_685_550 / 3 + 34
+        num_integer::div_ceil(2_685_550, 3) + 34
     );
 
     // Temp entry
@@ -903,7 +903,7 @@ fn test_rent_extend_with_size_change_and_extend() {
         // Rent: 2_685_550 + 2_685_550 / 3 + 268_556
         // Expiration entry write bytes: ceil(3 * 500 * 48 / 1024) (=71) +
         // Expiration entry write: 10 * 3
-        3_849_289 + 71 + 30
+        3_849_290 + 71 + 30
     );
 
     // Small increments

--- a/soroban-simulation/src/test/simulation.rs
+++ b/soroban-simulation/src/test/simulation.rs
@@ -141,7 +141,7 @@ fn test_simulate_upload_wasm() {
             .write_bytes
             .to_string(),
     );
-    expect!["4714773"].assert_eq(
+    expect!["4714774"].assert_eq(
         &res.transaction_data
             .as_ref()
             .unwrap()
@@ -201,7 +201,7 @@ fn test_simulate_upload_wasm() {
         res.simulated_instructions
     );
     assert_eq!(res_with_adjustments.simulated_memory, res.simulated_memory);
-    expect!["7071426"].assert_eq(
+    expect!["7071427"].assert_eq(
         &res_with_adjustments
             .transaction_data
             .as_ref()
@@ -635,7 +635,7 @@ fn test_simulate_invoke_contract_with_autorestore() {
         .unwrap()
         .len() as u32;
     expect!["10998010"].assert_eq(&res.simulated_instructions.to_string());
-    expect!["6231402"].assert_eq(
+    expect!["6231403"].assert_eq(
         &res.transaction_data
             .as_ref()
             .unwrap()
@@ -756,7 +756,7 @@ fn test_simulate_extend_ttl_op() {
     )
     .unwrap();
 
-    expect!["6204121"].assert_eq(
+    expect!["6204123"].assert_eq(
         &extension_for_some_entries
             .transaction_data
             .resource_fee
@@ -798,7 +798,7 @@ fn test_simulate_extend_ttl_op() {
         1_000_001,
     )
     .unwrap();
-    expect!["104563088"].assert_eq(
+    expect!["104563090"].assert_eq(
         &extension_for_all_entries
             .transaction_data
             .resource_fee
@@ -849,7 +849,7 @@ fn test_simulate_extend_ttl_op() {
     )
     .unwrap();
 
-    expect!["156844607"].assert_eq(
+    expect!["156844610"].assert_eq(
         &extension_for_all_entries_with_adjustment
             .transaction_data
             .resource_fee
@@ -972,7 +972,7 @@ fn test_simulate_restore_op() {
             .resources
             .write_bytes
     );
-    expect!["10922801"].assert_eq(
+    expect!["10922803"].assert_eq(
         &restoration_for_some_entries
             .transaction_data
             .resource_fee
@@ -1032,7 +1032,7 @@ fn test_simulate_restore_op() {
             .resources
             .write_bytes
     );
-    expect!["11130765"].assert_eq(
+    expect!["11130768"].assert_eq(
         &extension_for_all_entries
             .transaction_data
             .resource_fee
@@ -1072,7 +1072,7 @@ fn test_simulate_restore_op() {
     )
     .unwrap();
 
-    expect!["16695904"].assert_eq(
+    expect!["16695909"].assert_eq(
         &extension_for_all_entries_with_adjustment
             .transaction_data
             .resource_fee


### PR DESCRIPTION
### What

Round the contract code rent discount up.

That's a protocol bug fix that will be included in p26.

### Why

Rounding down was inconsistent with the rest computations and resulted in missing 1 stroop from rent computations from time to time.

### Known limitations

N/A
