### PR TITLE
Update load_from_snapshot interface

### DIFF
--- a/soroban-simulation/src/network_config.rs
+++ b/soroban-simulation/src/network_config.rs
@@ -84,10 +84,7 @@ impl NetworkConfig {
     ///
     /// This may only fail in case when provided snapshot doesn't contain
     /// all the necessary entries or when these entries are mis-configured.
-    pub fn load_from_snapshot(
-        snapshot: &impl SnapshotSource,
-        #[cfg(not(feature = "unstable-next-api"))] _bucket_list_size: u64,
-    ) -> Result<Self> {
+    pub fn load_from_snapshot(snapshot: &impl SnapshotSource) -> Result<Self> {
         let compute = load_setting!(snapshot, ContractComputeV0);
         let ledger_cost = load_setting!(snapshot, ContractLedgerCostV0);
         let ledger_cost_ext = load_setting!(snapshot, ContractLedgerCostExtV0);

--- a/soroban-simulation/src/test/network_config.rs
+++ b/soroban-simulation/src/test/network_config.rs
@@ -141,9 +141,6 @@ fn test_load_config_from_snapshot() {
     ])
     .unwrap();
 
-    #[cfg(not(feature = "unstable-next-api"))]
-    let network_config = NetworkConfig::load_from_snapshot(&snapshot_source, 0).unwrap();
-    #[cfg(feature = "unstable-next-api")]
     let network_config = NetworkConfig::load_from_snapshot(&snapshot_source).unwrap();
 
     // From tests/resources `test_compute_rent_write_fee`


### PR DESCRIPTION
### What

The outdated interface can be removed now that we're working on p26.