### PR TITLE
Bump stellar-xdr for SCSpecTypeUDTV2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1809,7 +1809,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "27.0.0"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=72f3f76ea03189fa32b588c66fa0a461c6970e47#72f3f76ea03189fa32b588c66fa0a461c6970e47"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=71021aea8210d75eab7290cc176f27df8e0a432f#71021aea8210d75eab7290cc176f27df8e0a432f"
 dependencies = [
  "arbitrary",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1809,7 +1809,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "27.0.0"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=a90de0c0d6eba8be668e9074cfb7b285ac0ecd34#a90de0c0d6eba8be668e9074cfb7b285ac0ecd34"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=72f3f76ea03189fa32b588c66fa0a461c6970e47#72f3f76ea03189fa32b588c66fa0a461c6970e47"
 dependencies = [
  "arbitrary",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ wasmparser = "=0.116.1"
 [workspace.dependencies.stellar-xdr]
 version = "=27.0.0"
 git = "https://github.com/stellar/rs-stellar-xdr"
-rev = "a90de0c0d6eba8be668e9074cfb7b285ac0ecd34"
+rev = "72f3f76ea03189fa32b588c66fa0a461c6970e47"
 default-features = false
 features = ["cap_0085_executable_ref"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ wasmparser = "=0.116.1"
 [workspace.dependencies.stellar-xdr]
 version = "=27.0.0"
 git = "https://github.com/stellar/rs-stellar-xdr"
-rev = "72f3f76ea03189fa32b588c66fa0a461c6970e47"
+rev = "71021aea8210d75eab7290cc176f27df8e0a432f"
 default-features = false
 features = ["cap_0085_executable_ref"]
 


### PR DESCRIPTION
> [!WARNING]
> Depends on unmerged and unreleased changes in:
> - stellar/stellar-xdr#310
> - stellar/rs-stellar-xdr#560
> - stellar/rs-stellar-xdr#562
> - stellar/rs-stellar-xdr#564
>
> A valid merge order for the whole stack:
> 1. stellar/stellar-xdr#310 — add `SCSpecTypeUDTV2` to the contract spec XDR
> 2. stellar/rs-stellar-xdr#560 — borrowed `Ref` variants of the generated types
> 3. stellar/rs-stellar-xdr#562 — const XDR serialization on those `Ref` types
> 4. stellar/rs-stellar-xdr#564 — regenerate with `SCSpecTypeUDTV2`
> 5. **this PR**
> 6. stellar/rs-soroban-sdk#1965 — encode contract spec XDR at const evaluation time
> 7. stellar/rs-soroban-sdk#1966 — reference user-defined types by id

### What

Move the pinned `stellar-xdr` rev forward to the regeneration that adds `ScSpecTypeUdtv2` and its `ScSpecTypeDef::UdtV2` variant.

### Why

Nothing here reads or constructs the new variant — the host does not reference `ScSpecTypeDef` at all — so this has no effect on host behavior and needs no host code changes. It is here because `rs-soroban-env` pins `stellar-xdr` by rev, and that pin has to move to the rev carrying `SCSpecTypeUDTV2` before an `rs-soroban-env` release can be cut against it. Landing it as its own change keeps the mechanical bump separate from the SDK work that actually uses the variant.

### Known limitations

No test exercises the change, because nothing in the host touches the new variant; the coverage lives downstream in the SDK. Pins an unmerged `rs-stellar-xdr` branch, so `check-git-rev-deps` fails until that lands and the pin moves to a merged commit.