### PR TITLE
Add CodeQL config file to only run the scan for production code

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,24 @@
+name: "CodeQL config"
+
+# Restrict CodeQL analysis to the `src` directory of each Rust crate so that
+# tests, benchmarks, fuzz targets, observations and other non-production code
+# are excluded from scanning.
+# See: https://docs.github.com/en/code-security/reference/code-scanning/workflow-configuration-options#specifying-directories-to-scan
+paths:
+  - soroban-builtin-sdk-macros/src
+  - soroban-env-common/src
+  - soroban-env-guest/src
+  - soroban-env-host/src
+  - soroban-env-macros/src
+  - soroban-simulation/src
+  - soroban-synth-wasm/src
+  - soroban-test-wasms/src
+
+paths-ignore:
+  - "**/tests/**"
+  - "**/benches/**"
+  - "**/observations/**"
+  - "**/fuzz/**"
+  - "**/build.rs"
+  - soroban-env-host/fuzz
+  - soroban-test-wasms/wasm-workspace

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,7 +1,7 @@
 name: "CodeQL"
 
 on:
-  push:
+  pull_request:
     branches: [main]
   schedule:
     - cron: "0 6 * * 1"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: rust
+            build-mode: manual
+          - language: actions
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Build (Rust)
+        if: matrix.language == 'rust'
+        run: cargo build --workspace --all-features
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
### What
Add CodeQL config file to only run the scan for production code

### Why
Current CodeQL scan has tagged a lot of test files that we can ignore