### PR TITLE
Update stellar-xdr, enable cap_0083, and bump to 27.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1798,7 +1798,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "26.0.0"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=a749b69b3471aec0c20ec431b0297f3414d66421#a749b69b3471aec0c20ec431b0297f3414d66421"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=deae51ba0eb4d13e287fb036c0ee9d8ed8ab9560#deae51ba0eb4d13e287fb036c0ee9d8ed8ab9560"
 dependencies = [
  "arbitrary",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1589,7 +1589,7 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "soroban-bench-utils"
-version = "26.1.2"
+version = "27.0.0"
 dependencies = [
  "perf-event",
  "soroban-env-common",
@@ -1599,7 +1599,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "26.1.2"
+version = "27.0.0"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1609,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "26.1.2"
+version = "27.0.0"
 dependencies = [
  "arbitrary",
  "crate-git-revision",
@@ -1628,7 +1628,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "26.1.2"
+version = "27.0.0"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -1636,7 +1636,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "26.1.2"
+version = "27.0.0"
 dependencies = [
  "arbitrary",
  "ark-bls12-381",
@@ -1696,7 +1696,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "26.1.2"
+version = "27.0.0"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1709,7 +1709,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-fuzz-targets"
-version = "26.1.2"
+version = "27.0.0"
 dependencies = [
  "arbitrary",
  "soroban-env-host",
@@ -1720,7 +1720,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-simulation"
-version = "26.1.2"
+version = "27.0.0"
 dependencies = [
  "anyhow",
  "expect-test",
@@ -1735,7 +1735,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-synth-wasm"
-version = "26.1.2"
+version = "27.0.0"
 dependencies = [
  "arbitrary",
  "expect-test",
@@ -1749,7 +1749,7 @@ dependencies = [
 
 [[package]]
 name = "soroban-test-wasms"
-version = "26.1.2"
+version = "27.0.0"
 
 [[package]]
 name = "soroban-wasmi"
@@ -1853,7 +1853,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "test_no_std"
-version = "26.1.2"
+version = "27.0.0"
 dependencies = [
  "soroban-env-common",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,15 +21,15 @@ exclude = ["soroban-test-wasms/wasm-workspace"]
 # NB: When bumping the major version make sure to clean up the
 # code guarded by `unstable-*` features to make it enabled
 # unconditionally.
-version = "26.1.2"
+version = "27.0.0"
 rust-version = "1.84.0"
 
 [workspace.dependencies]
-soroban-env-common = { version = "=26.1.2", path = "soroban-env-common", default-features = false }
-soroban-env-guest = { version = "=26.1.2", path = "soroban-env-guest" }
-soroban-env-host = { version = "=26.1.2", path = "soroban-env-host" }
-soroban-env-macros = { version = "=26.1.2", path = "soroban-env-macros" }
-soroban-builtin-sdk-macros = { version = "=26.1.2", path = "soroban-builtin-sdk-macros" }
+soroban-env-common = { version = "=27.0.0", path = "soroban-env-common", default-features = false }
+soroban-env-guest = { version = "=27.0.0", path = "soroban-env-guest" }
+soroban-env-host = { version = "=27.0.0", path = "soroban-env-host" }
+soroban-env-macros = { version = "=27.0.0", path = "soroban-env-macros" }
+soroban-builtin-sdk-macros = { version = "=27.0.0", path = "soroban-builtin-sdk-macros" }
 # NB: this must match the wasmparser version wasmi is using
 wasmparser = "=0.116.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,9 +37,9 @@ wasmparser = "=0.116.1"
 [workspace.dependencies.stellar-xdr]
 version = "=26.0.0"
 git = "https://github.com/stellar/rs-stellar-xdr"
-rev = "a749b69b3471aec0c20ec431b0297f3414d66421"
+rev = "deae51ba0eb4d13e287fb036c0ee9d8ed8ab9560"
 default-features = false
-features = ["cap_0071"]
+features = ["cap_0071", "cap_0083"]
 
 [workspace.dependencies.wasmi]
 package = "soroban-wasmi"


### PR DESCRIPTION
### What

- Updates `stellar-xdr` to [`deae51ba0eb4d13e287fb036c0ee9d8ed8ab9560`](https://github.com/stellar/rs-stellar-xdr/commit/deae51ba0eb4d13e287fb036c0ee9d8ed8ab9560).
- Enables the `cap_0083` feature.
- Bumps the workspace version from `26.1.2` to `27.0.0`.

### Why

Pulls in the latest `stellar-xdr` and turns on `cap_0083`.

The major version bump to `27.0.0` matches the protocol version targeted by `main` (`ledger_protocol_version: 27` in `meta.rs`) and accommodates the breaking API changes introduced by CAP-71 (#1607) — the new `Env`/`VmCallerEnv` trait methods and the changed auto-trait impls on `AuthorizationManager`. This is what the failing `semver-checks` was flagging.

### Known limitations

None