### PR TITLE
Bump semver binary to 0.50.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,10 +66,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: rustup update
-    - uses: stellar/binaries@v52
+    - uses: stellar/binaries@v86
       with:
         name: cargo-semver-checks
-        version: 0.46.0
+        version: 0.50.0
     - run: cargo semver-checks --exclude soroban-simulation
 
   build-and-test:


### PR DESCRIPTION
### What

Bump semver binary to 0.50.0

### Why

Unblock CI

### Known limitations

N/A
