### PR TITLE
Repin stellar-xdr and drop the cap_0085_executable_ref feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1809,7 +1809,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "27.0.0"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=a90de0c0d6eba8be668e9074cfb7b285ac0ecd34#a90de0c0d6eba8be668e9074cfb7b285ac0ecd34"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=3305b3e31f19fdb4e64e4b7a4354bb120cdf4415#3305b3e31f19fdb4e64e4b7a4354bb120cdf4415"
 dependencies = [
  "arbitrary",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,9 +37,8 @@ wasmparser = "=0.116.1"
 [workspace.dependencies.stellar-xdr]
 version = "=27.0.0"
 git = "https://github.com/stellar/rs-stellar-xdr"
-rev = "a90de0c0d6eba8be668e9074cfb7b285ac0ecd34"
+rev = "3305b3e31f19fdb4e64e4b7a4354bb120cdf4415"
 default-features = false
-features = ["cap_0085_executable_ref"]
 
 [workspace.dependencies.wasmi]
 package = "soroban-wasmi"


### PR DESCRIPTION
Repins `stellar-xdr` to stellar/rs-stellar-xdr#565, where CAP-0083 and CAP-0085 were ungated. That feature no longer exists there — the types are unconditional now — so the dep stops requesting it.

No host code changes: CAP-0085 and CAP-0086 both landed ungated, so there were no cfgs to remove. Verified `--features testutils` (830 tests) and `--features testutils,next` (829), both green.

Third of the P28 ungating stack; stellar-core follows.