### PR TITLE
Update stellar-strkey to 0.0.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1841,7 +1841,8 @@ dependencies = [
 [[package]]
 name = "stellar-strkey"
 version = "0.0.18"
-source = "git+https://github.com/stellar/rs-stellar-strkey?rev=73bf43778a4acad5e7b3589f54a5ec3607c4b7b1#73bf43778a4acad5e7b3589f54a5ec3607c4b7b1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f34ff61c0ca6f1c2b4169e8d1633417bd9225f58b6175e4e317204565d16277"
 dependencies = [
  "crate-git-revision 0.0.9",
  "data-encoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1720,7 +1720,7 @@ dependencies = [
  "soroban-test-wasms",
  "soroban-wasmi",
  "static_assertions",
- "stellar-strkey 0.0.17",
+ "stellar-strkey 0.0.18",
  "tabwriter",
  "textplots",
  "thousands",
@@ -1840,9 +1840,8 @@ dependencies = [
 
 [[package]]
 name = "stellar-strkey"
-version = "0.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0247b168bdee20244445e3d9cdea697dde6211e88742dd04acfd1b498661e936"
+version = "0.0.18"
+source = "git+https://github.com/stellar/rs-stellar-strkey?rev=73bf43778a4acad5e7b3589f54a5ec3607c4b7b1#73bf43778a4acad5e7b3589f54a5ec3607c4b7b1"
 dependencies = [
  "crate-git-revision 0.0.9",
  "data-encoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,6 +298,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes-lit"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,6 +792,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,6 +819,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
+]
+
+[[package]]
+name = "heapless"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+ "zeroize",
 ]
 
 [[package]]
@@ -1694,7 +1720,7 @@ dependencies = [
  "soroban-test-wasms",
  "soroban-wasmi",
  "static_assertions",
- "stellar-strkey",
+ "stellar-strkey 0.0.17",
  "tabwriter",
  "textplots",
  "thousands",
@@ -1791,6 +1817,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1804,6 +1836,18 @@ checksum = "ee1832fb50c651ad10f734aaf5d31ca5acdfb197a6ecda64d93fcdb8885af913"
 dependencies = [
  "crate-git-revision 0.0.6",
  "data-encoding",
+]
+
+[[package]]
+name = "stellar-strkey"
+version = "0.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0247b168bdee20244445e3d9cdea697dde6211e88742dd04acfd1b498661e936"
+dependencies = [
+ "crate-git-revision 0.0.9",
+ "data-encoding",
+ "heapless",
+ "zeroize",
 ]
 
 [[package]]
@@ -1822,7 +1866,7 @@ dependencies = [
  "serde",
  "serde_with",
  "sha2",
- "stellar-strkey",
+ "stellar-strkey 0.0.13",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,12 +53,6 @@ rev = "0ed3f3dee30dc41ebe21972399e0a73a41944aa0"
 # soroban-wasmi = { path = "../wasmi/crates/wasmi/" }
 # soroban-wasmi_core = { path = "../wasmi/crates/core/" }
 
-# Temporary: stellar-strkey 0.0.18 is not yet published to crates.io. Point at
-# the release/v0.0.18 branch so this PR can be validated against the actual
-# 0.0.18 code ahead of the release. Remove once 0.0.18 is published.
-[patch.crates-io]
-stellar-strkey = { git = "https://github.com/stellar/rs-stellar-strkey", rev = "73bf43778a4acad5e7b3589f54a5ec3607c4b7b1" }
-
 [profile.release]
 lto = true
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,12 @@ rev = "0ed3f3dee30dc41ebe21972399e0a73a41944aa0"
 # soroban-wasmi = { path = "../wasmi/crates/wasmi/" }
 # soroban-wasmi_core = { path = "../wasmi/crates/core/" }
 
+# Temporary: stellar-strkey 0.0.18 is not yet published to crates.io. Point at
+# the release/v0.0.18 branch so this PR can be validated against the actual
+# 0.0.18 code ahead of the release. Remove once 0.0.18 is published.
+[patch.crates-io]
+stellar-strkey = { git = "https://github.com/stellar/rs-stellar-strkey", rev = "73bf43778a4acad5e7b3589f54a5ec3607c4b7b1" }
+
 [profile.release]
 lto = true
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ exclude = ["soroban-test-wasms/wasm-workspace"]
 # code guarded by `unstable-*` features to make it enabled
 # unconditionally.
 version = "27.0.0"
-rust-version = "1.84.0"
+rust-version = "1.87.0"
 
 [workspace.dependencies]
 soroban-env-common = { version = "=27.0.0", path = "soroban-env-common", default-features = false }

--- a/cackle.toml
+++ b/cackle.toml
@@ -262,6 +262,11 @@ build.allow_apis = [
 
 [pkg.heapless]
 allow_unsafe = true
+build.allow_apis = [
+    "env",
+    "fs",
+    "process",
+]
 
 [pkg.tracking-allocator]
 allow_unsafe = true

--- a/cackle.toml
+++ b/cackle.toml
@@ -109,6 +109,9 @@ allow_apis = [
 
 [pkg.rand]
 allow_unsafe = true
+allow_apis = [
+    "rand",
+]
 
 [pkg.backtrace]
 allow_apis = [
@@ -144,6 +147,18 @@ allow_unsafe = true
 allow_unsafe = true
 
 [pkg.subtle]
+allow_unsafe = true
+
+[pkg.byteorder]
+allow_unsafe = true
+
+[pkg.hash32]
+allow_unsafe = true
+
+[pkg.stable_deref_trait]
+allow_unsafe = true
+
+[pkg.stellar-strkey]
 allow_unsafe = true
 
 [pkg.zeroize]
@@ -246,11 +261,7 @@ build.allow_apis = [
 ]
 
 [pkg.heapless]
-build.allow_apis = [
-    "env",
-    "fs",
-    "process",
-]
+allow_unsafe = true
 
 [pkg.tracking-allocator]
 allow_unsafe = true

--- a/cackle.toml
+++ b/cackle.toml
@@ -245,6 +245,13 @@ build.allow_apis = [
     "env",
 ]
 
+[pkg.heapless]
+build.allow_apis = [
+    "env",
+    "fs",
+    "process",
+]
+
 [pkg.tracking-allocator]
 allow_unsafe = true
 from.test.allow_apis = [

--- a/deny.toml
+++ b/deny.toml
@@ -246,6 +246,10 @@ skip = [
     { name = "hashbrown", version = "=0.14.1" },
     { name = "syn", version = "=1.0.109" },
     { name = "crate-git-revision", version = "=0.0.6" },
+    # Transitional duplicate: we depend on stellar-strkey 0.0.17 directly while
+    # the published stellar-xdr 27.0.0 still pulls in 0.0.13. This goes away once
+    # the stellar-xdr v28 (protocol-28) release also ships on strkey 0.0.17.
+    { name = "stellar-strkey", version = "=0.0.13" },
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive

--- a/deny.toml
+++ b/deny.toml
@@ -246,9 +246,9 @@ skip = [
     { name = "hashbrown", version = "=0.14.1" },
     { name = "syn", version = "=1.0.109" },
     { name = "crate-git-revision", version = "=0.0.6" },
-    # Transitional duplicate: we depend on stellar-strkey 0.0.17 directly while
+    # Transitional duplicate: we depend on stellar-strkey 0.0.18 directly while
     # the published stellar-xdr 27.0.0 still pulls in 0.0.13. This goes away once
-    # the stellar-xdr v28 (protocol-28) release also ships on strkey 0.0.17.
+    # the stellar-xdr v28 (protocol-28) release also ships on strkey 0.0.18.
     { name = "stellar-strkey", version = "=0.0.13" },
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate

--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -18,7 +18,7 @@ soroban-builtin-sdk-macros = { workspace = true }
 soroban-env-common = { workspace = true, features = ["std", "wasmi", "shallow-val-hash"] }
 wasmi = { workspace = true }
 wasmparser = { workspace = true }
-stellar-strkey = "0.0.13"
+stellar-strkey = "0.0.17"
 static_assertions = "1.1.0"
 sha2 = "0.10.8"
 hex-literal = "0.4.1"

--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -18,7 +18,7 @@ soroban-builtin-sdk-macros = { workspace = true }
 soroban-env-common = { workspace = true, features = ["std", "wasmi", "shallow-val-hash"] }
 wasmi = { workspace = true }
 wasmparser = { workspace = true }
-stellar-strkey = "0.0.17"
+stellar-strkey = "0.0.18"
 static_assertions = "1.1.0"
 sha2 = "0.10.8"
 hex-literal = "0.4.1"

--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 version.workspace = true
 readme = "../README.md"
 edition = "2021"
-rust-version = "1.84.0"
+rust-version = "1.87.0"
 build = "build.rs"
 
 exclude = ["observations/"]

--- a/soroban-env-host/src/crypto/poseidon/poseidon2.rs
+++ b/soroban-env-host/src/crypto/poseidon/poseidon2.rs
@@ -89,7 +89,7 @@ impl<F: MeteredScalar> Poseidon2<F> {
     /// (https://eprint.iacr.org/2023/323)
     fn matmul_m4(&self, host: &Host, state: &mut [F]) -> Result<(), HostError> {
         let t = self.params.t;
-        if t % 4 != 0 {
+        if !t.is_multiple_of(4) {
             return Err(host.error(
                 INVALID_INPUT,
                 "Poseidon2: matmul_m4 state size must be divisible by 4",

--- a/soroban-env-host/src/crypto/poseidon/poseidon2_params.rs
+++ b/soroban-env-host/src/crypto/poseidon/poseidon2_params.rs
@@ -46,7 +46,7 @@ impl<F: MeteredScalar> Poseidon2Params<F> {
                 ],
             ));
         }
-        if rounds_f % 2 != 0 {
+        if !rounds_f.is_multiple_of(2) {
             return Err(host.error(
                 INVALID_INPUT,
                 "Poseidon2: `rounds_f` must be even",

--- a/soroban-env-host/src/crypto/poseidon/poseidon_params.rs
+++ b/soroban-env-host/src/crypto/poseidon/poseidon_params.rs
@@ -46,7 +46,7 @@ impl<S: MeteredScalar> PoseidonParams<S> {
                 ],
             ));
         }
-        if rounds_f % 2 != 0 {
+        if !rounds_f.is_multiple_of(2) {
             return Err(host.error(
                 INVALID_INPUT,
                 "Poseidon: `rounds_f` must be even",

--- a/soroban-env-host/src/host/conversion.rs
+++ b/soroban-env-host/src/host/conversion.rs
@@ -686,7 +686,7 @@ impl Host {
                 ))
             }
         };
-        Ok(strkey.to_string())
+        Ok(strkey.to_string().as_str().to_string())
     }
 
     pub(crate) fn muxed_sc_address_to_strkey(
@@ -708,7 +708,7 @@ impl Host {
                         ed25519: muxed_account.ed25519.0.metered_clone(self)?,
                     },
                 );
-                Ok(strkey.to_string())
+                Ok(strkey.to_string().as_str().to_string())
             }
             _ => Err(self.err(
                 ScErrorType::Object,

--- a/soroban-fuzz-targets/Cargo.toml
+++ b/soroban-fuzz-targets/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Stellar Development Foundation <info@stellar.org>"]
 license = "Apache-2.0"
 version.workspace = true
 edition = "2021"
-rust-version = "1.84.0"
+rust-version = "1.87.0"
 publish = false
 
 [dependencies]


### PR DESCRIPTION
### What

Bumps the direct `stellar-strkey` dependency in `soroban-env-host` from 0.0.13 to 0.0.18, and adapts the two strkey-encoding call sites in `host/conversion.rs` to the new API. In 0.0.17+ the crate is `no_std` by default and `Strkey::to_string()` now returns a fixed-capacity `heapless::String` rather than `std::string::String`, so those sites now convert via `.as_str().to_string()`. The lockfile re-resolves to contain both 0.0.18 (for `soroban-env-host`) and 0.0.13 (transitively via the published `stellar-xdr` 27.0.0, which still pins 0.0.13); the 0.0.13 entry is expected and left in place, and `deny.toml` skips the duplicate.

### Why

This moves `soroban-env-host` onto the stellar-strkey release line targeted for protocol 28.

This supersedes the earlier 0.0.17 bump: 0.0.17 contained a CLI bug (`Decoded<Strkey>` rejected owned JSON keys, breaking `strkey encode`), fixed in 0.0.18 by stellar/rs-stellar-strkey#125.

### Known limitations

N/A

---

## Protocol 28 coordination

⚠️ This change targets versions of software that will ship for **Protocol 28**, and should **not** be merged unless this repository is ready to accept Protocol 28 changes.

This is one of a coordinated set of PRs bumping `stellar-strkey` to **0.0.18** across the Protocol 28 component stack. It is preferred that all Protocol 28 releases of these components depend on the **same** version of `stellar-strkey`:

- stellar/rs-stellar-xdr#547
- stellar/rs-soroban-env#1694
- stellar/rs-soroban-sdk#1913
- stellar/rs-stellar-rpc-client#99
- stellar/stellar-cli#2614

`stellar-strkey` 0.0.18 raises the minimum supported Rust version to 1.87 and updates/adds transitive dependencies (`heapless` 0.9, `zeroize`), so MSRV and supply-chain policy (cargo-deny / cackle) updates may be required in some repositories before CI is green.