### PR TITLE
Return error when invoking account addresses as contracts

### DIFF
--- a/soroban-env-host/observations/test__invocation__invoke_with_account_address_err.json
+++ b/soroban-env-host/observations/test__invocation__invoke_with_account_address_err.json
@@ -1,0 +1,10 @@
+{
+  "   0 begin": "cpu:14488, mem:0, prngs:-/9b4a753, objs:-/-, vm:-/-, evt:-, store:-/-, foot:-, stk:-, auth:-/-",
+  "   1 call vec_new()": "cpu:14930, mem:80, objs:-/1@ad26cd6b",
+  "   2 ret vec_new -> Ok(Vec(obj#3))": "cpu:15433, mem:160, objs:-/2@c68e8e8a",
+  "   3 call try_call(Address(obj#1), Symbol(go), Vec(obj#3))": "",
+  "   4 ret try_call -> Ok(Error(Context, InvalidAction))": "cpu:16246, mem:176",
+  "   5 call call(Address(obj#1), Symbol(go), Vec(obj#3))": "",
+  "   6 ret call -> Err(Error(Object, InvalidInput))": "cpu:17059, mem:192",
+  "   7 end": "cpu:17059, mem:192, prngs:-/9b4a753, objs:-/2@c68e8e8a, vm:-/-, evt:-, store:-/-, foot:-, stk:-, auth:-/-"
+}

--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -2589,12 +2589,18 @@ impl VmCallerEnv for Host {
         let argvec = self.call_args_from_obj(args)?;
         // this is the recommended path of calling a contract, with `reentry`
         // always set `ContractReentryMode::Prohibited`
-        let res = self.call_n_internal(
-            &self.contract_id_from_address(contract_address)?,
-            func,
-            argvec.as_slice(),
-            CallParams::default_external_call(),
-        );
+        // Treat non-contract `contract_address` errors as a contract call failure, as
+        // from the guest's perspective everything is an Address
+        let res = self
+            .contract_id_from_address(contract_address)
+            .and_then(|contract_id| {
+                self.call_n_internal(
+                    &contract_id,
+                    func,
+                    argvec.as_slice(),
+                    CallParams::default_external_call(),
+                )
+            });
         if let Err(e) = &res {
             self.error(
                 e.error,
@@ -2627,12 +2633,18 @@ impl VmCallerEnv for Host {
         // TODO: A `reentry` flag will be passed from `try_call` into here.
         // For now, we are passing in `ContractReentryMode::Prohibited` to disable
         // reentry.
-        let res = self.call_n_internal(
-            &self.contract_id_from_address(contract_address)?,
-            func,
-            argvec.as_slice(),
-            CallParams::default_external_call(),
-        );
+        // Treat `contract_id_from_address` errors as a recoverable contract call
+        // failure, as from the guest's perspective everything is an Address
+        let res = self
+            .contract_id_from_address(contract_address)
+            .and_then(|contract_id| {
+                self.call_n_internal(
+                    &contract_id,
+                    func,
+                    argvec.as_slice(),
+                    CallParams::default_external_call(),
+                )
+            });
         match res {
             Ok(rv) => Ok(rv),
             Err(e) => {

--- a/soroban-env-host/src/test/invocation.rs
+++ b/soroban-env-host/src/test/invocation.rs
@@ -2,7 +2,7 @@ use std::{cmp::Ordering, rc::Rc};
 
 use expect_test::expect;
 use soroban_env_common::{
-    xdr::{self, ContractCostType, ScError, ScErrorCode},
+    xdr::{self, AccountId, ContractCostType, PublicKey, ScAddress, ScError, ScErrorCode, Uint256},
     Compare, Env, EnvBase, TryFromVal, TryIntoVal, Val,
 };
 
@@ -201,6 +201,49 @@ fn invoke_cross_contract_indirect_err() -> Result<(), HostError> {
     // run `UPDATE_EXPECT=true cargo test` to update this.
     let expected = expect![[
         r#"[Diagnostic Event] topics:[error, Error(WasmVm, InvalidAction)], data:["contract call failed", add_with, [2147483647, 1, Bytes()]]"#
+    ]];
+    let actual = format!("{}", last_event);
+    expected.assert_eq(&actual);
+
+    Ok(())
+}
+
+#[test]
+fn invoke_with_account_address_err() -> Result<(), HostError> {
+    let host = observe_host!(Host::test_host_with_recording_footprint());
+    host.enable_debug()?;
+    let account_address = host.add_host_object(ScAddress::Account(AccountId(
+        PublicKey::PublicKeyTypeEd25519(Uint256([1; 32])),
+    )))?;
+    let sym = Symbol::try_from_small_str("go")?;
+    let args = host.vec_new()?;
+
+    // try call -- address conversion will fail but we should get a recoverable error, not a trap
+    let res = host.try_call(account_address, sym, args)?;
+    let expected = Error::from_type_and_code(ScErrorType::Context, ScErrorCode::InvalidAction);
+    assert!(res.shallow_eq(&expected.to_val()));
+
+    let events = host.get_events()?.0;
+    let last_event: &HostEvent = events.last().unwrap();
+    // run `UPDATE_EXPECT=true cargo test` to update this.
+    let expected = expect![[
+        r#"[Diagnostic Event] topics:[error, Error(Object, InvalidInput)], data:["contract try_call failed", go, []]"#
+    ]];
+    let actual = format!("{}", last_event);
+    expected.assert_eq(&actual);
+
+    // call -- address conversion will fail like a contract call error
+    let res = host.call(account_address, sym, args);
+    assert!(HostError::result_matches_err(
+        res,
+        (ScErrorType::Object, ScErrorCode::InvalidInput)
+    ));
+
+    let events = host.get_events()?.0;
+    let last_event: &HostEvent = events.last().unwrap();
+    // run `UPDATE_EXPECT=true cargo test` to update this.
+    let expected = expect![[
+        r#"[Diagnostic Event] topics:[error, Error(Object, InvalidInput)], data:["contract call failed", go, []]"#
     ]];
     let actual = format!("{}", last_event);
     expected.assert_eq(&actual);


### PR DESCRIPTION
### What

Updates contract invocation so `try_call` returns the default contract call host error when given an account Address instead of a contract Address.

Updates `call` to use the same logic, so diagnostic events remain consistent.

### Why

Fixes: #1683

This aligns errors to be along the mental modal of an account address is just an address with no invokable functions.

### Known limitations

- If we disagree this is the correct approach, we can instead return the invalid action error directly when parsing `contract_id` in `try_call` only, and leave `call` untouched. These errors will not appear in the diagnostics.
```rust
Ok(Error::from_type_and_code(
    ScErrorType::Context,
    ScErrorCode::InvalidAction,
)
.to_val())
```
