### PR TITLE
Update stellar-xdr to 156759ab and drop cap_0071/cap_0083 features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1797,8 +1797,9 @@ dependencies = [
 
 [[package]]
 name = "stellar-xdr"
-version = "26.0.0"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=deae51ba0eb4d13e287fb036c0ee9d8ed8ab9560#deae51ba0eb4d13e287fb036c0ee9d8ed8ab9560"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ff843326969bdf1ef673dcdba94c08f4a3c8f1e58d6e6ef39b1bd4f749179a"
 dependencies = [
  "arbitrary",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,11 +35,10 @@ wasmparser = "=0.116.1"
 
 # NB: When updating, also update the version in rs-soroban-env dev-dependencies
 [workspace.dependencies.stellar-xdr]
-version = "=26.0.0"
-git = "https://github.com/stellar/rs-stellar-xdr"
-rev = "deae51ba0eb4d13e287fb036c0ee9d8ed8ab9560"
+version = "=27.0.0"
+#git = "https://github.com/stellar/rs-stellar-xdr"
+#rev = "156759ab322dda6976d07435c6f5b70f98e9fd0c"
 default-features = false
-features = ["cap_0071", "cap_0083"]
 
 [workspace.dependencies.wasmi]
 package = "soroban-wasmi"


### PR DESCRIPTION
- Bumps stellar-xdr 27.0.0
- Drops cap_0071: CAP-71 types are now in the base XDR (feature removed upstream).
- Drops cap_0083: we need to enable it only for next

