### PR TITLE
Add a recording auth parameter for switching between v1/v2 Address credential recording.

### DIFF
--- a/soroban-env-host/src/e2e_invoke.rs
+++ b/soroban-env-host/src/e2e_invoke.rs
@@ -567,19 +567,31 @@ fn storage_footprint_to_ledger_footprint(
 impl RecordedAuthPayload {
     fn into_auth_entry_with_emulated_signature(
         self,
+        use_address_v2: bool,
     ) -> Result<SorobanAuthorizationEntry, HostError> {
         const EMULATED_SIGNATURE_SIZE: usize = 512;
 
         match (self.address, self.nonce) {
             (Some(address), Some(nonce)) => Ok(SorobanAuthorizationEntry {
-                credentials: SorobanCredentials::AddressV2(SorobanAddressCredentials {
-                    address,
-                    nonce,
-                    signature_expiration_ledger: 0,
-                    signature: ScVal::Bytes(
-                        vec![0_u8; EMULATED_SIGNATURE_SIZE].try_into().unwrap(),
-                    ),
-                }),
+                credentials: if use_address_v2 {
+                    SorobanCredentials::AddressV2(SorobanAddressCredentials {
+                        address,
+                        nonce,
+                        signature_expiration_ledger: 0,
+                        signature: ScVal::Bytes(
+                            vec![0_u8; EMULATED_SIGNATURE_SIZE].try_into().unwrap(),
+                        ),
+                    })
+                } else {
+                    SorobanCredentials::Address(SorobanAddressCredentials {
+                        address,
+                        nonce,
+                        signature_expiration_ledger: 0,
+                        signature: ScVal::Bytes(
+                            vec![0_u8; EMULATED_SIGNATURE_SIZE].try_into().unwrap(),
+                        ),
+                    })
+                },
                 root_invocation: self.invocation,
             }),
             (None, None) => Ok(SorobanAuthorizationEntry {
@@ -606,14 +618,41 @@ fn clear_signature(auth_entry: &mut SorobanAuthorizationEntry) {
 }
 
 #[cfg(any(test, feature = "recording_mode"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub struct RecordingInvocationAuthParams {
+    pub disable_non_root_auth: bool,
+    pub use_address_v2: bool,
+}
+
+#[cfg(any(test, feature = "recording_mode"))]
+impl RecordingInvocationAuthParams {
+    pub const fn new(disable_non_root_auth: bool, use_address_v2: bool) -> Self {
+        Self {
+            disable_non_root_auth,
+            use_address_v2,
+        }
+    }
+}
+
+#[cfg(any(test, feature = "recording_mode"))]
 /// Defines the authorization mode for the `invoke_host_function_in_recording_mode`.
 pub enum RecordingInvocationAuthMode {
     /// Use enforcing auth and pass the signed authorization entries to be used.
     Enforcing(Vec<SorobanAuthorizationEntry>),
     /// Use recording auth and determine whether non-root authorization is
-    /// disabled (i.e. non-root auth is not allowed when `true` is passed to
-    /// the enum).
-    Recording(bool),
+    /// disabled, and whether recorded auth should use `AddressV2`
+    /// credentials.
+    Recording(RecordingInvocationAuthParams),
+}
+
+#[cfg(any(test, feature = "recording_mode"))]
+impl RecordingInvocationAuthMode {
+    pub const fn recording(disable_non_root_auth: bool, use_address_v2: bool) -> Self {
+        Self::Recording(RecordingInvocationAuthParams::new(
+            disable_non_root_auth,
+            use_address_v2,
+        ))
+    }
 }
 
 /// Invokes a host function within a fresh host instance in 'recording' mode.
@@ -663,7 +702,11 @@ pub fn invoke_host_function_in_recording_mode(
 ) -> Result<InvokeHostFunctionRecordingModeResult, HostError> {
     let storage = Storage::with_recording_footprint(ledger_snapshot.clone());
     let host = Host::with_storage_and_budget(storage, budget.clone());
-    let is_recording_auth = matches!(auth_mode, RecordingInvocationAuthMode::Recording(_));
+    let recording_auth = match &auth_mode {
+        RecordingInvocationAuthMode::Recording(recording_auth) => Some(*recording_auth),
+        RecordingInvocationAuthMode::Enforcing(_) => None,
+    };
+    let is_recording_auth = recording_auth.is_some();
     let ledger_seq = ledger_info.sequence_number;
     let min_live_until_ledger = ledger_info
         .min_live_until_ledger_checked(ContractDataDurability::Persistent)
@@ -683,8 +726,8 @@ pub fn invoke_host_function_in_recording_mode(
         RecordingInvocationAuthMode::Enforcing(auth_entries) => {
             host.set_authorization_entries(auth_entries.clone())?;
         }
-        RecordingInvocationAuthMode::Recording(disable_non_root_auth) => {
-            host.switch_to_recording_auth(*disable_non_root_auth)?;
+        RecordingInvocationAuthMode::Recording(recording_auth) => {
+            host.switch_to_recording_auth(recording_auth.disable_non_root_auth)?;
         }
     }
 
@@ -706,7 +749,20 @@ pub fn invoke_host_function_in_recording_mode(
         let recorded_auth = host.get_recorded_auth_payloads()?;
         recorded_auth
             .into_iter()
-            .map(|a| a.into_auth_entry_with_emulated_signature())
+            .map(|a| {
+                a.into_auth_entry_with_emulated_signature(
+                    recording_auth
+                        .ok_or_else(|| {
+                            host.err(
+                                ScErrorType::Context,
+                                ScErrorCode::InternalError,
+                                "expected to have recording auth info in recording mode",
+                                &[],
+                            )
+                        })?
+                        .use_address_v2,
+                )
+            })
             .collect::<Result<Vec<SorobanAuthorizationEntry>, HostError>>()?
     };
 

--- a/soroban-env-host/src/e2e_invoke.rs
+++ b/soroban-env-host/src/e2e_invoke.rs
@@ -647,6 +647,11 @@ pub enum RecordingInvocationAuthMode {
 
 #[cfg(any(test, feature = "recording_mode"))]
 impl RecordingInvocationAuthMode {
+    /// Convenience constructor for recording auth mode.
+    ///
+    /// - `disable_non_root_auth`: when `true`, non-root authorization is not allowed during recording.
+    /// - `use_address_v2`: when `true`, recorded authorization uses `AddressV2` credentials;
+    ///   otherwise it uses `Address` credentials.
     pub const fn recording(disable_non_root_auth: bool, use_address_v2: bool) -> Self {
         Self::Recording(RecordingInvocationAuthParams::new(
             disable_non_root_auth,

--- a/soroban-env-host/src/test/e2e_tests.rs
+++ b/soroban-env-host/src/test/e2e_tests.rs
@@ -514,7 +514,7 @@ fn invoke_host_function_using_simulation_with_signers(
         enable_diagnostics,
         host_fn,
         source_account,
-        RecordingInvocationAuthMode::Recording(true),
+        RecordingInvocationAuthMode::recording(true, true),
         ledger_info,
         ledger_entries_with_ttl.clone(),
         prng_seed,
@@ -770,7 +770,7 @@ fn test_run_out_of_budget_before_calling_host_in_recording_mode() {
         true,
         &upload_wasm_host_fn(ADD_I32),
         &get_account_id([0; 32]),
-        RecordingInvocationAuthMode::Recording(true),
+        RecordingInvocationAuthMode::recording(true, true),
         &default_ledger_info(),
         vec![],
         &prng_seed(),
@@ -860,7 +860,7 @@ fn test_wasm_upload_success_in_recording_mode() {
         false,
         &upload_wasm_host_fn(ADD_I32),
         &get_account_id([123; 32]),
-        RecordingInvocationAuthMode::Recording(true),
+        RecordingInvocationAuthMode::recording(true, true),
         &ledger_info,
         vec![],
         &prng_seed(),
@@ -915,7 +915,7 @@ fn test_wasm_upload_failure_in_recording_mode() {
         true,
         &upload_wasm_host_fn(&[0_u8; 1000]),
         &get_account_id([123; 32]),
-        RecordingInvocationAuthMode::Recording(true),
+        RecordingInvocationAuthMode::recording(true, true),
         &ledger_info,
         vec![],
         &prng_seed(),
@@ -953,7 +953,7 @@ fn test_unsupported_wasm_upload_failure_in_recording_mode() {
         true,
         &upload_wasm_host_fn(ADD_F32),
         &get_account_id([123; 32]),
-        RecordingInvocationAuthMode::Recording(true),
+        RecordingInvocationAuthMode::recording(true, true),
         &ledger_info,
         vec![],
         &prng_seed(),
@@ -1407,7 +1407,7 @@ fn test_create_contract_success_in_recording_mode() {
         true,
         &cd.host_fn,
         &cd.deployer,
-        RecordingInvocationAuthMode::Recording(true),
+        RecordingInvocationAuthMode::recording(true, true),
         &ledger_info,
         vec![(
             cd.wasm_entry.clone(),
@@ -1496,7 +1496,7 @@ fn test_create_contract_success_in_recording_mode_with_custom_account() {
         true,
         &cd.host_fn,
         &cd.deployer,
-        RecordingInvocationAuthMode::Recording(true),
+        RecordingInvocationAuthMode::recording(true, true),
         &ledger_info,
         vec![
             (
@@ -2040,7 +2040,7 @@ fn test_invoke_contract_with_storage_ops_success_in_recording_mode() {
         true,
         &host_fn,
         &cd.deployer,
-        RecordingInvocationAuthMode::Recording(true),
+        RecordingInvocationAuthMode::recording(true, true),
         &ledger_info,
         vec![
             (
@@ -2121,7 +2121,7 @@ fn test_invoke_contract_with_storage_ops_success_in_recording_mode() {
         true,
         &extend_host_fn,
         &cd.deployer,
-        RecordingInvocationAuthMode::Recording(true),
+        RecordingInvocationAuthMode::recording(true, true),
         &ledger_info,
         vec![
             (
@@ -2393,7 +2393,7 @@ fn test_auto_restore_with_extension_in_recording_mode() {
         true,
         &host_fn,
         &cd.deployer,
-        RecordingInvocationAuthMode::Recording(true),
+        RecordingInvocationAuthMode::recording(true, true),
         &ledger_info,
         le_with_ttl.clone(),
         &prng_seed(),
@@ -2535,7 +2535,7 @@ fn test_auto_restore_with_overwrite_in_recording_mode() {
         true,
         &host_fn,
         &cd.deployer,
-        RecordingInvocationAuthMode::Recording(true),
+        RecordingInvocationAuthMode::recording(true, true),
         &ledger_info,
         le_with_ttl.clone(),
         &prng_seed(),
@@ -2664,7 +2664,7 @@ fn test_auto_restore_with_new_entry_in_recording_mode() {
         true,
         &host_fn,
         &cd.deployer,
-        RecordingInvocationAuthMode::Recording(true),
+        RecordingInvocationAuthMode::recording(true, true),
         &ledger_info,
         le_with_ttl.clone(),
         &prng_seed(),
@@ -2795,7 +2795,7 @@ fn test_auto_restore_with_expired_temp_entry_in_recording_mode() {
         true,
         &host_fn,
         &cd.deployer,
-        RecordingInvocationAuthMode::Recording(true),
+        RecordingInvocationAuthMode::recording(true, true),
         &ledger_info,
         vec![
             (
@@ -2922,7 +2922,7 @@ fn test_auto_restore_with_recreated_temp_entry_in_recording_mode() {
         true,
         &host_fn,
         &cd.deployer,
-        RecordingInvocationAuthMode::Recording(true),
+        RecordingInvocationAuthMode::recording(true, true),
         &ledger_info,
         vec![
             (
@@ -3065,7 +3065,7 @@ fn test_invoke_contract_with_storage_ops_success_using_simulation() {
         true,
         &extend_host_fn,
         &cd.deployer,
-        RecordingInvocationAuthMode::Recording(true),
+        RecordingInvocationAuthMode::recording(true, true),
         &ledger_info,
         vec![
             (

--- a/soroban-simulation/src/test/simulation.rs
+++ b/soroban-simulation/src/test/simulation.rs
@@ -117,7 +117,7 @@ fn test_simulate_upload_wasm() {
         &SimulationAdjustmentConfig::no_adjustments(),
         &ledger_info,
         upload_wasm_host_fn(ADD_I32),
-        RecordingInvocationAuthMode::Recording(true),
+        RecordingInvocationAuthMode::recording(true, true),
         &source_account,
         [1; 32],
         true,
@@ -179,7 +179,7 @@ fn test_simulate_upload_wasm() {
         &test_adjustment_config(),
         &ledger_info,
         upload_wasm_host_fn(ADD_I32),
-        RecordingInvocationAuthMode::Recording(true),
+        RecordingInvocationAuthMode::recording(true, true),
         &source_account,
         [1; 32],
         true,
@@ -245,7 +245,7 @@ fn test_simulation_returns_insufficient_budget_error() {
         &SimulationAdjustmentConfig::no_adjustments(),
         &ledger_info,
         upload_wasm_host_fn(ADD_I32),
-        RecordingInvocationAuthMode::Recording(true),
+        RecordingInvocationAuthMode::recording(true, true),
         &source_account,
         [1; 32],
         true,
@@ -279,7 +279,7 @@ fn test_simulation_returns_logic_error() {
         &SimulationAdjustmentConfig::no_adjustments(),
         &ledger_info,
         upload_wasm_host_fn(&bad_wasm),
-        RecordingInvocationAuthMode::Recording(true),
+        RecordingInvocationAuthMode::recording(true, true),
         &source_account,
         [1; 32],
         true,
@@ -320,7 +320,7 @@ fn test_simulate_create_contract() {
         &SimulationAdjustmentConfig::no_adjustments(),
         &ledger_info,
         contract.host_fn.clone(),
-        RecordingInvocationAuthMode::Recording(true),
+        RecordingInvocationAuthMode::recording(true, true),
         &source_account,
         [1; 32],
         true,
@@ -464,7 +464,7 @@ fn test_simulate_invoke_contract_with_auth() {
         &SimulationAdjustmentConfig::no_adjustments(),
         &ledger_info,
         host_fn,
-        RecordingInvocationAuthMode::Recording(true),
+        RecordingInvocationAuthMode::recording(true, true),
         &source_account,
         [1; 32],
         true,
@@ -568,6 +568,118 @@ fn test_simulate_invoke_contract_with_auth() {
 }
 
 #[test]
+fn test_simulate_invoke_contract_with_auth_using_address_credentials() {
+    let contracts = vec![
+        CreateContractData::new([1; 32], AUTH_TEST_CONTRACT),
+        CreateContractData::new([2; 32], AUTH_TEST_CONTRACT),
+        CreateContractData::new([3; 32], AUTH_TEST_CONTRACT),
+        CreateContractData::new([4; 32], AUTH_TEST_CONTRACT),
+    ];
+
+    let tree = AuthContractInvocationNode {
+        address: contracts[0].contract_address.clone(),
+        children: vec![
+            AuthContractInvocationNode {
+                address: contracts[1].contract_address.clone(),
+                children: vec![AuthContractInvocationNode {
+                    address: contracts[2].contract_address.clone(),
+                    children: vec![AuthContractInvocationNode {
+                        address: contracts[3].contract_address.clone(),
+                        children: vec![],
+                    }],
+                }],
+            },
+            AuthContractInvocationNode {
+                address: contracts[2].contract_address.clone(),
+                children: vec![
+                    AuthContractInvocationNode {
+                        address: contracts[1].contract_address.clone(),
+                        children: vec![],
+                    },
+                    AuthContractInvocationNode {
+                        address: contracts[3].contract_address.clone(),
+                        children: vec![],
+                    },
+                ],
+            },
+        ],
+    };
+    let source_account = get_account_id([123; 32]);
+    let other_account = get_account_id([124; 32]);
+    let host_fn = auth_contract_invocation(
+        vec![
+            ScAddress::Account(source_account.clone()),
+            ScAddress::Account(other_account.clone()),
+        ],
+        tree.clone(),
+    );
+    let ledger_info = default_ledger_info();
+    let network_config = default_network_config();
+    let snapshot_source = Rc::new(
+        MockSnapshotSource::from_entries(vec![
+            (
+                contracts[0].wasm_entry.clone(),
+                Some(ledger_info.sequence_number + 100),
+            ),
+            (
+                contracts[0].contract_entry.clone(),
+                Some(ledger_info.sequence_number + 1000),
+            ),
+            (
+                contracts[1].contract_entry.clone(),
+                Some(ledger_info.sequence_number + 1000),
+            ),
+            (
+                contracts[2].contract_entry.clone(),
+                Some(ledger_info.sequence_number + 1000),
+            ),
+            (
+                contracts[3].contract_entry.clone(),
+                Some(ledger_info.sequence_number + 1000),
+            ),
+            (account_entry(&other_account), None),
+        ])
+        .unwrap(),
+    );
+
+    let res = simulate_invoke_host_function_op(
+        snapshot_source,
+        &network_config,
+        &SimulationAdjustmentConfig::no_adjustments(),
+        &ledger_info,
+        host_fn,
+        RecordingInvocationAuthMode::recording(true, false),
+        &source_account,
+        [1; 32],
+        true,
+    )
+    .unwrap();
+    assert_eq!(res.invoke_result.unwrap(), ScVal::Void);
+
+    let other_account_address = ScAddress::Account(other_account.clone());
+    let other_account_nonce = 1039859045797838027;
+    let expected_auth_tree = tree.into_authorized_invocation();
+    assert_eq!(
+        res.auth,
+        vec![
+            SorobanAuthorizationEntry {
+                credentials: SorobanCredentials::SourceAccount,
+                root_invocation: expected_auth_tree.clone(),
+            },
+            SorobanAuthorizationEntry {
+                credentials: SorobanCredentials::Address(SorobanAddressCredentials {
+                    address: other_account_address,
+                    nonce: other_account_nonce,
+                    signature_expiration_ledger: 0,
+                    signature: ScVal::Void,
+                }),
+                root_invocation: expected_auth_tree,
+            }
+        ]
+    );
+}
+
+#[test]
 fn test_simulate_invoke_contract_with_autorestore() {
     let contracts = vec![
         CreateContractData::new([1; 32], AUTH_TEST_CONTRACT),
@@ -613,7 +725,7 @@ fn test_simulate_invoke_contract_with_autorestore() {
         &SimulationAdjustmentConfig::no_adjustments(),
         &ledger_info,
         host_fn,
-        RecordingInvocationAuthMode::Recording(true),
+        RecordingInvocationAuthMode::recording(true, true),
         &source_account,
         [1; 32],
         true,
@@ -1279,7 +1391,7 @@ fn test_simulate_successful_sac_call() {
         &SimulationAdjustmentConfig::no_adjustments(),
         &ledger_info,
         host_fn,
-        RecordingInvocationAuthMode::Recording(true),
+        RecordingInvocationAuthMode::recording(true, true),
         &source_account,
         [1; 32],
         true,
@@ -1417,7 +1529,7 @@ fn test_simulate_unsuccessful_sac_call_with_try_call() {
         &SimulationAdjustmentConfig::no_adjustments(),
         &ledger_info,
         host_fn,
-        RecordingInvocationAuthMode::Recording(true),
+        RecordingInvocationAuthMode::recording(true, true),
         &source_account,
         [1; 32],
         true,


### PR DESCRIPTION
### What

Add a recording auth parameter for switching between v1/v2 Address credential recording.

### Why

This will allow RPC to select the preferred mode when calling simulation, which in turns allows testing v2 credentials in RPC without a hard protocol-based switch.

### Known limitations

This is a breaking change, which should be fine given that it's going to be included in a major release.
