### PR TITLE
Update crate-git-revision to 0.0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,6 +392,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "crate-git-revision"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54851b5b3f24621804b1cded2820975623c205e3055d2d44031cdb1237339ac8"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
 name = "crypto-bigint"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1612,7 +1623,7 @@ name = "soroban-env-common"
 version = "27.0.0"
 dependencies = [
  "arbitrary",
- "crate-git-revision",
+ "crate-git-revision 0.0.9",
  "ethnum",
  "num-derive",
  "num-traits",
@@ -1791,7 +1802,7 @@ version = "0.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee1832fb50c651ad10f734aaf5d31ca5acdfb197a6ecda64d93fcdb8885af913"
 dependencies = [
- "crate-git-revision",
+ "crate-git-revision 0.0.6",
  "data-encoding",
 ]
 
@@ -1804,7 +1815,7 @@ dependencies = [
  "arbitrary",
  "base64 0.22.1",
  "cfg_eval",
- "crate-git-revision",
+ "crate-git-revision 0.0.6",
  "escape-bytes",
  "ethnum",
  "hex",

--- a/deny.toml
+++ b/deny.toml
@@ -245,6 +245,7 @@ deny = [
 skip = [
     { name = "hashbrown", version = "=0.14.1" },
     { name = "syn", version = "=1.0.109" },
+    { name = "crate-git-revision", version = "=0.0.6" },
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive

--- a/soroban-env-common/Cargo.toml
+++ b/soroban-env-common/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 rust-version.workspace = true
 
 [build-dependencies]
-crate-git-revision = "0.0.6"
+crate-git-revision = "0.0.9"
 
 [dependencies]
 soroban-env-macros = { workspace = true }


### PR DESCRIPTION
### What

Bump the `crate-git-revision` build dependency of `soroban-env-common` from 0.0.6 to 0.0.9 and refresh `Cargo.lock` accordingly.

### Why

Keeps the build-time git revision tooling current with the latest published release.

### Known limitations

Because `0.0.x` releases are not semver-compatible with one another, the transitive `^0.0.6` requirement pulled in by `stellar-strkey` remains pinned to 0.0.6, so the lockfile now legitimately carries both 0.0.6 and 0.0.9. That will disappear when stellar-strkey also gets updated everywhere. A one-line skip for the 0.0.6 duplicate was added to `deny.toml` (mirroring the existing skips) so `cargo-deny`'s bans check passes.