### PR TITLE
Bump stellar-xdr to 28.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1808,8 +1808,9 @@ dependencies = [
 
 [[package]]
 name = "stellar-xdr"
-version = "27.0.0"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=3305b3e31f19fdb4e64e4b7a4354bb120cdf4415#3305b3e31f19fdb4e64e4b7a4354bb120cdf4415"
+version = "28.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93d09ff8b9f919b084f664003c4c546ac66a76affd5429460dbe29f4b326f8e"
 dependencies = [
  "arbitrary",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,11 +33,10 @@ soroban-builtin-sdk-macros = { version = "=28.0.0", path = "soroban-builtin-sdk-
 # NB: this must match the wasmparser version wasmi is using
 wasmparser = "=0.116.1"
 
-# NB: When updating, also update the version in rs-soroban-env dev-dependencies
 [workspace.dependencies.stellar-xdr]
-version = "=27.0.0"
-git = "https://github.com/stellar/rs-stellar-xdr"
-rev = "3305b3e31f19fdb4e64e4b7a4354bb120cdf4415"
+version = "=28.0.0"
+#git = "https://github.com/stellar/rs-stellar-xdr"
+#rev = "3305b3e31f19fdb4e64e4b7a4354bb120cdf4415"
 default-features = false
 
 [workspace.dependencies.wasmi]


### PR DESCRIPTION
### What

Bump `stellar-xdr` from the git rev pin at `3305b3e` to the released `28.0.0` on crates.io, and drop a stale NB comment.

### Why

rs-stellar-xdr released v28.0.0, which is the pinned rev plus a version bump, so this is a no-op re-point that unblocks publishing.
