### PR TITLE
SPIKE: Protocol 28 (CAP-0084)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1809,8 +1809,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "27.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ff843326969bdf1ef673dcdba94c08f4a3c8f1e58d6e6ef39b1bd4f749179a"
+source = "git+https://github.com/sisuresh/rs-stellar-xdr?rev=bd30d420ce6f63ccd9360e371830384cb84d1c04#bd30d420ce6f63ccd9360e371830384cb84d1c04"
 dependencies = [
  "arbitrary",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,10 @@ wasmparser = "=0.116.1"
 # NB: When updating, also update the version in rs-soroban-env dev-dependencies
 [workspace.dependencies.stellar-xdr]
 version = "=27.0.0"
-#git = "https://github.com/stellar/rs-stellar-xdr"
-#rev = "156759ab322dda6976d07435c6f5b70f98e9fd0c"
+# SPIKE: rs-stellar-xdr#548 (CAP-0084). Fork-hosted branch p28-cap-0084.
+# Productionize -> stellar/rs-stellar-xdr merged SHA (or crates.io version) once #548 lands.
+git = "https://github.com/sisuresh/rs-stellar-xdr"
+rev = "bd30d420ce6f63ccd9360e371830384cb84d1c04"
 default-features = false
 
 [workspace.dependencies.wasmi]

--- a/deny.toml
+++ b/deny.toml
@@ -272,7 +272,10 @@ allow-git = []
 
 [sources.allow-org]
 # 1 or more github.com organizations to allow git sources for
-github = ["stellar"]
+# TEMP CAP-0084 SPIKE: "sisuresh" allows the rs-stellar-xdr#548 fork-rev pin
+# (git+https://github.com/sisuresh/rs-stellar-xdr?rev=bd30d420). Revert when the
+# stellar-xdr dependency re-points to an accepted stellar/rs-stellar-xdr rev.
+github = ["stellar", "sisuresh"]
 # 1 or more gitlab.com organizations to allow git sources for
 # gitlab = [""]
 # 1 or more bitbucket.org organizations to allow git sources for

--- a/soroban-env-common/Cargo.toml
+++ b/soroban-env-common/Cargo.toml
@@ -37,7 +37,10 @@ std = ["stellar-xdr/std", "stellar-xdr/base64"]
 serde = ["dep:serde", "stellar-xdr/serde"]
 wasmi = ["dep:wasmi", "dep:wasmparser"]
 testutils = ["dep:arbitrary", "stellar-xdr/arbitrary"]
-next = ["soroban-env-macros/next"]
+# `next` also enables the gated XDR of CAPs targeting the next protocol. Each
+# cap_XXXX entry becomes unconditional (moved to the workspace stellar-xdr
+# dep) at the protocol bump, and is removed once folded into the base XDR.
+next = ["soroban-env-macros/next", "stellar-xdr/cap_0083", "stellar-xdr/cap_0084"]
 tracy = ["dep:tracy-client"]
 shallow-val-hash = []
 

--- a/soroban-env-host/src/builtin_contracts/base_types.rs
+++ b/soroban-env-host/src/builtin_contracts/base_types.rs
@@ -455,6 +455,11 @@ impl TryFromVal<Host, ScAddress> for MuxedAddress {
                 let obj = env.add_host_object(MuxedScAddress(addr.clone()))?;
                 MuxedAddress::try_from_val(env, &obj)
             }
+            #[cfg(feature = "next")]
+            ScAddress::MuxedContract(_) => {
+                let obj = env.add_host_object(MuxedScAddress(addr.clone()))?;
+                MuxedAddress::try_from_val(env, &obj)
+            }
             _ => {
                 let obj = env.add_host_object(addr.clone())?;
                 MuxedAddress::try_from_val(env, &obj)

--- a/soroban-env-host/src/builtin_contracts/stellar_asset_contract/contract.rs
+++ b/soroban-env-host/src/builtin_contracts/stellar_asset_contract/contract.rs
@@ -75,6 +75,18 @@ fn check_not_issuer(e: &Host, addr: &Address) -> Result<(), HostError> {
     }
 }
 
+// Destination type for SAC `mint`. Under the current protocol it is a plain
+// `Address` (byte-for-byte unchanged). Under `next` (Protocol 28 / CAP-0084) it
+// widens to `MuxedAddress` so a muxed contract can be a mint destination,
+// mirroring `transfer`. This is a cfg'd alias on a single `mint` method rather
+// than two cfg'd `mint` methods because the builtin `#[contractimpl]` dispatch
+// macro keys arms by positional index and discards per-method cfg attributes,
+// so two same-named cfg'd `mint` definitions would desync the dispatch table.
+#[cfg(not(feature = "next"))]
+type MintDestination = Address;
+#[cfg(feature = "next")]
+type MintDestination = MuxedAddress;
+
 #[contractimpl]
 // Metering: covered by components.
 impl StellarAssetContract {
@@ -334,9 +346,16 @@ impl StellarAssetContract {
     }
 
     // Metering: covered by components
-    pub(crate) fn mint(e: &Host, to: Address, amount: i128) -> Result<(), HostError> {
+    pub(crate) fn mint(e: &Host, to: MintDestination, amount: i128) -> Result<(), HostError> {
         let _span = tracy_span!("SAC mint");
         check_nonnegative_amount(e, amount)?;
+        // Under `next`, `to` is a `MuxedAddress`: de-mux to the underlying
+        // address and capture the mux id for the event (mirrors `transfer`).
+        // Under curr, `to` is already a plain `Address` and no mux id is emitted.
+        #[cfg(feature = "next")]
+        let (to, to_muxed_id) = (to.address()?, to.id()?);
+        #[cfg(not(feature = "next"))]
+        let to_muxed_id: Option<u64> = None;
         check_not_issuer(e, &to)?;
 
         let admin = read_administrator(e)?;
@@ -348,7 +367,7 @@ impl StellarAssetContract {
         )?;
 
         receive_balance(e, to.metered_clone(e)?, amount)?;
-        event::mint(e, to, None, amount)?;
+        event::mint(e, to, to_muxed_id, amount)?;
         Ok(())
     }
 

--- a/soroban-env-host/src/builtin_contracts/stellar_asset_contract/test_stellar_asset_contract.rs
+++ b/soroban-env-host/src/builtin_contracts/stellar_asset_contract/test_stellar_asset_contract.rs
@@ -214,6 +214,16 @@ impl<'a> TestStellarAssetContract<'a> {
         self.call_with_single_signer(admin, "mint", test_vec![self.host, to, amount])
     }
 
+    #[cfg(feature = "next")]
+    pub(crate) fn mint_muxed(
+        &self,
+        admin: &TestSigner,
+        to: MuxedAddress,
+        amount: i128,
+    ) -> Result<(), HostError> {
+        self.call_with_single_signer(admin, "mint", test_vec![self.host, to, amount])
+    }
+
     pub(crate) fn clawback(
         &self,
         admin: &TestSigner,

--- a/soroban-env-host/src/builtin_contracts/testutils.rs
+++ b/soroban-env-host/src/builtin_contracts/testutils.rs
@@ -56,6 +56,27 @@ pub(crate) fn contract_id_to_address(host: &Host, contract_id: [u8; 32]) -> Addr
     .unwrap()
 }
 
+// CAP-0084: build a muxed contract address (`ScAddress::MuxedContract`) wrapping
+// the given contract id and multiplexing id, mirroring `TestSigner::muxed_address`
+// for accounts.
+#[cfg(feature = "next")]
+pub(crate) fn muxed_contract_address(
+    host: &Host,
+    contract_id: [u8; 32],
+    mux_id: u64,
+) -> MuxedAddress {
+    use soroban_env_common::xdr::MuxedContract;
+    let sc_address = ScAddress::MuxedContract(MuxedContract {
+        id: mux_id,
+        contract_id: ContractId(Hash(contract_id)),
+    });
+    MuxedAddress::try_from_val(
+        host,
+        &host.add_host_object(MuxedScAddress(sc_address)).unwrap(),
+    )
+    .unwrap()
+}
+
 #[derive(Clone)]
 pub(crate) enum TestSigner {
     AccountInvoker(AccountId),

--- a/soroban-env-host/src/events/mod.rs
+++ b/soroban-env-host/src/events/mod.rs
@@ -42,6 +42,14 @@ fn display_address(addr: &ScAddress, f: &mut std::fmt::Formatter<'_>) -> std::fm
             };
             write!(f, "{}", strkey)
         }
+        // CAP-0084: muxed contracts have no canonical strkey form yet, so this
+        // is a diagnostic-only rendering. In practice muxed contract addresses
+        // are de-muxed before they reach events, making this arm unreachable.
+        #[cfg(feature = "next")]
+        ScAddress::MuxedContract(muxed_contract) => {
+            let strkey = stellar_strkey::Contract(muxed_contract.contract_id.0 .0);
+            write!(f, "{}:{}", strkey, muxed_contract.id)
+        }
         // Note, that claimable balance and liquidity pool types can't normally
         // appear in host, so we have the proper rendering for these here just
         // for consistency (similar to e.g. non-representable ScVal types).

--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -3747,6 +3747,10 @@ impl VmCallerEnv for Host {
                 )));
                 Ok(address)
             }
+            #[cfg(feature = "next")]
+            ScAddress::MuxedContract(muxed_contract) => Ok(ScAddress::Contract(
+                muxed_contract.contract_id.metered_clone(self)?,
+            )),
             _ => Err(self.err(
                 ScErrorType::Object,
                 ScErrorCode::InternalError,
@@ -3764,6 +3768,8 @@ impl VmCallerEnv for Host {
     ) -> Result<U64Val, Self::Error> {
         let mux_id = self.visit_obj(muxed_address, |addr: &MuxedScAddress| match &addr.0 {
             ScAddress::MuxedAccount(muxed_account) => Ok(muxed_account.id),
+            #[cfg(feature = "next")]
+            ScAddress::MuxedContract(muxed_contract) => Ok(muxed_contract.id),
             _ => Err(self.err(
                 ScErrorType::Object,
                 ScErrorCode::InternalError,

--- a/soroban-env-host/src/host/conversion.rs
+++ b/soroban-env-host/src/host/conversion.rs
@@ -629,6 +629,10 @@ impl Host {
                     ScAddress::MuxedAccount(_) => Ok(self
                         .add_host_object(MuxedScAddress(addr.metered_clone(self)?))?
                         .into()),
+                    #[cfg(feature = "next")]
+                    ScAddress::MuxedContract(_) => Ok(self
+                        .add_host_object(MuxedScAddress(addr.metered_clone(self)?))?
+                        .into()),
                     _ => Err(self.err(
                         ScErrorType::Object,
                         ScErrorCode::UnexpectedType,

--- a/soroban-env-host/src/host_object.rs
+++ b/soroban-env-host/src/host_object.rs
@@ -257,6 +257,8 @@ impl HostObjectType for MuxedScAddress {
     fn inject(self, host: &Host) -> Result<HostObject, HostError> {
         match &self.0 {
             xdr::ScAddress::MuxedAccount(_) => Ok(HostObject::MuxedAddress(self)),
+            #[cfg(feature = "next")]
+            xdr::ScAddress::MuxedContract(_) => Ok(HostObject::MuxedAddress(self)),
             _ => Err(host.err(
                 ScErrorType::Object,
                 ScErrorCode::InvalidInput,

--- a/soroban-env-host/src/test/address.rs
+++ b/soroban-env-host/src/test/address.rs
@@ -50,6 +50,32 @@ fn test_muxed_address_to_components_conversion() {
     assert_eq!(mux_id_val, ScVal::U64(123));
 }
 
+// CAP-0084: `get_address_from_muxed_address` / `get_id_from_muxed_address` on a
+// muxed contract return the underlying contract address and the mux id.
+#[cfg(feature = "next")]
+#[test]
+fn test_muxed_contract_to_components_conversion() {
+    use crate::xdr::MuxedContract;
+    let host = observe_host!(Host::test_host());
+    let muxed_address_obj = host
+        .add_host_object(MuxedScAddress(ScAddress::MuxedContract(MuxedContract {
+            id: 456,
+            contract_id: ContractId(Hash([20; 32])),
+        })))
+        .unwrap();
+    let address = host
+        .get_address_from_muxed_address(muxed_address_obj)
+        .unwrap();
+    let mux_id = host.get_id_from_muxed_address(muxed_address_obj).unwrap();
+    let address_val = host.from_host_val(address.into()).unwrap();
+    let mux_id_val = host.from_host_val(mux_id.into()).unwrap();
+    assert_eq!(
+        address_val,
+        ScVal::Address(ScAddress::Contract(ContractId(Hash([20; 32]))))
+    );
+    assert_eq!(mux_id_val, ScVal::U64(456));
+}
+
 #[test]
 fn test_invalid_muxed_address_object_conversions() {
     let host = observe_host!(Host::test_host());

--- a/soroban-env-host/src/test/stellar_asset_contract.rs
+++ b/soroban-env-host/src/test/stellar_asset_contract.rs
@@ -895,6 +895,139 @@ fn test_cap_67_transfer_with_muxed_accounts() {
     );
 }
 
+#[cfg(feature = "next")]
+#[test]
+fn test_cap_84_transfer_with_muxed_contracts() {
+    use crate::builtin_contracts::testutils::muxed_contract_address;
+
+    let test = StellarAssetContractTest::setup(function_name!());
+    // Enable invocation metering to get the events to reset automatically on
+    // every contract call.
+    test.host.enable_invocation_metering();
+    let contract = test.default_stellar_asset_contract();
+
+    let user = TestSigner::account(&test.user_key);
+    test.create_default_account(&user);
+    test.create_default_trustline(&user);
+
+    // The destination is a contract; contracts hold SAC balances without a
+    // trustline. The de-muxed contract address is what the event/balance use.
+    let dst_contract_id = generate_bytes_array(&test.host);
+    let dst_address = contract_id_to_address(&test.host, dst_contract_id);
+
+    contract
+        .mint(
+            &TestSigner::account(&test.issuer_key),
+            user.address(&test.host),
+            100_000_000,
+        )
+        .unwrap();
+
+    let transfer_symbol = Symbol::try_from_small_str("transfer").unwrap().to_val();
+    let token_name = contract.name().unwrap();
+
+    // Transfer from a (non-muxed) account to a muxed contract destination.
+    contract
+        .transfer_muxed(
+            &user,
+            muxed_contract_address(&test.host, dst_contract_id, 0xCAFE),
+            9_999_999,
+        )
+        .unwrap();
+
+    assert_eq!(
+        test.host.get_contract_events().unwrap().0,
+        vec![contract.test_event(
+            test_vec![
+                &test.host,
+                transfer_symbol,
+                user.address(&test.host),
+                // `to` topic is the de-muxed contract address.
+                dst_address.clone(),
+                &token_name,
+            ],
+            test_map![
+                &test.host,
+                ("amount", 9_999_999_i128),
+                ("to_muxed_id", 0xCAFE_u64)
+            ]
+            .into()
+        )]
+    );
+    // Balance credits the underlying contract.
+    assert_eq!(contract.balance(dst_address.clone()).unwrap(), 9_999_999);
+    assert_eq!(
+        contract.balance(user.address(&test.host)).unwrap(),
+        90_000_001
+    );
+
+    // A plain (non-muxed) contract destination emits no `to_muxed_id`.
+    contract
+        .transfer(&user, dst_address.clone(), 1)
+        .unwrap();
+    assert_eq!(
+        test.host.get_contract_events().unwrap().0,
+        vec![contract.test_event(
+            test_vec![
+                &test.host,
+                transfer_symbol,
+                user.address(&test.host),
+                dst_address.clone(),
+                &token_name,
+            ],
+            1_i128.try_into_val(&test.host).unwrap()
+        )]
+    );
+    assert_eq!(contract.balance(dst_address).unwrap(), 10_000_000);
+}
+
+#[cfg(feature = "next")]
+#[test]
+fn test_cap_84_mint_with_muxed_contract() {
+    use crate::builtin_contracts::testutils::muxed_contract_address;
+
+    let test = StellarAssetContractTest::setup(function_name!());
+    test.host.enable_invocation_metering();
+    let admin = TestSigner::account(&test.issuer_key);
+    let contract = test.default_stellar_asset_contract();
+
+    let dst_contract_id = generate_bytes_array(&test.host);
+    let dst_address = contract_id_to_address(&test.host, dst_contract_id);
+
+    let mint_symbol = Symbol::try_from_small_str("mint").unwrap().to_val();
+    let token_name = contract.name().unwrap();
+
+    // Mint to a muxed contract destination.
+    contract
+        .mint_muxed(
+            &admin,
+            muxed_contract_address(&test.host, dst_contract_id, 7_654_321),
+            100_000_000,
+        )
+        .unwrap();
+
+    assert_eq!(
+        test.host.get_contract_events().unwrap().0,
+        vec![contract.test_event(
+            test_vec![
+                &test.host,
+                mint_symbol,
+                // `to` topic is the de-muxed contract address.
+                dst_address.clone(),
+                &token_name,
+            ],
+            test_map![
+                &test.host,
+                ("amount", 100_000_000_i128),
+                ("to_muxed_id", 7_654_321_u64)
+            ]
+            .into()
+        )]
+    );
+    // Balance credits the underlying contract.
+    assert_eq!(contract.balance(dst_address).unwrap(), 100_000_000);
+}
+
 #[test]
 fn test_native_self_transfer() {
     let test = StellarAssetContractTest::setup(function_name!());

--- a/soroban-env-host/src/test/stellar_asset_contract.rs
+++ b/soroban-env-host/src/test/stellar_asset_contract.rs
@@ -962,9 +962,7 @@ fn test_cap_84_transfer_with_muxed_contracts() {
     );
 
     // A plain (non-muxed) contract destination emits no `to_muxed_id`.
-    contract
-        .transfer(&user, dst_address.clone(), 1)
-        .unwrap();
+    contract.transfer(&user, dst_address.clone(), 1).unwrap();
     assert_eq!(
         test.host.get_contract_events().unwrap().0,
         vec![contract.test_event(

--- a/soroban-env-host/src/test/storage.rs
+++ b/soroban-env-host/src/test/storage.rs
@@ -422,6 +422,34 @@ fn muxed_address_storage_key_conversion() {
     assert!(res_non_storage.is_ok());
 }
 
+// CAP-0084: a muxed contract address routes through the same `MuxedAddress`
+// vehicle, so it inherits the storage-key prohibition.
+#[cfg(feature = "next")]
+#[test]
+fn muxed_contract_storage_key_conversion() {
+    use crate::xdr::MuxedContract;
+    let host = observe_host!(Host::test_host_with_recording_footprint());
+    let muxed_address = MuxedScAddress(ScAddress::MuxedContract(MuxedContract {
+        id: 42,
+        contract_id: ContractId([7; 32].into()),
+    }));
+    let muxed_address_val = host
+        .add_host_object(muxed_address.clone())
+        .unwrap()
+        .to_val();
+    // Conversion for use as a storage key should fail.
+    let res = host.from_host_val_for_storage(muxed_address_val);
+
+    assert!(HostError::result_matches_err(
+        res,
+        (ScErrorType::Storage, ScErrorCode::InvalidInput)
+    ));
+
+    // Conversion to regular ScVal should succeed.
+    let res_non_storage = host.from_host_val(muxed_address_val);
+    assert!(res_non_storage.is_ok());
+}
+
 #[test]
 fn test_muxed_account_is_not_allowed_as_storage_key() {
     let host = Host::test_host_with_recording_footprint();


### PR DESCRIPTION
SPIKE against unreleased upstream. Adds muxed contract address support (CAP-0084) to the SAC, gated behind the `next` cargo feature. No version bump (protocol 28 is already reported under `next`); no new host functions.

## Changes
- Pin `stellar-xdr` to rs-stellar-xdr#548 (fork git rev `bd30d420`); enable `cap_0083` + `cap_0084` under `next`.
- Route `ScAddress::MuxedContract` through the existing `MuxedAddressObject` vehicle (`get_address_from_muxed_address` / `get_id_from_muxed_address` de-mux to the underlying `Contract`). All new variant arms are `#[cfg(feature = "next")]`.
- SAC `mint` destination cfg-split: `Address` under curr (byte-for-byte unchanged), `MuxedAddress` under `next` — mirrors `transfer`, emits `to_muxed_id`.
- `transfer` already de-muxes, so it handles muxed contracts automatically. Muxed addresses remain prohibited as storage keys (inherited).
- Tests (all `#[cfg(feature = "next")]`): transfer/mint to a muxed contract, storage-key prohibition, de-mux accessors.

## Deferred
- Productionize the XDR pin to a merged `stellar/rs-stellar-xdr` SHA / crates.io release once #548 lands (currently a fork git rev).
- Downstream re-pin (rs-soroban-sdk → stellar-core / stellar-rpc) from this branch head.

## Flag for review
1. `mint` under `next` accepts any `MuxedAddress` (muxed accounts *and* contracts), matching CAP-0084 (`AddressObject or MuxedAddressObject`, no account/contract discrimination) — so no pre-de-mux guard. FYI, not an open question.
2. No canonical strkey/`Display` form for muxed contracts yet — `display_address` is diagnostic-only.
3. **Plan deviation:** the plan's two cfg'd `mint` methods are infeasible — `#[contractimpl]` (`derive_fn.rs`) keys dispatch arms by positional `enumerate()` index and discards per-method `#[cfg]`, so duplicate names desync the table. Used the plan's documented fallback: a single `mint` with a cfg'd destination type alias (`MintDestination`). Both `cargo build` and `cargo build --features next` pass.

## Cross-links
- Upstream: stellar/rs-stellar-xdr#548 → stellar/stellar-xdr#305

🤖 Generated with [Claude Code](https://claude.com/claude-code)
