### PR TITLE
Skip snapshot source read for test contract Wasm code key

### DIFF
--- a/soroban-env-host/src/host/lifecycle.rs
+++ b/soroban-env-host/src/host/lifecycle.rs
@@ -373,6 +373,17 @@ impl Host {
         let mut storage = self.try_borrow_storage_mut()?;
 
         // We will definitely put the contract in the ledger if it isn't there yet.
+        //
+        // In the test / `testutils` path, check the code entry existence
+        // directly in the storage map instead of going through the snapshot in
+        // the recording mode (as synthetic Wasms may not appear in the
+        // snapshot, and there is no need to read a key that is about to be
+        // written). This mirrors the native test-contract registration path in
+        // `register_native_contract_as_wasm_internal`.
+        #[cfg(any(test, feature = "testutils"))]
+        #[allow(unused_mut)]
+        let mut should_put_contract = storage.get_from_map(&code_key, self)?.is_none();
+        #[cfg(not(any(test, feature = "testutils")))]
         #[allow(unused_mut)]
         let mut should_put_contract = !storage.has(&code_key, self, None)?;
 


### PR DESCRIPTION
## Problem

`upload_contract_wasm` checks whether the contract code entry already exists via `Storage::has(&code_key, ...)`. In recording mode `has` runs `prepare_read_only_access`, which reads through to the `SnapshotSource` for any key not yet in the in-memory map.

For a freshly registered test Wasm the code entry is written immediately after this check, so the read is always unnecessary. With an empty mock source it is a wasted lookup; with a file- or network-backed source (as an SDK test or preflight may use) it is a real disk or network hit on every registration. This is what #1725 reports, and @roebee traced it to exactly this `has` call.

## Fix

In the `test` / `testutils` build, check existence directly in the storage map via `Storage::get_from_map`, which reads only the in-memory map and never touches the snapshot. The production (non-test, non-`testutils`) path is unchanged and still uses `has`.

This mirrors the native test-contract registration path added in #1720, which already does the same thing in `register_native_contract_as_wasm_internal`:

```rust
// Check the code entry existence directly in the storage map instead
// of going through the snapshot in the recording mode (as synthetic
// Wasms may not appear in the snapshot).
if self.try_borrow_storage_mut()?.get_from_map(&code_key, self)?.is_none() {
    self.store_test_contract_code_entry(...)?;
}
```

## The open question from #1725

@roebee asked whether the test path should (1) still read the snapshot when the key is absent from the map but present in the snapshot (to compare the `ext` field), or (2) never read the snapshot for code keys.

This PR takes option (2), consistent with the issue title ("Test contract Wasm entries should never be loaded via the snapshot source") and with how #1720 already handles the native path. Practical consequence: if a test pre-loads a snapshot that already contains the same Wasm hash, the code key is now treated as a fresh write rather than a snapshot-backed `ext` comparison. If you would rather preserve the `ext` comparison for that case, I'm happy to switch to option (1).

## Verification

I have not run the suite locally against this change; CI covers it. The diff is a single feature-gated branch (+11 -0) with no change to the production path.

Fixes #1725
