### PR TITLE
Update stellar-xdr to 156759ab

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1798,7 +1798,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "26.0.0"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=deae51ba0eb4d13e287fb036c0ee9d8ed8ab9560#deae51ba0eb4d13e287fb036c0ee9d8ed8ab9560"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=156759ab322dda6976d07435c6f5b70f98e9fd0c#156759ab322dda6976d07435c6f5b70f98e9fd0c"
 dependencies = [
  "arbitrary",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,9 +37,8 @@ wasmparser = "=0.116.1"
 [workspace.dependencies.stellar-xdr]
 version = "=26.0.0"
 git = "https://github.com/stellar/rs-stellar-xdr"
-rev = "deae51ba0eb4d13e287fb036c0ee9d8ed8ab9560"
+rev = "156759ab322dda6976d07435c6f5b70f98e9fd0c"
 default-features = false
-features = ["cap_0071", "cap_0083"]
 
 [workspace.dependencies.wasmi]
 package = "soroban-wasmi"


### PR DESCRIPTION
### What

- Updates `stellar-xdr` to [`156759ab322dda6976d07435c6f5b70f98e9fd0c`](https://github.com/stellar/rs-stellar-xdr/commit/156759ab322dda6976d07435c6f5b70f98e9fd0c).
- Drops the `cap_0071` and `cap_0083` features.

### Why

The new `stellar-xdr` commit no longer gates CAP-71 (delegated auth) types behind the `cap_0071` feature — they're now part of the base XDR — so the feature was removed upstream and can no longer be enabled here. `cap_0083` is dropped as we don't want to include it.

Version stays `26.0.0`. Builds clean and the full workspace test suite passes.

### Known limitations

N/A