### PR TITLE
Update stellar-strkey to 0.0.16

### DIFF
--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -18,7 +18,7 @@ soroban-builtin-sdk-macros = { workspace = true }
 soroban-env-common = { workspace = true, features = ["std", "wasmi", "shallow-val-hash"] }
 wasmi = { workspace = true }
 wasmparser = { workspace = true }
-stellar-strkey = "0.0.13"
+stellar-strkey = "0.0.16"
 static_assertions = "1.1.0"
 sha2 = "0.10.8"
 hex-literal = "0.4.1"


### PR DESCRIPTION
> ⚠️ This change targets versions of software that will ship for **protocol 28**. Do not merge if this repository is not yet ready to accept v28 changes.

### What

Bump the `stellar-strkey` dependency of `soroban-env-host` from `0.0.13` to `0.0.16`.

### Why

Aligns the strkey dependency with the versions of software shipping for protocol 28.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BoLJbUXtP9Z7b64Toh9FG8)_