### PR TITLE
Update ethnum to 1.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,9 +638,9 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
 name = "ethnum"
-version = "1.5.0"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "expect-test"

--- a/soroban-env-common/Cargo.toml
+++ b/soroban-env-common/Cargo.toml
@@ -20,7 +20,7 @@ wasmi = { workspace = true, optional = true }
 wasmparser = { workspace = true, optional = true}
 serde = { version = "1.0.192", features = ["derive"], optional = true }
 static_assertions = "1.1.0"
-ethnum = "1.5.0"
+ethnum = "1.5.3"
 arbitrary = { version = "1.3.2", features = ["derive"], optional = true }
 num-traits = {version = "0.2.17", default-features = false}
 num-derive = "0.4.1"


### PR DESCRIPTION
`release/v25.2.1` pins `ethnum` 1.5.0, which fails to build on rustc >= 1.97: it transmutes `()` into `TryFromIntError`, now non-zero-sized, triggering `error[E0512]`. 1.5.3 replaces the transmute with a safe constructor and satisfies the existing `^1.5.0` requirement (lock-only change, 2 lines).

This mirrors the bump already on `main` in ed1bb8d2327cdb559c96e77ffb0c734f5fcfce55 (#1681); this PR backports just the `ethnum` lock bump to the release branch so downstreams pinning it build on current Rust.

Refs:
- Upstream cause: https://github.com/nlordell/ethnum-rs/issues/60
- Downstream breakage: https://github.com/Homebrew/homebrew-core/pull/298710
