### PR TITLE
Update `stellar-xdr` to latest commit and update `ethnum`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,9 +678,9 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
 name = "ethnum"
-version = "1.5.0"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "expect-test"
@@ -1621,7 +1621,7 @@ dependencies = [
  "soroban-env-macros",
  "soroban-wasmi",
  "static_assertions",
- "stellar-xdr 26.0.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=f0ed902950d517ec3cc31d5af7c268e2f025d093)",
+ "stellar-xdr",
  "tracy-client",
  "wasmparser",
 ]
@@ -1684,7 +1684,7 @@ dependencies = [
  "soroban-wasmi",
  "static_assertions",
  "stellar-strkey",
- "stellar-xdr 26.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stellar-xdr",
  "tabwriter",
  "textplots",
  "thousands",
@@ -1704,7 +1704,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "stellar-xdr 26.0.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=f0ed902950d517ec3cc31d5af7c268e2f025d093)",
+ "stellar-xdr",
  "syn",
 ]
 
@@ -1742,7 +1742,7 @@ dependencies = [
  "expect-test",
  "soroban-env-common",
  "soroban-env-macros",
- "stellar-xdr 26.0.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=f0ed902950d517ec3cc31d5af7c268e2f025d093)",
+ "stellar-xdr",
  "wasm-encoder",
  "wasmparser",
  "wasmprinter",
@@ -1799,23 +1799,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "26.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea3195594b044ea3a5b05906f81d945480825f00db4e3ae7d77526bf546ff3a"
-dependencies = [
- "arbitrary",
- "cfg_eval",
- "crate-git-revision",
- "escape-bytes",
- "ethnum",
- "hex",
- "sha2",
- "stellar-strkey",
-]
-
-[[package]]
-name = "stellar-xdr"
-version = "26.0.0"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=f0ed902950d517ec3cc31d5af7c268e2f025d093#f0ed902950d517ec3cc31d5af7c268e2f025d093"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=b71d1f84ada0868c468bc64273a8da717262c622#b71d1f84ada0868c468bc64273a8da717262c622"
 dependencies = [
  "arbitrary",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ wasmparser = "=0.116.1"
 [workspace.dependencies.stellar-xdr]
 version = "=26.0.0"
 git = "https://github.com/stellar/rs-stellar-xdr"
-rev = "f0ed902950d517ec3cc31d5af7c268e2f025d093"
+rev = "b71d1f84ada0868c468bc64273a8da717262c622"
 default-features = false
 
 [workspace.dependencies.wasmi]

--- a/deny.toml
+++ b/deny.toml
@@ -95,7 +95,11 @@ ignore = [
     # advisory, this shouldn't impact us as we don't support ARM, and
     # we link `keccak` transitively through `sha3`.
     # This should be removed after `sha3` update to >10.8 version.
-    "RUSTSEC-2026-0012"
+    "RUSTSEC-2026-0012",
+    # Ignores 'Rand is unsound with a custom logger using rand::rng()' advisory.
+    # `rand` 0.8.5 is only vulnerable when its `log` + `thread_rng` path is
+    # enabled with a custom logger, which we don't use
+    "RUSTSEC-2026-0097"
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories

--- a/soroban-env-common/Cargo.toml
+++ b/soroban-env-common/Cargo.toml
@@ -20,7 +20,7 @@ wasmi = { workspace = true, optional = true }
 wasmparser = { workspace = true, optional = true}
 serde = { version = "1.0.192", features = ["derive"], optional = true }
 static_assertions = "1.1.0"
-ethnum = "1.5.0"
+ethnum = "1.5.3"
 arbitrary = { version = "1.3.2", features = ["derive"], optional = true }
 num-traits = {version = "0.2.17", default-features = false}
 num-derive = "0.4.1"

--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -86,14 +86,9 @@ lazy_static = "1.5.0"
 
 [dev-dependencies.stellar-xdr]
 version = "=26.0.0"
-#git = "https://github.com/stellar/rs-stellar-xdr"
-#rev = "99c73b18ccd68bc3439be30801da6261b193d2da"
+git = "https://github.com/stellar/rs-stellar-xdr"
+rev = "b71d1f84ada0868c468bc64273a8da717262c622"
 default-features = false
-# env should be pinned to next while the next protocol is in development. Switch to curr when it is updated.
-features = ["arbitrary",
-"curr",
-#"next"
-]
 
 [features]
 testutils = ["soroban-env-common/testutils", "recording_mode"]


### PR DESCRIPTION
### What

Updates `stellar-xdr` to the latest commit and updates `ethnum` to `1.5.3`.

### Why

`ethnum` has a patch in `1.5.3` to prevent compiler errors against nightly. See https://github.com/stellar/rs-stellar-xdr/pull/525

### Known limitations

None