### PR TITLE
Gate cap_0083 XDR under the next feature

### DIFF
--- a/soroban-env-common/Cargo.toml
+++ b/soroban-env-common/Cargo.toml
@@ -37,7 +37,10 @@ std = ["stellar-xdr/std", "stellar-xdr/base64"]
 serde = ["dep:serde", "stellar-xdr/serde"]
 wasmi = ["dep:wasmi", "dep:wasmparser"]
 testutils = ["dep:arbitrary", "stellar-xdr/arbitrary"]
-next = ["soroban-env-macros/next"]
+# `next` also enables the gated XDR of CAPs targeting the next protocol. Each
+# cap_XXXX entry becomes unconditional (moved to the workspace stellar-xdr
+# dep) at the protocol bump, and is removed once folded into the base XDR.
+next = ["soroban-env-macros/next", "stellar-xdr/cap_0083"]
 tracy = ["dep:tracy-client"]
 shallow-val-hash = []
 


### PR DESCRIPTION
### What

Enable `stellar-xdr/cap_0083` through soroban-env-common's `next` feature, so next-enabled builds compile in the CAP-83 XDR while production builds keep it excluded. No `Cargo.lock` change; verified `cargo check -p soroban-env-host` passes with and without `--features next`.

### Why

Follow-up to #1687, which dropped the hardcoded `cap_0083` feature but left no way to enable it at all — core's vnext builds (which enable the CAP-83 XDR on the C++ side) had no matching knob for the host. Core already passes `--features next` to the max-protocol host in vnext builds, so no core changes are needed.

Going forward, gated XDR features for next-protocol CAPs ride `next`: each entry becomes unconditional at the protocol bump and is removed once folded into the base XDR upstream (documented in the Cargo.toml comment).